### PR TITLE
fix(plugin): admission validate immutable releaseNamespace

### DIFF
--- a/pkg/admission/plugin_webhook.go
+++ b/pkg/admission/plugin_webhook.go
@@ -104,7 +104,7 @@ func ValidateCreatePlugin(ctx context.Context, c client.Client, obj runtime.Obje
 
 func ValidateUpdatePlugin(ctx context.Context, c client.Client, old, obj runtime.Object) (admission.Warnings, error) {
 	var allWarns admission.Warnings
-	oldPlugin, ok := obj.(*greenhousev1alpha1.Plugin)
+	oldPlugin, ok := old.(*greenhousev1alpha1.Plugin)
 	if !ok {
 		return nil, nil
 	}
@@ -130,6 +130,11 @@ func ValidateUpdatePlugin(ctx context.Context, c client.Client, old, obj runtime
 	}
 	if err := validateImmutableField(oldPlugin.Spec.ClusterName, plugin.Spec.ClusterName,
 		field.NewPath("spec", "clusterName"),
+	); err != nil {
+		return allWarns, err
+	}
+	if err := validateImmutableField(oldPlugin.Spec.ReleaseNamespace, plugin.Spec.ReleaseNamespace,
+		field.NewPath("spec", "releaseNamespace"),
 	); err != nil {
 		return allWarns, err
 	}

--- a/pkg/admission/plugin_webhook_test.go
+++ b/pkg/admission/plugin_webhook_test.go
@@ -250,6 +250,7 @@ var testPlugin = &greenhousev1alpha1.Plugin{
 	},
 	Spec: greenhousev1alpha1.PluginSpec{
 		PluginDefinition: "test-plugindefinition",
+		ReleaseNamespace: "test-namespace",
 	},
 }
 
@@ -327,6 +328,15 @@ var _ = Describe("Validate pluginConfig clusterName", Ordered, func() {
 		testPlugin.Spec.ClusterName = ""
 		err := test.K8sClient.Update(test.Ctx, testPlugin)
 		expectClusterMustBeSetError(err)
+		// reset the clusterName for following tests to pass
+		testPlugin.Spec.ClusterName = "test-cluster"
+	})
+
+	It("should reject a plugin update where the releaseNamespace changes", func() {
+		testPlugin.Spec.ReleaseNamespace = "foo-bar"
+		err := test.K8sClient.Update(test.Ctx, testPlugin)
+		Expect(err).ToNot(BeNil(), "there should be an error changing the plugin's releaseNamespace")
+		Expect(err.Error()).To(ContainSubstring("field is immutable"))
 	})
 })
 


### PR DESCRIPTION
## Description

The `releaseNamespace` of a Plugin must be immutable. Also fixes regression where `ValidateUpdate` did not compare the old with the current object.

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->
- Related Issue # (issue)
- Closes # (issue)
- Fixes # (issue)

> Remove if not applicable

## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [x] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
