### PR TITLE
fix(dev-env): pin setup-envtest version in dockerfile

### DIFF
--- a/Dockerfile.dev-env
+++ b/Dockerfile.dev-env
@@ -10,7 +10,7 @@ RUN make generate-manifests
 RUN --mount=type=cache,target=/go/pkg/mod \
 	--mount=type=cache,target=/root/.cache/go-build \
 	make generate build-dev-env GO_ENABLED=0 GOOS=linux GOARCH=amd64 \
-	&& GOBIN=/workspace/bin go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest \
+	&& GOBIN=/workspace/bin go install sigs.k8s.io/controller-runtime/tools/setup-envtest@bf15e44028f908c790721fc8fe67c7bf2d06a611 \
 	&& cp $(/workspace/bin/setup-envtest use ${ENVTEST_K8S_VERSION} -p path)/* /usr/local/bin
 
 


### PR DESCRIPTION
The lib was upgraded to go1.22, this pins it to the last commit before to avoid the forced upgrade.