### PR TITLE
fix(codeowners): dedicated entry for openapi docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,6 +10,7 @@
 /website/               @andypf @artiereus @auhlig @edda @hodanoori @ivogoman @kengou @onuryilmaz @tilmanhaupt @uwe-mayer
 .gitignore              @andypf @artiereus @auhlig @edda @hodanoori @ivogoman @kengou @onuryilmaz @tilmanhaupt @uwe-mayer
 
+/docs/reference/api     @auhlig @ivogoman @kengou @onuryilmaz @uwe-mayer
 /charts/                @auhlig @ivogoman @kengou @onuryilmaz @uwe-mayer
 /cmd/                   @auhlig @ivogoman @kengou @onuryilmaz @uwe-mayer
 /grafana/               @auhlig @ivogoman @kengou @onuryilmaz @uwe-mayer


### PR DESCRIPTION
## Description

More fine granular handling of CODEOWNERS to reduce Github Notifications for the team.
`/docs/reference/api` contains the API documentation generated from the Go Structs for the Greenhouse CRDs

## What type of PR is this? (check all applicable)

- [] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [x] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [x] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
