### PR TITLE
fix(gh-actions) run in paralell/ always upload trivy

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -21,8 +21,10 @@ jobs:
   build:
     name: Build
     runs-on: [ default ]
+    continue-on-error: true
     strategy:
-      max-parallel: 3
+      fail-fast: false
+      max-parallel: 6
       matrix:
         include:
           - Dockerfiles: Dockerfile
@@ -136,7 +138,8 @@ jobs:
       packages: read
       security-events: write
     strategy:
-      max-parallel: 3
+      fail-fast: false
+      max-parallel: 6
       matrix:
         include:
           - Dockerfiles: Dockerfile
@@ -158,6 +161,7 @@ jobs:
     steps:
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
+        if: success()
         with:
           image-ref: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.Imagename }}:${{ github.sha }}
           ignore-unfixed: true
@@ -168,5 +172,6 @@ jobs:
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v2
+        if: always()
         with:
           sarif_file: trivy-results.sarif


### PR DESCRIPTION
upload `SARIF` results to `GitHub Code` scanning even upon a non zero exit code from `Trivy Scan`