### PR TITLE
[plugin-admin] Fix deep nested options

### DIFF
--- a/ui/plugin-admin/package-lock.json
+++ b/ui/plugin-admin/package-lock.json
@@ -28,7 +28,7 @@
         "esbuild": "^0.19.5",
         "jest": "^29.3.1",
         "jest-environment-jsdom": "^29.3.1",
-        "juno-ui-components": "https://assets.juno.global.cloud.sap/libs/juno-ui-components@2.12.1/package.tgz",
+        "juno-ui-components": "https://assets.juno.global.cloud.sap/libs/juno-ui-components@2.13.5/package.tgz",
         "luxon": "^2.3.0",
         "postcss": "^8.4.21",
         "postcss-url": "^10.1.3",
@@ -8533,9 +8533,9 @@
       }
     },
     "node_modules/juno-ui-components": {
-      "version": "2.12.1",
-      "resolved": "https://assets.juno.global.cloud.sap/libs/juno-ui-components@2.12.1/package.tgz",
-      "integrity": "sha512-AFEIkQhQHPiPoGEymBxOPN1sJ5QWtASTLdYuehtZnXD1w9PVu8rS2zq+P6uohPktvHpUwKN6FKvyN+9mG/SUkw==",
+      "version": "2.13.5",
+      "resolved": "https://assets.juno.global.cloud.sap/libs/juno-ui-components@2.13.5/package.tgz",
+      "integrity": "sha512-H/Szwq9G2JC65y8LDE825jdLhYNTAN8E7FY+znowE3mLBHJdyuIjkt2UA+OnQ2cWvtSvd3a7vDPvJJ2u1zQuaw==",
       "dev": true,
       "license": "Apache-2.0",
       "peerDependencies": {

--- a/ui/plugin-admin/package.json
+++ b/ui/plugin-admin/package.json
@@ -30,7 +30,7 @@
     "esbuild": "^0.19.5",
     "jest": "^29.3.1",
     "jest-environment-jsdom": "^29.3.1",
-    "juno-ui-components": "https://assets.juno.global.cloud.sap/libs/juno-ui-components@2.12.1/package.tgz",
+    "juno-ui-components": "https://assets.juno.global.cloud.sap/libs/juno-ui-components@2.13.5/package.tgz",
     "luxon": "^2.3.0",
     "postcss": "^8.4.21",
     "postcss-url": "^10.1.3",

--- a/ui/plugin-admin/package.json
+++ b/ui/plugin-admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "greenhouse-plugin-admin",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "author": "UI-Team",
   "contributors": [
     "Tilman Haupt"

--- a/ui/plugin-admin/src/components/PluginDetail.js
+++ b/ui/plugin-admin/src/components/PluginDetail.js
@@ -143,22 +143,14 @@ const PluginDetail = () => {
                   if (option?.name.startsWith("greenhouse.")) return null
 
                   return (
-                    <DataGridRow>
+                    <DataGridRow key={option?.name}>
                       <DataGridHeadCell style={{ overflowWrap: "break-word" }}>
                         {option?.name}
                       </DataGridHeadCell>
                       <DataGridCell>
-                        {typeof option.value != "undefined" &&
-                          (typeof option.value === "object" ? (
-                            Array.isArray(option.value) ? (
-                              <ol>
-                                {option?.value?.map((value, index) => {
-                                  return <li key={index}>{value}</li>
-                                })}
-                              </ol>
-                            ) : (
-                              <JsonViewer data={option?.value} />
-                            )
+                        {typeof option?.value != "undefined" &&
+                          (typeof option?.value === "object" ? (
+                            <JsonViewer data={option?.value} />
                           ) : (
                             String(option?.value)
                           ))}


### PR DESCRIPTION
There was a runtime error for unexpectedly deeply nested options. Fixed it by removing the logic that tried to differentiate between arrays and objects and instead used `JsonViewer` also for arrays. Also updated the `JsonViewer` component in `juno-ui-components` to also allow arrays.