### PR TITLE
fix(manager): Remove tests from docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,13 +4,13 @@ FROM golang:1.21 as builder
 WORKDIR /workspace
 
 COPY Makefile .
-RUN make controller-gen envtest
+RUN make controller-gen
 COPY . .
 
 # Build greenhouse operator and tooling.
 RUN --mount=type=cache,target=/go/pkg/mod \
 	--mount=type=cache,target=/root/.cache/go-build \
-	make test build CGO_ENABLED=0 GOOS=linux GOARCH=amd64
+	make build CGO_ENABLED=0 GOOS=linux GOARCH=amd64
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details


### PR DESCRIPTION
This removes the tests from the docker build.

Out of scope: Incorporation of tests into gh actions before image builds. 
fyi @kengou 