### PR TITLE
fix(plugin): allow defaulting releaseNamespace during admission

### DIFF
--- a/pkg/admission/plugin_webhook.go
+++ b/pkg/admission/plugin_webhook.go
@@ -133,6 +133,12 @@ func ValidateUpdatePlugin(ctx context.Context, c client.Client, old, obj runtime
 	); err != nil {
 		return allWarns, err
 	}
+
+	// temporary: allow changing the release namespace to the plugin namespace for the migration to releaseNamespaces
+	if oldPlugin.Spec.ReleaseNamespace == "" && plugin.Spec.ReleaseNamespace == plugin.Namespace {
+		return allWarns, nil
+	}
+
 	if err := validateImmutableField(oldPlugin.Spec.ReleaseNamespace, plugin.Spec.ReleaseNamespace,
 		field.NewPath("spec", "releaseNamespace"),
 	); err != nil {


### PR DESCRIPTION
## Description
Plugins do not have the releaseNamespace set if they were created before it was introduced.
This ensures the AdmissionWebhook does not block the defaulting of the releaseNamespace for existing Plugins.

Once the releaseNamespace is set for all Plugins this can be removed again.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->
- Related Issue # (issue)
- Closes # (issue)
- Fixes # (issue)

> Remove if not applicable

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [ ] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
