### PR TITLE
feat(greenhouse-rbac): add ClusterAdmin and PluginAdmin roles

### DIFF
--- a/cmd/dev-env/main.go
+++ b/cmd/dev-env/main.go
@@ -36,8 +36,8 @@ var (
 	kubeProxyPort     string
 	graceFullShutDown bool
 	userData          = map[string][]string{
-		"test-org-admin":  {rbac.GetOrganizationRoleName("test-org"), rbac.GetAdminRoleNameForOrganization("test-org"), rbac.GetTeamRoleName("test-team-1")},
-		"test-org-member": {rbac.GetOrganizationRoleName("test-org"), rbac.GetTeamRoleName("test-team-1")},
+		"test-org-admin":  {rbac.OrganizationRoleName("test-org"), rbac.OrganizationAdminRoleName("test-org"), rbac.GetTeamRoleName("test-team-1")},
+		"test-org-member": {rbac.OrganizationRoleName("test-org"), rbac.GetTeamRoleName("test-team-1")},
 	}
 )
 

--- a/pkg/controllers/organization/rbac_controller_test.go
+++ b/pkg/controllers/organization/rbac_controller_test.go
@@ -50,83 +50,103 @@ var _ = Describe("Test RBAC reconciliation", func() {
 		})
 
 		It("must create a ClusterRole for the Org Admin", func() {
-			clusterRoleID := types.NamespacedName{Name: rbac.GetAdminRoleNameForOrganization(orgName), Namespace: ""}
+			clusterRoleID := types.NamespacedName{Name: rbac.OrganizationAdminRoleName(orgName), Namespace: ""}
 			actClusterRole := &rbacv1.ClusterRole{}
 			Eventually(func() bool {
 				return test.K8sClient.Get(test.Ctx, clusterRoleID, actClusterRole) == nil
 			}).Should(BeTrue(), "ClusterRole for the Admin must be created")
-			Expect(actClusterRole.Rules).To(ContainElements(rbac.MakePolicyRulesForOrganizationAdminClusterRole(orgName)), "ClusterRole for the Admin must have the correct rules")
+			Expect(actClusterRole.Rules).To(ContainElements(rbac.OrganizationAdminClusterRolePolicyRules(orgName)), "ClusterRole for the Admin must have the correct rules")
 			Expect(actClusterRole.OwnerReferences).To(ContainElement(ownerRef), "ClusterRole for the Admin must have the correct owner reference")
 		})
 
 		It("must create a ClusterRoleBinding for Org Admin ", func() {
-			clusterRoleBindingID := types.NamespacedName{Name: rbac.GetAdminRoleNameForOrganization(orgName), Namespace: ""}
+			clusterRoleBindingID := types.NamespacedName{Name: rbac.OrganizationAdminRoleName(orgName), Namespace: ""}
 			actClusterRoleBinding := &rbacv1.ClusterRoleBinding{}
 			Eventually(func() bool {
 				return test.K8sClient.Get(test.Ctx, clusterRoleBindingID, actClusterRoleBinding) == nil
 			}).Should(BeTrue(), "ClusterRoleBinding for the Admin must be created")
-			Expect(actClusterRoleBinding.Subjects).To(ContainElement(rbacv1.Subject{APIGroup: rbacv1.GroupName, Kind: rbacv1.GroupKind, Name: rbac.GetAdminRoleNameForOrganization(orgName)}), "ClusterRoleBinding for org admin must have the correct subject")
+			Expect(actClusterRoleBinding.Subjects).To(ContainElement(rbacv1.Subject{APIGroup: rbacv1.GroupName, Kind: rbacv1.GroupKind, Name: rbac.OrganizationAdminRoleName(orgName)}), "ClusterRoleBinding for org admin must have the correct subject")
 			Expect(actClusterRoleBinding.OwnerReferences).To(ContainElement(ownerRef), "ClusterRoleBinding for the Admin must have the correct owner reference")
 		})
 
 		It("must create a Role for Org Admins", func() {
-			roleID := types.NamespacedName{Name: rbac.GetAdminRoleNameForOrganization(orgName), Namespace: test.TestNamespace}
+			roleID := types.NamespacedName{Name: rbac.OrganizationAdminRoleName(orgName), Namespace: test.TestNamespace}
 			actRole := &rbacv1.Role{}
 			Eventually(func() bool {
 				return test.K8sClient.Get(test.Ctx, roleID, actRole) == nil
 			}).Should(BeTrue(), "Role for the org admins must be created")
-			Expect(actRole.Rules).To(ContainElements(rbac.MakePolicyRulesForOrganizationAdminRole()), "Role for org admins must have the correct rules")
+			Expect(actRole.Rules).To(ContainElements(rbac.OrganizationAdminPolicyRules()), "Role for org admins must have the correct rules")
 			Expect(actRole.OwnerReferences).To(ContainElement(ownerRef), "Role for org admins must have the correct owner reference")
 		})
 
 		It("must create a RoleBinding for org admins", func() {
-			roleBindingID := types.NamespacedName{Name: rbac.GetAdminRoleNameForOrganization(orgName), Namespace: test.TestNamespace}
+			roleBindingID := types.NamespacedName{Name: rbac.OrganizationAdminRoleName(orgName), Namespace: test.TestNamespace}
 			actRoleBinding := &rbacv1.RoleBinding{}
 			Eventually(func() bool {
 				return test.K8sClient.Get(test.Ctx, roleBindingID, actRoleBinding) == nil
 			}).Should(BeTrue(), "RoleBinding for org admins must be created")
-			Expect(actRoleBinding.RoleRef.Name).To(Equal(rbac.GetAdminRoleNameForOrganization(orgName)), "RoleBinding for org admins must have the correct role reference")
-			Expect(actRoleBinding.Subjects).To(ContainElement(rbacv1.Subject{APIGroup: rbacv1.GroupName, Kind: rbacv1.GroupKind, Name: rbac.GetAdminRoleNameForOrganization(orgName)}), "RoleBinding for org admins must have the correct subject")
+			Expect(actRoleBinding.RoleRef.Name).To(Equal(rbac.OrganizationAdminRoleName(orgName)), "RoleBinding for org admins must have the correct role reference")
+			Expect(actRoleBinding.Subjects).To(ContainElement(rbacv1.Subject{APIGroup: rbacv1.GroupName, Kind: rbacv1.GroupKind, Name: rbac.OrganizationAdminRoleName(orgName)}), "RoleBinding for org admins must have the correct subject")
 			Expect(actRoleBinding.OwnerReferences).To(ContainElement(ownerRef), "RoleBinding for org admins must have the correct owner reference")
 		})
 
 		It("must create a ClusterRole for Org Member", func() {
-			clusterRoleID := types.NamespacedName{Name: rbac.GetOrganizationRoleName(orgName), Namespace: ""}
+			clusterRoleID := types.NamespacedName{Name: rbac.OrganizationRoleName(orgName), Namespace: ""}
 			actClusterRole := &rbacv1.ClusterRole{}
 			Eventually(func() bool {
 				return test.K8sClient.Get(test.Ctx, clusterRoleID, actClusterRole) == nil
 			}).Should(BeTrue(), "ClusterRole for the Admin must be created")
-			Expect(actClusterRole.Rules).To(ContainElements(rbac.MakePolicyRulesForOrganizationMemberClusterRole(orgName)), "ClusterRole for Member must have the correct rules")
+			Expect(actClusterRole.Rules).To(ContainElements(rbac.OrganizationMemberClusterRolePolicyRules(orgName)), "ClusterRole for Member must have the correct rules")
 		})
 
 		It("must create a ClusterRoleBinding for Org Member ", func() {
-			clusterRoleBindingID := types.NamespacedName{Name: rbac.GetOrganizationRoleName(orgName), Namespace: ""}
+			clusterRoleBindingID := types.NamespacedName{Name: rbac.OrganizationRoleName(orgName), Namespace: ""}
 			actClusterRoleBinding := &rbacv1.ClusterRoleBinding{}
 			Eventually(func() bool {
 				return test.K8sClient.Get(test.Ctx, clusterRoleBindingID, actClusterRoleBinding) == nil
 			}).Should(BeTrue(), "ClusterRoleBinding for org member must be created")
-			Expect(actClusterRoleBinding.Subjects).To(ContainElement(rbacv1.Subject{APIGroup: rbacv1.GroupName, Kind: rbacv1.GroupKind, Name: rbac.GetOrganizationRoleName(orgName)}), "ClusterRoleBinding for org member must have the correct subject")
+			Expect(actClusterRoleBinding.Subjects).To(ContainElement(rbacv1.Subject{APIGroup: rbacv1.GroupName, Kind: rbacv1.GroupKind, Name: rbac.OrganizationRoleName(orgName)}), "ClusterRoleBinding for org member must have the correct subject")
 			Expect(actClusterRoleBinding.OwnerReferences).To(ContainElement(ownerRef), "ClusterRoleBinding for org member must have the correct owner reference")
 		})
 
+		It("must create a Role for Org Cluster Admins", func() {
+			roleID := types.NamespacedName{Name: rbac.OrganizationClusterAdminRoleName(orgName), Namespace: test.TestNamespace}
+			actRole := &rbacv1.Role{}
+			Eventually(func() bool {
+				return test.K8sClient.Get(test.Ctx, roleID, actRole) == nil
+			}).Should(BeTrue(), "Role for org cluster admin must be created")
+			Expect(actRole.Rules).To(ContainElements(rbac.OrganizationClusterAdminPolicyRules()), "Role for org cluster admin must have the correct rules")
+			Expect(actRole.OwnerReferences).To(ContainElement(ownerRef), "Role for org cluster admin must have the correct owner reference")
+		})
+
+		It("must create a Role for Org Plugin Admins", func() {
+			roleID := types.NamespacedName{Name: rbac.OrganizationPluginAdminRoleName(orgName), Namespace: test.TestNamespace}
+			actRole := &rbacv1.Role{}
+			Eventually(func() bool {
+				return test.K8sClient.Get(test.Ctx, roleID, actRole) == nil
+			}).Should(BeTrue(), "Role for org plugin admin must be created")
+			Expect(actRole.Rules).To(ContainElements(rbac.OrganizationPluginAdminPolicyRules()), "Role for org plugin admin must have the correct rules")
+			Expect(actRole.OwnerReferences).To(ContainElement(ownerRef), "Role for org plugin admin must have the correct owner reference")
+		})
+
 		It("must create a Role for Org Member", func() {
-			roleID := types.NamespacedName{Name: rbac.GetOrganizationRoleName(orgName), Namespace: test.TestNamespace}
+			roleID := types.NamespacedName{Name: rbac.OrganizationRoleName(orgName), Namespace: test.TestNamespace}
 			actRole := &rbacv1.Role{}
 			Eventually(func() bool {
 				return test.K8sClient.Get(test.Ctx, roleID, actRole) == nil
 			}).Should(BeTrue(), "Role for org member must be created")
-			Expect(actRole.Rules).To(ContainElements(rbac.MakePolicyRulesForOrganizationMemberRole()), "Role for org member must have the correct rules")
+			Expect(actRole.Rules).To(ContainElements(rbac.OrganizationMemberPolicyRules()), "Role for org member must have the correct rules")
 			Expect(actRole.OwnerReferences).To(ContainElement(ownerRef), "Role for org member must have the correct owner reference")
 		})
 
 		It("must create a RoleBinding for org member", func() {
-			roleBindingID := types.NamespacedName{Name: rbac.GetOrganizationRoleName(orgName), Namespace: test.TestNamespace}
+			roleBindingID := types.NamespacedName{Name: rbac.OrganizationRoleName(orgName), Namespace: test.TestNamespace}
 			actRoleBinding := &rbacv1.RoleBinding{}
 			Eventually(func() bool {
 				return test.K8sClient.Get(test.Ctx, roleBindingID, actRoleBinding) == nil
 			}).Should(BeTrue(), "RoleBinding for org member must be created")
-			Expect(actRoleBinding.RoleRef.Name).To(Equal(rbac.GetOrganizationRoleName(orgName)), "RoleBinding for org member must have the correct role reference")
-			Expect(actRoleBinding.Subjects).To(ContainElement(rbacv1.Subject{APIGroup: rbacv1.GroupName, Kind: rbacv1.GroupKind, Name: rbac.GetOrganizationRoleName(orgName)}), "RoleBinding for org member must have the correct subject")
+			Expect(actRoleBinding.RoleRef.Name).To(Equal(rbac.OrganizationRoleName(orgName)), "RoleBinding for org member must have the correct role reference")
+			Expect(actRoleBinding.Subjects).To(ContainElement(rbacv1.Subject{APIGroup: rbacv1.GroupName, Kind: rbacv1.GroupKind, Name: rbac.OrganizationRoleName(orgName)}), "RoleBinding for org member must have the correct subject")
 			Expect(actRoleBinding.OwnerReferences).To(ContainElement(ownerRef), "RoleBinding for org member must have the correct owner reference")
 		})
 	})

--- a/pkg/idproxy/connector.go
+++ b/pkg/idproxy/connector.go
@@ -108,7 +108,7 @@ func (c *oidcConnector) Refresh(ctx context.Context, s connector.Scopes, identit
 
 func (c *oidcConnector) getGroups(organization string, upstreamGroups []string, ctx context.Context) ([]string, error) {
 	var groups []string
-	groups = append(groups, rbac.GetOrganizationRoleName(c.id))
+	groups = append(groups, rbac.OrganizationRoleName(c.id))
 
 	teamNamesByIDPGroups := make(map[string][]string)
 	roleNamesByIDPGroups := make(map[string]string)
@@ -136,7 +136,7 @@ func (c *oidcConnector) getGroups(organization string, upstreamGroups []string, 
 	if err != nil {
 		return nil, err
 	}
-	roleNamesByIDPGroups[org.Spec.MappedOrgAdminIDPGroup] = rbac.GetAdminRoleNameForOrganization(organization)
+	roleNamesByIDPGroups[org.Spec.MappedOrgAdminIDPGroup] = rbac.OrganizationAdminRoleName(organization)
 
 	for _, group := range upstreamGroups {
 		teamNameGroup, ok := teamNamesByIDPGroups[group]

--- a/pkg/rbac/clusterrole.go
+++ b/pkg/rbac/clusterrole.go
@@ -9,8 +9,8 @@ import (
 	greenhouseapisv1alpha1 "github.com/cloudoperators/greenhouse/pkg/apis/greenhouse/v1alpha1"
 )
 
-// MakePolicyRulesForOrganizationAdminClusterRole returns the cluster-scoped PolicyRules for an organization admin.
-func MakePolicyRulesForOrganizationAdminClusterRole(organizationName string) []rbacv1.PolicyRule {
+// OrganizationAdminClusterRolePolicyRules returns the cluster-scoped PolicyRules for an organization admin.
+func OrganizationAdminClusterRolePolicyRules(organizationName string) []rbacv1.PolicyRule {
 	orgAdminPolicyRules := []rbacv1.PolicyRule{
 		// Grant extensive permissions for this Organization to its administrators.
 		// Creation and deletion is only permitted for Greenhouse administrators though.
@@ -21,11 +21,11 @@ func MakePolicyRulesForOrganizationAdminClusterRole(organizationName string) []r
 			ResourceNames: []string{organizationName},
 		},
 	}
-	return append(MakePolicyRulesForOrganizationMemberClusterRole(organizationName), orgAdminPolicyRules...)
+	return append(OrganizationMemberClusterRolePolicyRules(organizationName), orgAdminPolicyRules...)
 }
 
-// MakePolicyRulesForOrganizationMemberClusterRole returns the cluster-scoped PolicyRules for an organization member.
-func MakePolicyRulesForOrganizationMemberClusterRole(organizationName string) []rbacv1.PolicyRule {
+// OrganizationMemberClusterRolePolicyRules returns the cluster-scoped PolicyRules for an organization member.
+func OrganizationMemberClusterRolePolicyRules(organizationName string) []rbacv1.PolicyRule {
 	return []rbacv1.PolicyRule{
 		// Grant read permissions for this Organization to its members.
 		{

--- a/pkg/rbac/role.go
+++ b/pkg/rbac/role.go
@@ -12,14 +12,42 @@ import (
 	greenhouseapisv1alpha1 "github.com/cloudoperators/greenhouse/pkg/apis/greenhouse/v1alpha1"
 )
 
-// MakePolicyRulesForOrganizationAdminRole returns the namespace-scoped PolicyRules for an organization admin.
-func MakePolicyRulesForOrganizationAdminRole() []rbacv1.PolicyRule {
+// OrganizationAdminPolicyRules returns the namespace-scoped PolicyRules for an organization admin.
+func OrganizationAdminPolicyRules() []rbacv1.PolicyRule {
 	orgAdminPolicyRules := []rbacv1.PolicyRule{
 		// Grant read permissions for Clusters, PluginConfigs to organization admins.
 		{
 			Verbs:     []string{"get", "list", "watch", "update", "patch", "delete", "create"},
 			APIGroups: []string{greenhouseapisv1alpha1.GroupVersion.Group},
-			Resources: []string{"clusters", "pluginconfigs", "teams", "teammemberships"},
+			Resources: []string{"teams", "teammemberships"},
+		},
+		// Grant permissions for secrets referenced by other resources, e.g. PluginConfigs for storing sensitive values.
+		// Retrieving these secrets is not permitted to the user.
+		{
+			Verbs:     []string{"create", "update", "patch"},
+			APIGroups: []string{corev1.GroupName},
+			Resources: []string{"secrets"},
+		},
+		// Grant permission to create RoleBindings
+		{
+			Verbs:     []string{"create"},
+			APIGroups: []string{"rbac.authorization.k8s.io"},
+			Resources: []string{"rolebindings"},
+		},
+	}
+	orgAdminPolicyRules = append(orgAdminPolicyRules,
+		OrganizationClusterAdminPolicyRules()...)
+	return append(orgAdminPolicyRules, OrganizationPluginAdminPolicyRules()...)
+}
+
+// OrganizationClusterAdminPolicyRules returns the namespace-scoped PolicyRules for an organization cluster admin.
+func OrganizationClusterAdminPolicyRules() []rbacv1.PolicyRule {
+	policyRules := []rbacv1.PolicyRule{
+		// Grant read permissions for Clusters to organization cluster admins.
+		{
+			Verbs:     []string{"get", "list", "watch", "update", "patch", "delete", "create"},
+			APIGroups: []string{greenhouseapisv1alpha1.GroupVersion.Group},
+			Resources: []string{"clusters"},
 		},
 		// Grant permissions for secrets referenced by other resources, e.g. PluginConfigs for storing sensitive values.
 		// Retrieving these secrets is not permitted to the user.
@@ -29,11 +57,31 @@ func MakePolicyRulesForOrganizationAdminRole() []rbacv1.PolicyRule {
 			Resources: []string{"secrets"},
 		},
 	}
-	return append(MakePolicyRulesForOrganizationMemberRole(), orgAdminPolicyRules...)
+	return append(OrganizationMemberPolicyRules(), policyRules...)
 }
 
-// MakePolicyRulesForOrganizationMemberRole returns the namespace-scoped PolicyRules for an organization member.
-func MakePolicyRulesForOrganizationMemberRole() []rbacv1.PolicyRule {
+// OrganizationPluginAdminPolicyRules returns the namespace-scoped PolicyRules for an organization plugin admin.
+func OrganizationPluginAdminPolicyRules() []rbacv1.PolicyRule {
+	policyRules := []rbacv1.PolicyRule{
+		// Grant read permissions for Plugins to organization cluster admins.
+		{
+			Verbs:     []string{"get", "list", "watch", "update", "patch", "delete", "create"},
+			APIGroups: []string{greenhouseapisv1alpha1.GroupVersion.Group},
+			Resources: []string{"plugins"},
+		},
+		// Grant permissions for secrets referenced by other resources, e.g. PluginConfigs for storing sensitive values.
+		// Retrieving these secrets is not permitted to the user.
+		{
+			Verbs:     []string{"create", "update", "patch"},
+			APIGroups: []string{corev1.GroupName},
+			Resources: []string{"secrets"},
+		},
+	}
+	return append(OrganizationMemberPolicyRules(), policyRules...)
+}
+
+// OrganizationMemberPolicyRules returns the namespace-scoped PolicyRules for an organization member.
+func OrganizationMemberPolicyRules() []rbacv1.PolicyRule {
 	return []rbacv1.PolicyRule{
 		// Grant read permissions for Clusters, PluginConfigs, Teams, TeamMemberships to organization members.
 		{

--- a/pkg/rbac/util.go
+++ b/pkg/rbac/util.go
@@ -7,12 +7,22 @@ import (
 	"fmt"
 )
 
-// GetAdminRoleNameForOrganization returns the name of the admin role for an organization.
-func GetAdminRoleNameForOrganization(orgName string) string {
+// OrganizationAdminRoleName returns the name of the admin role for an organization.
+func OrganizationAdminRoleName(orgName string) string {
 	return fmt.Sprintf("role:%s:admin", orgName)
 }
 
-// GetOrganizationRoleName returns the name of the role for an organization.
-func GetOrganizationRoleName(orgName string) string {
+// OrganizationClusterAdminRoleName returns the name of the cluster admin role for an organization.
+func OrganizationClusterAdminRoleName(orgName string) string {
+	return fmt.Sprintf("role:%s:cluster-admin", orgName)
+}
+
+// GetOrganizationPluginAdminRoleName returns the name of the plugin admin role for an organization.
+func OrganizationPluginAdminRoleName(orgName string) string {
+	return fmt.Sprintf("role:%s:plugin-admin", orgName)
+}
+
+// OrganizationRoleName returns the name of the role for an organization.
+func OrganizationRoleName(orgName string) string {
 	return fmt.Sprintf("organization:%s", orgName)
 }


### PR DESCRIPTION
Org Admins are granted the ability to create RoleBindings. With [restrictions-on-role-binding-creation-or-update](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#restrictions-on-role-binding-creation-or-update) they can only grant access contained by the OrgAdmin role.

The roles ClusterAdmin and PluginAdmin respectively grant the abilities for editing Clusters & Plugins respectively

Changes:

- each org receives a dedicated rbacv1.Role for Cluster and Plugin Admins
- refactor funcs for role names and policy rules