### PR TITLE
Fix dependencies. Don't use latest

### DIFF
--- a/ui/cluster-admin/package-lock.json
+++ b/ui/cluster-admin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "greenhouse-cluster-admin",
-  "version": "1.6.2",
+  "version": "1.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "greenhouse-cluster-admin",
-      "version": "1.6.2",
+      "version": "1.6.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/jest": "^27.5.2",
@@ -39,7 +39,7 @@
         "eslint-plugin-react-hooks": "^4.6.0",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.3.1",
-        "juno-ui-components": "https://assets.juno.global.cloud.sap/libs/juno-ui-components@latest/package.tgz",
+        "juno-ui-components": "https://assets.juno.global.cloud.sap/libs/juno-ui-components@2.12.1/package.tgz",
         "postcss": "^8.4.21",
         "postcss-url": "^10.1.3",
         "prop-types": "^15.8.1",
@@ -50,7 +50,7 @@
         "sass": "^1.60.0",
         "shadow-dom-testing-library": "^1.7.1",
         "tailwindcss": "^3.3.1",
-        "url-state-provider": "https://assets.juno.global.cloud.sap/libs/url-state-provider@latest/package.tgz",
+        "url-state-provider": "https://assets.juno.global.cloud.sap/libs/url-state-provider@1.3.2/package.tgz",
         "util": "^0.12.4",
         "zustand": "^4.1.1"
       },
@@ -6053,6 +6053,13 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
+    "node_modules/flatpickr": {
+      "version": "4.6.13",
+      "resolved": "https://registry.npmjs.org/flatpickr/-/flatpickr-4.6.13.tgz",
+      "integrity": "sha512-97PMG/aywoYpB4IvbvUJi0RQi8vearvU0oov1WW3k0WZPBMrTQVqekSX5CjSG/M4Q3i6A/0FKXC7RyAoAUUSPw==",
+      "dev": true,
+      "peer": true
+    },
     "node_modules/flatted": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
@@ -9048,15 +9055,16 @@
       }
     },
     "node_modules/juno-ui-components": {
-      "version": "2.11.2",
-      "resolved": "https://assets.juno.global.cloud.sap/libs/juno-ui-components@latest/package.tgz",
-      "integrity": "sha512-kCHmktKXefW44qxsOhm6axUZevwuGcGJ/Xe1wHGU4ZpY1w7IYPGLq+0sk+XmW+noFZ+vPJ+233UcgTDbUPlE0g==",
+      "version": "2.12.1",
+      "resolved": "https://assets.juno.global.cloud.sap/libs/juno-ui-components@2.12.1/package.tgz",
+      "integrity": "sha512-AFEIkQhQHPiPoGEymBxOPN1sJ5QWtASTLdYuehtZnXD1w9PVu8rS2zq+P6uohPktvHpUwKN6FKvyN+9mG/SUkw==",
       "dev": true,
       "license": "Apache-2.0",
       "peerDependencies": {
-        "prop-types": "^15.8.1",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "flatpickr": "4.6.13",
+        "prop-types": "15.8.1",
+        "react": "18.2.0",
+        "react-dom": "18.2.0"
       }
     },
     "node_modules/juri": {
@@ -11129,7 +11137,7 @@
     },
     "node_modules/url-state-provider": {
       "version": "1.3.2",
-      "resolved": "https://assets.juno.global.cloud.sap/libs/url-state-provider@latest/package.tgz",
+      "resolved": "https://assets.juno.global.cloud.sap/libs/url-state-provider@1.3.2/package.tgz",
       "integrity": "sha512-+6ID9hl4YIFiRd4EWy7oZlvFmevBNsIXa8KTZ0+HCj/f48s4NNZKXWooSakXeCmeFCzkcnP/Wv4jYD3RyWFAjg==",
       "dev": true,
       "license": "Apache-2.0",

--- a/ui/cluster-admin/package-lock.json
+++ b/ui/cluster-admin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "greenhouse-cluster-admin",
-  "version": "1.6.1",
+  "version": "1.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "greenhouse-cluster-admin",
-      "version": "1.6.1",
+      "version": "1.6.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/jest": "^27.5.2",

--- a/ui/cluster-admin/package.json
+++ b/ui/cluster-admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "greenhouse-cluster-admin",
-  "version": "1.6.1",
+  "version": "1.6.3",
   "author": "Services-Team",
   "contributors": [
     "Uwe Mayer"

--- a/ui/cluster-admin/package.json
+++ b/ui/cluster-admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "greenhouse-cluster-admin",
-  "version": "1.6.2",
+  "version": "1.6.1",
   "author": "Services-Team",
   "contributors": [
     "Uwe Mayer"
@@ -32,7 +32,7 @@
     "eslint-plugin-react-hooks": "^4.6.0",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.3.1",
-    "juno-ui-components": "https://assets.juno.global.cloud.sap/libs/juno-ui-components@latest/package.tgz",
+    "juno-ui-components": "https://assets.juno.global.cloud.sap/libs/juno-ui-components@2.12.1/package.tgz",
     "postcss": "^8.4.21",
     "postcss-url": "^10.1.3",
     "prop-types": "^15.8.1",
@@ -43,7 +43,7 @@
     "sass": "^1.60.0",
     "shadow-dom-testing-library": "^1.7.1",
     "tailwindcss": "^3.3.1",
-    "url-state-provider": "https://assets.juno.global.cloud.sap/libs/url-state-provider@latest/package.tgz",
+    "url-state-provider": "https://assets.juno.global.cloud.sap/libs/url-state-provider@1.3.2/package.tgz",
     "util": "^0.12.4",
     "zustand": "^4.1.1"
   },


### PR DESCRIPTION
"Latest" doesn't work for dependencies. If they change then the sha hash of the version originally used and stored in `package-lock.json` doesn't match the sha hash of the current version anymore which leads to inconsistencies.