### PR TITLE
feat(teamrbac): grant permissions to OrgAdmins and ClusterAdmins

### DIFF
--- a/pkg/rbac/role.go
+++ b/pkg/rbac/role.go
@@ -34,6 +34,12 @@ func OrganizationAdminPolicyRules() []rbacv1.PolicyRule {
 			APIGroups: []string{"rbac.authorization.k8s.io"},
 			Resources: []string{"rolebindings"},
 		},
+		// Grant permission for TeamRoles
+		{
+			Verbs:     []string{"get", "list", "watch", "update", "patch", "delete", "create"},
+			APIGroups: []string{greenhouseapisv1alpha1.GroupVersion.Group},
+			Resources: []string{"teamroles"},
+		},
 	}
 	orgAdminPolicyRules = append(orgAdminPolicyRules,
 		OrganizationClusterAdminPolicyRules()...)
@@ -55,6 +61,12 @@ func OrganizationClusterAdminPolicyRules() []rbacv1.PolicyRule {
 			Verbs:     []string{"create", "update", "patch"},
 			APIGroups: []string{corev1.GroupName},
 			Resources: []string{"secrets"},
+		},
+		// Grant permission for TeamRoleBindings
+		{
+			Verbs:     []string{"get", "list", "watch", "update", "patch", "delete", "create"},
+			APIGroups: []string{greenhouseapisv1alpha1.GroupVersion.Group},
+			Resources: []string{"teamrolebindings"},
 		},
 	}
 	return append(OrganizationMemberPolicyRules(), policyRules...)


### PR DESCRIPTION
## Description
This feature allows admins within a Organization to maintain Team RBAC.
OrgAdmins gain permissions to CRUD TeamRoles & TeamRoleBindings.
ClusteAdmins gain permissiosn to CRUD TeamRoleBindings.


## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [x] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
