### PR TITLE
fix(renovate): ignore dexidp since go mod version not supported

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,6 +7,9 @@
   "constraints": {
     "go": "1.21"
   },
+  "ignoreDeps": [
+    "github.com/dexidp/dex"
+  ],
   "packageRules": [
     {
       "groupName": "github actions",


### PR DESCRIPTION
Dex versions are not compatible with Go nor dependabot. See: https://github.com/dexidp/dex/issues/2880