### PR TITLE
Feat/team role seeder

### DIFF
--- a/charts/manager/templates/manager-role.yaml
+++ b/charts/manager/templates/manager-role.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/charts/manager/templates/manager-role.yaml
+++ b/charts/manager/templates/manager-role.yaml
@@ -1,8 +1,3 @@
-{{/* 
-SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-SPDX-License-Identifier: Apache-2.0
-*/}}
-
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -242,8 +237,11 @@ rules:
   resources:
   - teamroles
   verbs:
+  - create
   - get
   - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - greenhouse.sap

--- a/charts/manager/templates/manager-role.yaml
+++ b/charts/manager/templates/manager-role.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/*
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/manager/templates/webhooks.yaml
+++ b/charts/manager/templates/webhooks.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/*
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 ---
 apiVersion: admissionregistration.k8s.io/v1

--- a/charts/manager/templates/webhooks.yaml
+++ b/charts/manager/templates/webhooks.yaml
@@ -1,8 +1,3 @@
-{{/* 
-SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-SPDX-License-Identifier: Apache-2.0
-*/}}
-
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration

--- a/charts/manager/templates/webhooks.yaml
+++ b/charts/manager/templates/webhooks.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration

--- a/cmd/greenhouse/controllers.go
+++ b/cmd/greenhouse/controllers.go
@@ -21,10 +21,11 @@ import (
 // knownControllers contains all controllers to be registered when starting the operator.
 var knownControllers = map[string]func(controllerName string, mgr ctrl.Manager) error{
 	// Organization controllers.
-	"organizationNamespace":    (&organizationcontrollers.NamespaceReconciler{}).SetupWithManager,
-	"organizationRBAC":         (&organizationcontrollers.RBACReconciler{}).SetupWithManager,
-	"organizationDEX":          startOrganizationDexReconciler,
-	"organizationServiceProxy": (&organizationcontrollers.ServiceProxyReconciler{}).SetupWithManager,
+	"organizationNamespace":      (&organizationcontrollers.NamespaceReconciler{}).SetupWithManager,
+	"organizationRBAC":           (&organizationcontrollers.RBACReconciler{}).SetupWithManager,
+	"organizationDEX":            startOrganizationDexReconciler,
+	"organizationServiceProxy":   (&organizationcontrollers.ServiceProxyReconciler{}).SetupWithManager,
+	"organizationTeamRoleSeeder": (&organizationcontrollers.TeamRoleSeederReconciler{}).SetupWithManager,
 
 	// Team controllers.
 	"teamCAM":         (&teamcontrollers.CAMReconciler{}).SetupWithManager,

--- a/docs/reference/api/index.html
+++ b/docs/reference/api/index.html
@@ -323,7 +323,7 @@ p {
             <p><h1>Greenhouse</h1></p>
             <p>PlusOne operations platform</p>
             <p>
-                <div class="app-desc">Version: e0e0059</div>
+                <div class="app-desc">Version: f91d940</div>
             </p>
           </div>
         </div>

--- a/docs/reference/api/openapi.yaml
+++ b/docs/reference/api/openapi.yaml
@@ -1,51 +1,127 @@
 openapi: 3.0.0
 info:
   title: Greenhouse
-  version: e0e0059
+  version: f91d940
   description: PlusOne operations platform
 paths:
-  /Cluster:
-    post:
-      responses:
-        default:
-          description: Cluster
   /Organization:
     post:
       responses:
         default:
           description: Organization
+  /Cluster:
+    post:
+      responses:
+        default:
+          description: Cluster
   /PluginConfig:
     post:
       responses:
         default:
           description: PluginConfig
-  /Plugin:
-    post:
-      responses:
-        default:
-          description: Plugin
-  /TeamMembership:
-    post:
-      responses:
-        default:
-          description: TeamMembership
-  /TeamRoleBinding:
-    post:
-      responses:
-        default:
-          description: TeamRoleBinding
   /TeamRole:
     post:
       responses:
         default:
           description: TeamRole
+  /TeamMembership:
+    post:
+      responses:
+        default:
+          description: TeamMembership
   /Team:
     post:
       responses:
         default:
           description: Team
+  /TeamRoleBinding:
+    post:
+      responses:
+        default:
+          description: TeamRoleBinding
+  /Plugin:
+    post:
+      responses:
+        default:
+          description: Plugin
 components:
   schemas:
+    Organization:
+      xml:
+        name: greenhouse.sap
+        namespace: v1alpha1
+      title: Organization
+      description: Organization is the Schema for the organizations API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: OrganizationSpec defines the desired state of Organization
+          properties:
+            authentication:
+              description: Authentication configures the organizations authentication mechanism.
+              properties:
+                oidc:
+                  description: OIDConfig configures the OIDC provider.
+                  properties:
+                    clientIDReference:
+                      description: ClientIDReference references the Kubernetes secret containing the client id.
+                      properties:
+                        key:
+                          description: Key in the secret to select the value from.
+                          type: string
+                        name:
+                          description: Name of the secret in the same namespace.
+                          type: string
+                      required:
+                        - key
+                        - name
+                      type: object
+                    clientSecretReference:
+                      description: ClientSecretReference references the Kubernetes secret containing the client secret.
+                      properties:
+                        key:
+                          description: Key in the secret to select the value from.
+                          type: string
+                        name:
+                          description: Name of the secret in the same namespace.
+                          type: string
+                      required:
+                        - key
+                        - name
+                      type: object
+                    issuer:
+                      description: Issuer is the URL of the identity service.
+                      type: string
+                    redirectURI:
+                      description: RedirectURI is the redirect URI. If none is specified, the Greenhouse ID proxy will be used.
+                      type: string
+                  required:
+                    - clientIDReference
+                    - clientSecretReference
+                    - issuer
+                  type: object
+              type: object
+            description:
+              description: Description provides additional details of the organization.
+              type: string
+            displayName:
+              description: DisplayName is an optional name for the organization to be displayed in the Greenhouse UI. Defaults to a normalized version of metadata.name.
+              type: string
+            mappedOrgAdminIdPGroup:
+              description: MappedOrgAdminIDPGroup is the IDP group ID identifying org admins
+              type: string
+          type: object
+        status:
+          description: OrganizationStatus defines the observed state of an Organization
+          type: object
+      type: object
     Cluster:
       xml:
         name: greenhouse.sap
@@ -203,82 +279,6 @@ components:
                     - type
                   x-kubernetes-list-type: map
               type: object
-          type: object
-      type: object
-    Organization:
-      xml:
-        name: greenhouse.sap
-        namespace: v1alpha1
-      title: Organization
-      description: Organization is the Schema for the organizations API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: OrganizationSpec defines the desired state of Organization
-          properties:
-            authentication:
-              description: Authentication configures the organizations authentication mechanism.
-              properties:
-                oidc:
-                  description: OIDConfig configures the OIDC provider.
-                  properties:
-                    clientIDReference:
-                      description: ClientIDReference references the Kubernetes secret containing the client id.
-                      properties:
-                        key:
-                          description: Key in the secret to select the value from.
-                          type: string
-                        name:
-                          description: Name of the secret in the same namespace.
-                          type: string
-                      required:
-                        - key
-                        - name
-                      type: object
-                    clientSecretReference:
-                      description: ClientSecretReference references the Kubernetes secret containing the client secret.
-                      properties:
-                        key:
-                          description: Key in the secret to select the value from.
-                          type: string
-                        name:
-                          description: Name of the secret in the same namespace.
-                          type: string
-                      required:
-                        - key
-                        - name
-                      type: object
-                    issuer:
-                      description: Issuer is the URL of the identity service.
-                      type: string
-                    redirectURI:
-                      description: RedirectURI is the redirect URI. If none is specified, the Greenhouse ID proxy will be used.
-                      type: string
-                  required:
-                    - clientIDReference
-                    - clientSecretReference
-                    - issuer
-                  type: object
-              type: object
-            description:
-              description: Description provides additional details of the organization.
-              type: string
-            displayName:
-              description: DisplayName is an optional name for the organization to be displayed in the Greenhouse UI. Defaults to a normalized version of metadata.name.
-              type: string
-            mappedOrgAdminIdPGroup:
-              description: MappedOrgAdminIDPGroup is the IDP group ID identifying org admins
-              type: string
-          type: object
-        status:
-          description: OrganizationStatus defines the observed state of an Organization
           type: object
       type: object
     PluginConfig:
@@ -469,6 +469,185 @@ components:
               type: integer
           type: object
       type: object
+    TeamRole:
+      xml:
+        name: greenhouse.sap
+        namespace: v1alpha1
+      title: TeamRole
+      description: TeamRole is the Schema for the TeamRoles API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: TeamRoleSpec defines the desired state of a TeamRole
+          properties:
+            rules:
+              description: Rules is a list of rbacv1.PolicyRules used on a managed RBAC (Cluster)Role
+              items:
+                description: PolicyRule holds information that describes a policy rule, but does not contain information about who the rule applies to or which namespace the rule applies to.
+                properties:
+                  apiGroups:
+                    description: APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of the enumerated resources in any API group will be allowed. "" represents the core API group and "*" represents all API groups.
+                    items:
+                      type: string
+                    type: array
+                  nonResourceURLs:
+                    description: NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path Since non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding. Rules can either apply to API resources (such as "pods" or "secrets") or non-resource URL paths (such as "/api"),  but not both.
+                    items:
+                      type: string
+                    type: array
+                  resourceNames:
+                    description: ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.
+                    items:
+                      type: string
+                    type: array
+                  resources:
+                    description: Resources is a list of resources this rule applies to. '*' represents all resources.
+                    items:
+                      type: string
+                    type: array
+                  verbs:
+                    description: Verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs.
+                    items:
+                      type: string
+                    type: array
+                required:
+                  - verbs
+                type: object
+              type: array
+          type: object
+        status:
+          description: TeamRoleStatus defines the observed state of a TeamRole
+          type: object
+      type: object
+    TeamMembership:
+      xml:
+        name: greenhouse.sap
+        namespace: v1alpha1
+      title: TeamMembership
+      description: TeamMembership is the Schema for the teammemberships API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: TeamMembershipSpec defines the desired state of TeamMembership
+          properties:
+            members:
+              description: Members list users that are part of a team.
+              items:
+                description: User specifies a human person.
+                properties:
+                  email:
+                    description: Email of the user.
+                    type: string
+                  firstName:
+                    description: FirstName of the user.
+                    type: string
+                  id:
+                    description: ID is the unique identifier of the user.
+                    type: string
+                  lastName:
+                    description: LastName of the user.
+                    type: string
+                required:
+                  - email
+                  - firstName
+                  - id
+                  - lastName
+                type: object
+              type: array
+          type: object
+        status:
+          description: TeamMembershipStatus defines the observed state of TeamMembership
+          properties:
+            lastSyncedTime:
+              description: LastSyncedTime is the information when was the last time the membership was synced
+              format: date-time
+              type: string
+            lastUpdateTime:
+              description: LastChangedTime is the information when was the last time the membership was actually changed
+              format: date-time
+              type: string
+          type: object
+      type: object
+    Team:
+      xml:
+        name: greenhouse.sap
+        namespace: v1alpha1
+      title: Team
+      description: Team is the Schema for the teams API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: TeamSpec defines the desired state of Team
+          properties:
+            description:
+              description: Description provides additional details of the team.
+              type: string
+            mappedIdPGroup:
+              description: IdP group id matching team.
+              type: string
+          type: object
+        status:
+          description: TeamStatus defines the observed state of Team
+          type: object
+      type: object
+    TeamRoleBinding:
+      xml:
+        name: greenhouse.sap
+        namespace: v1alpha1
+      title: TeamRoleBinding
+      description: TeamRoleBinding is the Schema for the rolebindings API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: TeamRoleBindingSpec defines the desired state of a TeamRoleBinding
+          properties:
+            clusterName:
+              description: ClusterName is the name of the cluster the pluginConfig is deployed to.
+              type: string
+            namespaces:
+              description: Namespaces is the immutable list of namespaces in the Greenhouse Clusters to apply the RoleBinding to
+              items:
+                type: string
+              type: array
+            teamRef:
+              description: TeamRef references a Greenhouse Team by name
+              type: string
+            teamRoleRef:
+              description: TeamRoleRef references a Greenhouse TeamRole by name
+              type: string
+          type: object
+        status:
+          description: TeamRoleBindingStatus defines the observed state of the TeamRoleBinding
+          type: object
+      type: object
     Plugin:
       xml:
         name: greenhouse.sap
@@ -573,184 +752,5 @@ components:
           type: object
         status:
           description: PluginStatus defines the observed state of Plugin
-          type: object
-      type: object
-    TeamMembership:
-      xml:
-        name: greenhouse.sap
-        namespace: v1alpha1
-      title: TeamMembership
-      description: TeamMembership is the Schema for the teammemberships API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: TeamMembershipSpec defines the desired state of TeamMembership
-          properties:
-            members:
-              description: Members list users that are part of a team.
-              items:
-                description: User specifies a human person.
-                properties:
-                  email:
-                    description: Email of the user.
-                    type: string
-                  firstName:
-                    description: FirstName of the user.
-                    type: string
-                  id:
-                    description: ID is the unique identifier of the user.
-                    type: string
-                  lastName:
-                    description: LastName of the user.
-                    type: string
-                required:
-                  - email
-                  - firstName
-                  - id
-                  - lastName
-                type: object
-              type: array
-          type: object
-        status:
-          description: TeamMembershipStatus defines the observed state of TeamMembership
-          properties:
-            lastSyncedTime:
-              description: LastSyncedTime is the information when was the last time the membership was synced
-              format: date-time
-              type: string
-            lastUpdateTime:
-              description: LastChangedTime is the information when was the last time the membership was actually changed
-              format: date-time
-              type: string
-          type: object
-      type: object
-    TeamRoleBinding:
-      xml:
-        name: greenhouse.sap
-        namespace: v1alpha1
-      title: TeamRoleBinding
-      description: TeamRoleBinding is the Schema for the rolebindings API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: TeamRoleBindingSpec defines the desired state of a TeamRoleBinding
-          properties:
-            clusterName:
-              description: ClusterName is the name of the cluster the pluginConfig is deployed to.
-              type: string
-            namespaces:
-              description: Namespaces is the immutable list of namespaces in the Greenhouse Clusters to apply the RoleBinding to
-              items:
-                type: string
-              type: array
-            teamRef:
-              description: TeamRef references a Greenhouse Team by name
-              type: string
-            teamRoleRef:
-              description: TeamRoleRef references a Greenhouse TeamRole by name
-              type: string
-          type: object
-        status:
-          description: TeamRoleBindingStatus defines the observed state of the TeamRoleBinding
-          type: object
-      type: object
-    TeamRole:
-      xml:
-        name: greenhouse.sap
-        namespace: v1alpha1
-      title: TeamRole
-      description: TeamRole is the Schema for the TeamRoles API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: TeamRoleSpec defines the desired state of a TeamRole
-          properties:
-            rules:
-              description: Rules is a list of rbacv1.PolicyRules used on a managed RBAC (Cluster)Role
-              items:
-                description: PolicyRule holds information that describes a policy rule, but does not contain information about who the rule applies to or which namespace the rule applies to.
-                properties:
-                  apiGroups:
-                    description: APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of the enumerated resources in any API group will be allowed. "" represents the core API group and "*" represents all API groups.
-                    items:
-                      type: string
-                    type: array
-                  nonResourceURLs:
-                    description: NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path Since non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding. Rules can either apply to API resources (such as "pods" or "secrets") or non-resource URL paths (such as "/api"),  but not both.
-                    items:
-                      type: string
-                    type: array
-                  resourceNames:
-                    description: ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.
-                    items:
-                      type: string
-                    type: array
-                  resources:
-                    description: Resources is a list of resources this rule applies to. '*' represents all resources.
-                    items:
-                      type: string
-                    type: array
-                  verbs:
-                    description: Verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs.
-                    items:
-                      type: string
-                    type: array
-                required:
-                  - verbs
-                type: object
-              type: array
-          type: object
-        status:
-          description: TeamRoleStatus defines the observed state of a TeamRole
-          type: object
-      type: object
-    Team:
-      xml:
-        name: greenhouse.sap
-        namespace: v1alpha1
-      title: Team
-      description: Team is the Schema for the teams API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: TeamSpec defines the desired state of Team
-          properties:
-            description:
-              description: Description provides additional details of the team.
-              type: string
-            mappedIdPGroup:
-              description: IdP group id matching team.
-              type: string
-          type: object
-        status:
-          description: TeamStatus defines the observed state of Team
           type: object
       type: object

--- a/docs/user-guides/team/rbac.md
+++ b/docs/user-guides/team/rbac.md
@@ -1,0 +1,64 @@
+---
+title: "Role based access control"
+description: >
+   Creating and managing roles and permissions in Greenhouse.
+---
+
+## Before you begin
+
+This guides describes how to manage roles and permissions in Greenhouse.  
+
+While all members of an organization can see the configured permissions, configuration of these requires **organization admin privileges**.
+
+# Greenhouse RBAC user guide
+
+Role-Based Access Control (RBAC) in Greenhouse allows organization administrators to regulate access to Kubernetes resources in onboarded clusters based on the roles of individual users within an organization.    
+Greenhouse utilizes custom RBAC configurations with `TeamRole` and `TeamRoleBinding` to manage access controls effectively.
+
+## Overview
+
+- **TeamRole**: Defines a set of permissions that can be assigned to teams.
+- **TeamRoleBinding**: Assigns a `TeamRole` to a specific team for certain clusters.
+
+## Defining Team Roles
+
+Team Roles define what actions a team can perform within the Kubernetes cluster.  
+Common roles including the below `cluster-admin` are pre-defined within each organization.
+
+### Cluster administrator 
+
+This TeamRole named cluster-admin grants full access to all resources in all API groups.
+
+```yaml
+apiVersion: greenhouse.sap/v1alpha1
+kind: TeamRole
+metadata:
+  name: cluster-admin
+spec:
+  rules:
+    - apiGroups:
+        - "*"
+      resources:
+        - "*"
+      verbs:
+        - "*"
+```
+
+## Assigning Roles to Teams
+
+Roles are assigned to teams through the TeamRoleBinding configuration, which links teams to their respective roles within specific clusters.
+
+This TeamRoleBinding assigns the `cluster-admin` role to the team named `my-team` in the cluster named `my-cluster`.
+
+Example: `team-rolebindings.yaml`
+
+```yaml
+apiVersion: greenhouse.sap/v1alpha1
+kind: TeamRoleBinding
+metadata:
+  name: my team
+spec:
+  teamRef: my-team
+  roleRef: cluster-admin
+  clusterName: my-cluster
+```

--- a/docs/user-guides/team/rbac.md
+++ b/docs/user-guides/team/rbac.md
@@ -22,7 +22,7 @@ Greenhouse utilizes custom RBAC configurations with `TeamRole` and `TeamRoleBind
 
 ## Defining Team Roles
 
-Team Roles define what actions a team can perform within the Kubernetes cluster.  
+`TeamRoles` define what actions a team can perform within the Kubernetes cluster.  
 Common roles including the below `cluster-admin` are pre-defined within each organization.
 
 ### Cluster administrator 

--- a/docs/user-guides/team/rbac.md
+++ b/docs/user-guides/team/rbac.md
@@ -1,5 +1,5 @@
 ---
-title: "Role based access control"
+title: "Role-based access control"
 description: >
    Creating and managing roles and permissions in Greenhouse.
 ---

--- a/pkg/controllers/organization/teamrole_seeder_controller.go
+++ b/pkg/controllers/organization/teamrole_seeder_controller.go
@@ -38,7 +38,7 @@ type TeamRoleSeederReconciler struct {
 //+kubebuilder:rbac:groups=greenhouse.sap,resources=organizations/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=greenhouse.sap,resources=organizations/finalizers,verbs=update
 //+kubebuilder:rbac:groups=greenhouse.sap,resources=teamroles,verbs=get;list;watch;create;update;patch
-//+kubebuilder:rbac:groups="",resources=events,verbs=get;list;watch;create;update;patch
+//+kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *TeamRoleSeederReconciler) SetupWithManager(name string, mgr ctrl.Manager) error {

--- a/pkg/controllers/organization/teamrole_seeder_controller.go
+++ b/pkg/controllers/organization/teamrole_seeder_controller.go
@@ -1,0 +1,93 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package organization
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	greenhousesapv1alpha1 "github.com/cloudoperators/greenhouse/pkg/apis/greenhouse/v1alpha1"
+	"github.com/cloudoperators/greenhouse/pkg/clientutil"
+)
+
+var defaultTeamRoles = map[string]greenhousesapv1alpha1.TeamRoleSpec{
+	"cluster-admin": {
+		Rules: []rbacv1.PolicyRule{{
+			APIGroups: []string{"*"},
+			Resources: []string{"*"},
+			Verbs:     []string{"*"},
+		}},
+	},
+}
+
+// TeamRoleSeederReconciler reconciles a Organization object
+type TeamRoleSeederReconciler struct {
+	client.Client
+	recorder record.EventRecorder
+}
+
+//+kubebuilder:rbac:groups=greenhouse.sap,resources=organizations,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=greenhouse.sap,resources=organizations/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=greenhouse.sap,resources=organizations/finalizers,verbs=update
+//+kubebuilder:rbac:groups=greenhouse.sap,resources=teamroles,verbs=get;list;watch;create;update;patch
+//+kubebuilder:rbac:groups="",resources=events,verbs=get;list;watch;create;update;patch
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *TeamRoleSeederReconciler) SetupWithManager(name string, mgr ctrl.Manager) error {
+	r.Client = mgr.GetClient()
+	r.recorder = mgr.GetEventRecorderFor(name)
+	return ctrl.NewControllerManagedBy(mgr).
+		Named(name).
+		For(&greenhousesapv1alpha1.Organization{}).
+		Owns(&greenhousesapv1alpha1.TeamRole{}).
+		Complete(r)
+}
+
+func (r *TeamRoleSeederReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	ctx = clientutil.LogIntoContextFromRequest(ctx, req)
+
+	var org = new(greenhousesapv1alpha1.Organization)
+	if err := r.Get(ctx, req.NamespacedName, org); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	if err := r.reconcileDefaultTeamRoles(ctx, org); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func (r *TeamRoleSeederReconciler) reconcileDefaultTeamRoles(ctx context.Context, org *greenhousesapv1alpha1.Organization) error {
+	for name, teamRoleSpec := range defaultTeamRoles {
+		var tr = new(greenhousesapv1alpha1.TeamRole)
+		tr.Name = name
+		tr.Namespace = org.GetName()
+
+		result, err := clientutil.CreateOrPatch(ctx, r.Client, tr, func() error {
+			tr.Spec = teamRoleSpec
+			return controllerutil.SetOwnerReference(org, tr, r.Scheme())
+		})
+		if err != nil {
+			return err
+		}
+		switch result {
+		case clientutil.OperationResultCreated:
+			log.FromContext(ctx).Info("created team role", "namespace", tr.GetNamespace(), "name", tr.GetName())
+			r.recorder.Eventf(org, corev1.EventTypeNormal, "CreatedTeamRole", "Created team role %s/%s", tr.GetNamespace(), tr.GetName())
+		case clientutil.OperationResultUpdated:
+			log.FromContext(ctx).Info("updated team role", "namespace", tr.GetNamespace(), "name", tr.GetName())
+			r.recorder.Eventf(org, corev1.EventTypeNormal, "UpdatedTeamRole", "Updated team role %s/%s", tr.GetNamespace(), tr.GetName())
+		}
+		return nil
+	}
+	return nil
+}

--- a/pkg/controllers/organization/teamrole_seeder_controller.go
+++ b/pkg/controllers/organization/teamrole_seeder_controller.go
@@ -34,9 +34,7 @@ type TeamRoleSeederReconciler struct {
 	recorder record.EventRecorder
 }
 
-//+kubebuilder:rbac:groups=greenhouse.sap,resources=organizations,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=greenhouse.sap,resources=organizations/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=greenhouse.sap,resources=organizations/finalizers,verbs=update
+//+kubebuilder:rbac:groups=greenhouse.sap,resources=organizations,verbs=get;list;watch
 //+kubebuilder:rbac:groups=greenhouse.sap,resources=teamroles,verbs=get;list;watch;create;update;patch
 //+kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 


### PR DESCRIPTION
This PR adds a default `cluster-admin` role to each organization.
Moreover, it adds a user guide to the documentation on how to setup this up until the UI takes over this part.