### PR TITLE
fix(helm): ensure releaseNamespace is set on clientGetter

### DIFF
--- a/pkg/controllers/plugin/helm_controller.go
+++ b/pkg/controllers/plugin/helm_controller.go
@@ -134,7 +134,6 @@ func (r *HelmReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		return ctrl.Result{}, err
 	}
 
-	// TODO: https://github.com/cloudoperators/greenhouse/issues/489
 	helmReconcileFailedCondition, pluginDefinition := r.getPlugin(ctx, plugin)
 	pluginStatus.StatusConditions.SetConditions(helmReconcileFailedCondition)
 	if pluginDefinition == nil {
@@ -216,7 +215,7 @@ func (r *HelmReconciler) initClientGetter(
 		clusterAccessReadyCondition.Message = fmt.Sprintf("Failed to get secret for cluster %s: %s", plugin.Spec.ClusterName, err.Error())
 		return clusterAccessReadyCondition, nil
 	}
-	restClientGetter, err = clientutil.NewRestClientGetterFromSecret(&secret, plugin.GetNamespace(), r.kubeClientOpts...)
+	restClientGetter, err = clientutil.NewRestClientGetterFromSecret(&secret, plugin.GetReleaseNamespace(), r.kubeClientOpts...)
 	if err != nil {
 		clusterAccessReadyCondition.Status = metav1.ConditionFalse
 		clusterAccessReadyCondition.Message = fmt.Sprintf("cannot access cluster %s: %s", plugin.Spec.ClusterName, err.Error())

--- a/pkg/controllers/plugin/remote_cluster_test.go
+++ b/pkg/controllers/plugin/remote_cluster_test.go
@@ -301,7 +301,7 @@ var _ = Describe("Validate plugin clusterName", Ordered, func() {
 		Expect(testPluginInDifferentNamespace.GetReleaseNamespace()).
 			Should(Equal("made-up-namespace"), "the release namespace should be the made-up-namespace")
 
-		By("creating a pluginconfig referencing the cluster")
+		By("creating a plugin referencing the cluster")
 		Expect(test.K8sClient.Create(test.Ctx, testPluginInDifferentNamespace)).
 			Should(Succeed(), "there should be no error creating the plugin")
 
@@ -320,6 +320,17 @@ var _ = Describe("Validate plugin clusterName", Ordered, func() {
 		}).Should(
 			Equal(testPluginInDifferentNamespace.GetReleaseNamespace()),
 			"the helm release should be deployed to the remote cluster in a different namespace",
+		)
+
+		By("checking the pod template without explicit namespace is deployed to the releaseNamespace")
+		podName := types.NamespacedName{Name: "alpine", Namespace: testPluginInDifferentNamespace.GetReleaseNamespace()}
+		Eventually(func(g Gomega) {
+			pod := &corev1.Pod{}
+			err := remoteK8sClient.Get(test.Ctx, podName, pod)
+			g.Expect(err).NotTo(HaveOccurred(), "there should be no error getting the pod")
+		}).Should(
+			Succeed(),
+			"the pod template without explicit namespace should be deployed to the releaseNamespace",
 		)
 
 		By("deleting the plugin")


### PR DESCRIPTION
## Description

Fix for a regression introduced with the releaseNamespaces. 
The namespace of the kube client is used to determine the namespace for a Helm resource without explicit namespace in the template. This resulted in some resource being deployed to the default greenhouse managed namespace, while others where deployed to the releaseNamespace.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->
- Related Issue # (issue)
- Closes # (issue)
- Fixes # (issue)

> Remove if not applicable

## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [x] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
