### PR TITLE
fix(gh-action) trivy scan format: template is deprecated

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -162,9 +162,8 @@ jobs:
           image-ref: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.Imagename }}:${{ github.sha }}
           ignore-unfixed: true
           exit-code: '1'
-          format: template
-          template: '@/contrib/sarif.tpl'
-          output: trivy-results.sarif
+          format: 'sarif'
+          output: 'trivy-results.sarif'
           severity: 'CRITICAL,HIGH'
 
       - name: Upload Trivy scan results to GitHub Security tab


### PR DESCRIPTION
`--template sarif.tpl` is deprecated, migrate to `--format sarif`