### PR TITLE
fix(helm) update license header comment style in template folder

### DIFF
--- a/charts/cors-proxy/templates/deployment.yaml
+++ b/charts/cors-proxy/templates/deployment.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 apiVersion: apps/v1
 kind: Deployment

--- a/charts/cors-proxy/templates/ingress.yaml
+++ b/charts/cors-proxy/templates/ingress.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "cors-proxy.fullname" . -}}

--- a/charts/cors-proxy/templates/service.yaml
+++ b/charts/cors-proxy/templates/service.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 apiVersion: v1
 kind: Service

--- a/charts/cors-proxy/templates/serviceaccount.yaml
+++ b/charts/cors-proxy/templates/serviceaccount.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 {{- if .Values.serviceAccount.create -}}
 apiVersion: v1

--- a/charts/demo/templates/alertmanager-pluginconfig.yaml
+++ b/charts/demo/templates/alertmanager-pluginconfig.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 {{- if .Values.alerts.enabled }}
 apiVersion: greenhouse.sap/v1alpha1

--- a/charts/demo/templates/demo-user.yaml
+++ b/charts/demo/templates/demo-user.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 apiVersion: v1
 kind: ServiceAccount

--- a/charts/demo/templates/doop-pluginconfig.yaml
+++ b/charts/demo/templates/doop-pluginconfig.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 {{- if .Values.doop.enabled }}
 apiVersion: greenhouse.sap/v1alpha1

--- a/charts/demo/templates/organization.yaml
+++ b/charts/demo/templates/organization.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 apiVersion: greenhouse.sap/v1alpha1
 kind: Organization

--- a/charts/demo/templates/teams.yaml
+++ b/charts/demo/templates/teams.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 {{ $chartName := .Chart.Name }}
 {{ $demoUser := .Values.demoUser }}

--- a/charts/greenhouse/templates/cluster-admin-rbac.yaml
+++ b/charts/greenhouse/templates/cluster-admin-rbac.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/charts/greenhouse/templates/oidc.yaml
+++ b/charts/greenhouse/templates/oidc.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 {{- if.Values.oidc.enabled }}
 apiVersion: v1

--- a/charts/greenhouse/templates/organization.yaml
+++ b/charts/greenhouse/templates/organization.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 apiVersion: greenhouse.sap/v1alpha1
 kind: Organization

--- a/charts/greenhouse/templates/pluginconfig-alerts.yaml
+++ b/charts/greenhouse/templates/pluginconfig-alerts.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 {{- if.Values.alerts.enabled }}
 apiVersion: greenhouse.sap/v1alpha1

--- a/charts/greenhouse/templates/pluginconfig-cert-manager.yaml
+++ b/charts/greenhouse/templates/pluginconfig-cert-manager.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 apiVersion: greenhouse.sap/v1alpha1
 kind: PluginConfig

--- a/charts/greenhouse/templates/pluginconfig-digicert-issuer.yaml
+++ b/charts/greenhouse/templates/pluginconfig-digicert-issuer.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 {{- if .Values.digicertIssuer.enabled }}
 apiVersion: greenhouse.sap/v1alpha1

--- a/charts/greenhouse/templates/pluginconfig-disco.yaml
+++ b/charts/greenhouse/templates/pluginconfig-disco.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 {{- if .Values.disco.enabled }}
 apiVersion: greenhouse.sap/v1alpha1

--- a/charts/greenhouse/templates/pluginconfig-ingress-nginx.yaml
+++ b/charts/greenhouse/templates/pluginconfig-ingress-nginx.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 {{- if .Values.ingress.enabled }}
 apiVersion: greenhouse.sap/v1alpha1

--- a/charts/greenhouse/templates/pluginconfig-kube-monitoring.yaml
+++ b/charts/greenhouse/templates/pluginconfig-kube-monitoring.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 {{- if .Values.monitoring.enabled }}
 apiVersion: greenhouse.sap/v1alpha1

--- a/charts/greenhouse/templates/teams.yaml
+++ b/charts/greenhouse/templates/teams.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 {{ $chartName := .Chart.Name }}
 {{ range $teamName, $team := .Values.teams }}

--- a/charts/headscale/templates/deployment.yaml
+++ b/charts/headscale/templates/deployment.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 {{- $fullName := include "headscale.fullname" . -}}
 apiVersion: apps/v1

--- a/charts/headscale/templates/ingress-grpc.yaml
+++ b/charts/headscale/templates/ingress-grpc.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 {{ if .Values.grpc.ingress.enabled }}
 {{- $fullName := include "headscale.fullname" . -}}

--- a/charts/headscale/templates/ingress.yaml
+++ b/charts/headscale/templates/ingress.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 {{ if .Values.ingress.enabled }}
 {{- $fullName := include "headscale.fullname" . -}}

--- a/charts/headscale/templates/postgres-service.yaml
+++ b/charts/headscale/templates/postgres-service.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 apiVersion: v1
 kind: Service

--- a/charts/headscale/templates/postgres-statefulset.yaml
+++ b/charts/headscale/templates/postgres-statefulset.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 apiVersion: apps/v1
 kind: StatefulSet

--- a/charts/headscale/templates/pvc.yaml
+++ b/charts/headscale/templates/pvc.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/charts/headscale/templates/rbac.yaml
+++ b/charts/headscale/templates/rbac.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/charts/headscale/templates/secret.yaml
+++ b/charts/headscale/templates/secret.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 apiVersion: v1
 kind: Secret

--- a/charts/headscale/templates/service.yaml
+++ b/charts/headscale/templates/service.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 apiVersion: v1
 kind: Service

--- a/charts/headscale/templates/serviceaccount.yaml
+++ b/charts/headscale/templates/serviceaccount.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 apiVersion: v1
 kind: ServiceAccount

--- a/charts/idproxy/templates/connectors.yaml
+++ b/charts/idproxy/templates/connectors.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 {{ range $connector := .Values.connectors }}
 ---

--- a/charts/idproxy/templates/deployment.yaml
+++ b/charts/idproxy/templates/deployment.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 apiVersion: apps/v1
 kind: Deployment

--- a/charts/idproxy/templates/ingress.yaml
+++ b/charts/idproxy/templates/ingress.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "idproxy.fullname" . -}}

--- a/charts/idproxy/templates/oauth2clients.yaml
+++ b/charts/idproxy/templates/oauth2clients.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 {{ range $client := .Values.clients }}
 ---

--- a/charts/idproxy/templates/poddisruptionbudget.yaml
+++ b/charts/idproxy/templates/poddisruptionbudget.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 apiVersion: policy/v1
 kind: PodDisruptionBudget

--- a/charts/idproxy/templates/rbac.yaml
+++ b/charts/idproxy/templates/rbac.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/charts/idproxy/templates/service.yaml
+++ b/charts/idproxy/templates/service.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 apiVersion: v1
 kind: Service

--- a/charts/idproxy/templates/serviceaccount.yaml
+++ b/charts/idproxy/templates/serviceaccount.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 {{- if .Values.serviceAccount.create -}}
 apiVersion: v1

--- a/charts/logshipping/templates/fluent-bit-configmap.yaml
+++ b/charts/logshipping/templates/fluent-bit-configmap.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 apiVersion: v1
 kind: ConfigMap

--- a/charts/logshipping/templates/fluent-bit-secret.yaml
+++ b/charts/logshipping/templates/fluent-bit-secret.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 apiVersion: v1
 kind: Secret

--- a/charts/manager/templates/deployment.yaml
+++ b/charts/manager/templates/deployment.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 apiVersion: apps/v1
 kind: Deployment

--- a/charts/manager/templates/kube-webhook-certgen-rbac.yaml
+++ b/charts/manager/templates/kube-webhook-certgen-rbac.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 apiVersion: v1
 kind: ServiceAccount

--- a/charts/manager/templates/kube-webhook-certgen.yaml
+++ b/charts/manager/templates/kube-webhook-certgen.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 apiVersion: batch/v1
 kind: Job

--- a/charts/manager/templates/leader-election-rbac.yaml
+++ b/charts/manager/templates/leader-election-rbac.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/charts/manager/templates/manager-config.yaml
+++ b/charts/manager/templates/manager-config.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 apiVersion: v1
 kind: ConfigMap

--- a/charts/manager/templates/manager-role.yaml
+++ b/charts/manager/templates/manager-role.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/manager/templates/manager-rolebinding.yaml
+++ b/charts/manager/templates/manager-rolebinding.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/charts/manager/templates/metrics-reader-rbac.yaml
+++ b/charts/manager/templates/metrics-reader-rbac.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/charts/manager/templates/metrics-service.yaml
+++ b/charts/manager/templates/metrics-service.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 apiVersion: v1
 kind: Service

--- a/charts/manager/templates/plugin-viewer-rbac.yaml
+++ b/charts/manager/templates/plugin-viewer-rbac.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/charts/manager/templates/proxy-rbac.yaml
+++ b/charts/manager/templates/proxy-rbac.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/charts/manager/templates/serviceaccount.yaml
+++ b/charts/manager/templates/serviceaccount.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 apiVersion: v1
 kind: ServiceAccount

--- a/charts/manager/templates/servicemonitor.yaml
+++ b/charts/manager/templates/servicemonitor.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 {{- if .Capabilities.APIVersions.Has "monitoring.coreos.com/v1/ServiceMonitor" }}
 apiVersion: monitoring.coreos.com/v1

--- a/charts/manager/templates/vpa.yaml
+++ b/charts/manager/templates/vpa.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 {{- if .Capabilities.APIVersions.Has "autoscaling.k8s.io/v1"}}
 apiVersion: autoscaling.k8s.io/v1

--- a/charts/manager/templates/webhook-service.yaml
+++ b/charts/manager/templates/webhook-service.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 apiVersion: v1
 kind: Service

--- a/charts/manager/templates/webhooks.yaml
+++ b/charts/manager/templates/webhooks.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 ---
 apiVersion: admissionregistration.k8s.io/v1

--- a/charts/tailscale-proxy/templates/deployment.yaml
+++ b/charts/tailscale-proxy/templates/deployment.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 apiVersion: apps/v1
 kind: Deployment

--- a/charts/tailscale-proxy/templates/service.yaml
+++ b/charts/tailscale-proxy/templates/service.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 apiVersion: v1
 kind: Service

--- a/charts/tailscale-proxy/templates/serviceaccount.yaml
+++ b/charts/tailscale-proxy/templates/serviceaccount.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 {{- if .Values.serviceAccount.create -}}
 apiVersion: v1

--- a/charts/team-membership/templates/configmap.yaml
+++ b/charts/team-membership/templates/configmap.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 apiVersion: v1
 kind: ConfigMap

--- a/charts/team-membership/templates/cronjob.yaml
+++ b/charts/team-membership/templates/cronjob.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 apiVersion: batch/v1
 kind: CronJob

--- a/charts/team-membership/templates/rbac.yaml
+++ b/charts/team-membership/templates/rbac.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/charts/team-membership/templates/secret.yaml
+++ b/charts/team-membership/templates/secret.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 apiVersion: v1
 kind: Secret

--- a/charts/team-membership/templates/serviceaccount.yaml
+++ b/charts/team-membership/templates/serviceaccount.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 apiVersion: v1
 kind: ServiceAccount

--- a/charts/ui/templates/deployment.yaml
+++ b/charts/ui/templates/deployment.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 kind: Deployment
 apiVersion: apps/v1

--- a/charts/ui/templates/index-html-cm.yaml
+++ b/charts/ui/templates/index-html-cm.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 apiVersion: v1
 kind: ConfigMap

--- a/charts/ui/templates/ingress.yaml
+++ b/charts/ui/templates/ingress.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 apiVersion: networking.k8s.io/v1
 kind: Ingress

--- a/charts/ui/templates/service.yaml
+++ b/charts/ui/templates/service.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 kind: Service
 apiVersion: v1

--- a/charts/website/templates/deployment.yaml
+++ b/charts/website/templates/deployment.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 apiVersion: apps/v1
 kind: Deployment

--- a/charts/website/templates/hpa.yaml
+++ b/charts/website/templates/hpa.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 {{- if .Values.autoscaling.enabled }}
 apiVersion: autoscaling/v2

--- a/charts/website/templates/ingress.yaml
+++ b/charts/website/templates/ingress.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 {{- $fullName := include "website.fullname" . -}}
 apiVersion: networking.k8s.io/v1

--- a/charts/website/templates/service.yaml
+++ b/charts/website/templates/service.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 apiVersion: v1
 kind: Service

--- a/charts/website/templates/serviceaccount.yaml
+++ b/charts/website/templates/serviceaccount.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 {{- if .Values.serviceAccount.create -}}
 apiVersion: v1


### PR DESCRIPTION
@IvoGoman found out that the comment style `#` does not work for the files in `../templates/*.yaml`. The comment style has to be changed to `{{/* ... */}}` for helm to be able to template the files.