### PR TITLE
fix(helmcontroller): fix regression that diff was not reconciled

### DIFF
--- a/pkg/controllers/pluginconfig/remote_cluster_test.go
+++ b/pkg/controllers/pluginconfig/remote_cluster_test.go
@@ -217,7 +217,7 @@ var _ = Describe("Validate pluginConfig clusterName", Ordered, func() {
 			return nil
 		})
 		Expect(err).ShouldNot(HaveOccurred(), "there should be no error updating the pluginConfig")
-		By("checkind the resources deployed to the remote cluster")
+		By("checking the resources deployed to the remote cluster")
 		remoteK8sClient, err := clientutil.NewK8sClientFromRestClientGetter(remoteRestClientGetter)
 		Expect(err).ShouldNot(HaveOccurred(), "there should be no error creating the k8s client")
 		podID := types.NamespacedName{Name: "alpine-flag", Namespace: test.TestNamespace}

--- a/pkg/controllers/pluginconfig/remote_cluster_test.go
+++ b/pkg/controllers/pluginconfig/remote_cluster_test.go
@@ -12,6 +12,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 
 	greenhouseapis "github.com/cloudoperators/greenhouse/pkg/apis"
@@ -125,6 +126,7 @@ var testClusterK8sSecret = corev1.Secret{
 var (
 	remoteKubeConfig []byte
 	remoteEnvTest    *envtest.Environment
+	remoteK8sClient  client.Client
 )
 
 var _ = Describe("Validate pluginConfig clusterName", Ordered, func() {
@@ -218,7 +220,6 @@ var _ = Describe("Validate pluginConfig clusterName", Ordered, func() {
 		})
 		Expect(err).ShouldNot(HaveOccurred(), "there should be no error updating the pluginConfig")
 		By("checking the resources deployed to the remote cluster")
-		remoteK8sClient, err := clientutil.NewK8sClientFromRestClientGetter(remoteRestClientGetter)
 		Expect(err).ShouldNot(HaveOccurred(), "there should be no error creating the k8s client")
 		podID := types.NamespacedName{Name: "alpine-flag", Namespace: test.TestNamespace}
 		pod := &corev1.Pod{}
@@ -257,9 +258,9 @@ var _ = Describe("Validate pluginConfig clusterName", Ordered, func() {
 		Expect(err).ShouldNot(HaveOccurred(), "there should be no error creating helm config")
 		listAction := action.NewList(helmConfig)
 
-		Eventually(func() []*release.Release {
+		Eventually(func(g Gomega) []*release.Release {
 			releases, err := listAction.Run()
-			Expect(err).ShouldNot(HaveOccurred(), "there should be no error listing helm releases")
+			g.Expect(err).ShouldNot(HaveOccurred(), "there should be no error listing helm releases")
 			return releases
 		}).Should(ContainElement(
 			gstruct.PointTo(
@@ -272,9 +273,9 @@ var _ = Describe("Validate pluginConfig clusterName", Ordered, func() {
 		Expect(test.K8sClient.Delete(test.Ctx, testPCwithSR)).Should(Succeed(), "there should be no error deleting the pluginConfig")
 
 		By("checking the helm releases deployed to the remote cluster")
-		Eventually(func() []*release.Release {
+		Eventually(func(g Gomega) []*release.Release {
 			releases, err := listAction.Run()
-			Expect(err).ShouldNot(HaveOccurred(), "there should be no error listing helm releases")
+			g.Expect(err).ShouldNot(HaveOccurred(), "there should be no error listing helm releases")
 			return releases
 		}).Should(BeEmpty(), "the helm release should be deleted from the remote cluster")
 	})
@@ -282,5 +283,5 @@ var _ = Describe("Validate pluginConfig clusterName", Ordered, func() {
 })
 
 func bootstrapRemoteCluster() {
-	_, _, remoteEnvTest, remoteKubeConfig = test.StartControlPlane("6885", false, false)
+	_, remoteK8sClient, remoteEnvTest, remoteKubeConfig = test.StartControlPlane("6885", false, false)
 }


### PR DESCRIPTION
## Description

With the introduction of the DriftDetection only a Drift triggered a helm deployment.
But a Diff between the deployed and the current release of the Plugin should trigger a helm deploy as well.
This change ensures that only if no drift and no diff there is a NOOP.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->
- Related Issue # (issue)
- Closes # (issue)
- Fixes # (issue)

> Remove if not applicable

## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [x] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
