### PR TITLE
fix: deny deletion of used plugindefinitions, migrate label

### DIFF
--- a/cmd/service-proxy/proxy_test.go
+++ b/cmd/service-proxy/proxy_test.go
@@ -14,15 +14,13 @@ import (
 	"github.com/go-logr/logr"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	greenhouseapis "github.com/cloudoperators/greenhouse/pkg/apis"
 	greenhousev1alpha1 "github.com/cloudoperators/greenhouse/pkg/apis/greenhouse/v1alpha1"
+	"github.com/cloudoperators/greenhouse/pkg/test"
 )
 
 // TestRewrite tests the rewrite function of the proxy manager.
@@ -95,12 +93,8 @@ func TestRewrite(t *testing.T) {
 // sets up a cluster and a plugin with an exposed service in the fake client.
 // The test checks if the route is properly added to the cluster.
 func TestReconcile(t *testing.T) {
-	scheme := runtime.NewScheme()
-	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
-	utilruntime.Must(greenhousev1alpha1.AddToScheme(scheme))
-
 	pm := NewProxyManager()
-	pm.client = fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+	pm.client = fake.NewClientBuilder().WithScheme(test.GreenhouseV1Alpha1Scheme()).WithObjects(
 		&greenhousev1alpha1.Plugin{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "plugin1",

--- a/pkg/admission/plugin_webhook.go
+++ b/pkg/admission/plugin_webhook.go
@@ -52,7 +52,8 @@ func DefaultPlugin(ctx context.Context, c client.Client, obj runtime.Object) err
 		plugin.Labels = make(map[string]string, 0)
 	}
 	// The label is used to help identifying Plugins, e.g. if a PluginDefinition changes.
-	plugin.Labels[greenhouseapis.LabelKeyPlugin] = plugin.Spec.PluginDefinition
+	delete(plugin.Labels, greenhouseapis.LabelKeyPlugin)
+	plugin.Labels[greenhouseapis.LabelKeyPluginDefinition] = plugin.Spec.PluginDefinition
 	plugin.Labels[greenhouseapis.LabelKeyCluster] = plugin.Spec.ClusterName
 
 	// Default the displayName to a normalized version of metadata.name.

--- a/pkg/apis/well_known.go
+++ b/pkg/apis/well_known.go
@@ -34,6 +34,9 @@ const (
 	// LabelKeyPlugin is used to identify corresponding PluginDefinition for the resource.
 	LabelKeyPlugin = "greenhouse.sap/plugin"
 
+	// LabelKeyPluginDefinition is used to identify corresponding PluginDefinition for the resource.
+	LabelKeyPluginDefinition = "greenhouse.sap/plugindefinition"
+
 	// LabelKeyCluster is used to identify corresponding Cluster for the resource.
 	LabelKeyCluster = "greenhouse.sap/cluster"
 

--- a/pkg/controllers/plugin/helm_controller.go
+++ b/pkg/controllers/plugin/helm_controller.go
@@ -80,7 +80,7 @@ func (r *HelmReconciler) SetupWithManager(name string, mgr ctrl.Manager) error {
 			builder.WithPredicates(clientutil.PredicateFilterBySecretType(helmReleaseSecretType), predicate.GenerationChangedPredicate{}),
 		).
 		// If a PluginDefinition was changed, reconcile relevant Plugins.
-		Watches(&greenhousev1alpha1.PluginDefinition{}, handler.EnqueueRequestsFromMapFunc(r.enqueueAllPluginsForPlugin),
+		Watches(&greenhousev1alpha1.PluginDefinition{}, handler.EnqueueRequestsFromMapFunc(r.enqueueAllPluginsForPluginDefinition),
 			builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		// Clusters and teams are passed as values to each Helm operation. Reconcile on change.
 		Watches(&greenhousev1alpha1.Cluster{}, handler.EnqueueRequestsFromMapFunc(r.enqueueAllPlugins),
@@ -423,8 +423,8 @@ func (r *HelmReconciler) enqueueAllPluginsInNamespace(ctx context.Context, o cli
 	return listPluginsAsReconcileRequests(ctx, r.Client, client.InNamespace(o.GetNamespace()))
 }
 
-func (r *HelmReconciler) enqueueAllPluginsForPlugin(ctx context.Context, o client.Object) []ctrl.Request {
-	return listPluginsAsReconcileRequests(ctx, r.Client, client.MatchingLabels{greenhouseapis.LabelKeyPlugin: o.GetName()})
+func (r *HelmReconciler) enqueueAllPluginsForPluginDefinition(ctx context.Context, o client.Object) []ctrl.Request {
+	return listPluginsAsReconcileRequests(ctx, r.Client, client.MatchingLabels{greenhouseapis.LabelKeyPluginDefinition: o.GetName()})
 }
 
 func listPluginsAsReconcileRequests(ctx context.Context, c client.Client, listOpts ...client.ListOption) []ctrl.Request {

--- a/pkg/test/util.go
+++ b/pkg/test/util.go
@@ -15,6 +15,9 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	greenhousev1alpha1 "github.com/cloudoperators/greenhouse/pkg/apis/greenhouse/v1alpha1"
@@ -92,4 +95,12 @@ var ClientObjectMatcherByName = func(name string) gomegaTypes.GomegaMatcher {
 		gstruct.IgnoreExtras, gstruct.Fields{"ObjectMeta": gstruct.MatchFields(
 			gstruct.IgnoreExtras, gstruct.Fields{"Name": Equal(
 				name)})})
+}
+
+// GreenhouseV1Alpha1Scheme returns a new runtime.Scheme with the Greenhouse v1alpha1 scheme added.
+func GreenhouseV1Alpha1Scheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(greenhousev1alpha1.AddToScheme(scheme))
+	return scheme
 }


### PR DESCRIPTION
PluginDefinitions which are used by one or more Plugins must not be deleted

Migrate to use 'greenhouse.sap/plugindefinition' label for Plugins. Delete 'greenhouse.sap/plugin' label from Plugins