### PR TITLE
feat(ui): cluster-admin add edit screen

### DIFF
--- a/ui/cluster-admin/package-lock.json
+++ b/ui/cluster-admin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "greenhouse-cluster-admin",
-  "version": "1.6.7",
+  "version": "1.6.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "greenhouse-cluster-admin",
-      "version": "1.6.7",
+      "version": "1.6.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/jest": "^27.5.2",

--- a/ui/cluster-admin/package.json
+++ b/ui/cluster-admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "greenhouse-cluster-admin",
-  "version": "1.6.7",
+  "version": "1.6.8",
   "author": "Services-Team",
   "contributors": [
     "Uwe Mayer"

--- a/ui/cluster-admin/src/AppContent.tsx
+++ b/ui/cluster-admin/src/AppContent.tsx
@@ -5,11 +5,12 @@
 
 import {
   Button,
+  ButtonRow,
   Container,
   DataGridToolbar,
-  ButtonRow,
 } from "juno-ui-components"
 import ClusterDetail from "./components/ClusterDetail"
+import ClusterEdit from "./components/ClusterEdit"
 import ClusterList from "./components/ClusterList"
 import DownloadKubeConfig from "./components/DownloadKubeConfig"
 import OnBoardCluster from "./components/OnBoardCluster"
@@ -25,6 +26,7 @@ const AppContent = () => {
   const showDownloadKubeConfig = useStore(
     (state) => state.showDownloadKubeConfig
   )
+  const clusterInEdit = useStore((state) => state.clusterInEdit)
   const auth = useStore((state) => state.auth)
   const authError = auth?.error
   const expiryTimestamp = auth?.parsed.expiresAt
@@ -79,6 +81,7 @@ const AppContent = () => {
           )}
           {clusters.length > 0 && <ClusterList clusters={clusters} />}
           {showClusterDetails && clusterDetails.cluster && <ClusterDetail />}
+          {clusterInEdit && <ClusterEdit />}
         </>
       ) : (
         <WelcomeView />

--- a/ui/cluster-admin/src/components/ClusterDetail.tsx
+++ b/ui/cluster-admin/src/components/ClusterDetail.tsx
@@ -5,6 +5,9 @@
 
 import {
   Container,
+  DataGridToolbar,
+  ButtonRow,
+  Button,
   DataGrid,
   DataGridCell,
   DataGridHeadCell,
@@ -26,6 +29,7 @@ const ClusterDetail: React.FC<any> = () => {
   const clusterDetails = useStore((state) => state.clusterDetails)
   const showClusterDetails = useStore((state) => state.showClusterDetails)
   const setShowClusterDetails = useStore((state) => state.setShowClusterDetails)
+  const setClusterInEdit = useStore((state) => state.setClusterInEdit)
 
   const clusterAge = useMemo(() => {
     if (clusterDetails.cluster?.metadata?.creationTimestamp) {
@@ -38,6 +42,11 @@ const ClusterDetail: React.FC<any> = () => {
 
   const onPanelClose = () => {
     setShowClusterDetails(false)
+  }
+
+  const openClusterEdit = () => {
+    setShowClusterDetails(false)
+    setClusterInEdit(clusterDetails.cluster!)
   }
 
   return (
@@ -54,47 +63,51 @@ const ClusterDetail: React.FC<any> = () => {
     >
       <PanelBody>
         <Container px={false} py>
-          <>
-            <DataGrid columns={2}>
+          <DataGridToolbar>
+            <ButtonRow>
+              <Button
+                icon="addCircle"
+                label="Edit Cluster"
+                onClick={() => openClusterEdit()}
+              />
+            </ButtonRow>
+          </DataGridToolbar>
+          <DataGrid columns={2}>
+            <DataGridRow>
+              <DataGridHeadCell>State</DataGridHeadCell>
+              <DataGridCell>{clusterDetails.clusterStatus?.state}</DataGridCell>
+            </DataGridRow>
+            <DataGridRow>
+              <DataGridHeadCell>Age</DataGridHeadCell>
+              <DataGridCell>{clusterAge}</DataGridCell>
+            </DataGridRow>
+            <DataGridRow>
+              <DataGridHeadCell>Kubernetes Version</DataGridHeadCell>
+              <DataGridCell>
+                {clusterDetails.cluster?.status?.kubernetesVersion ?? "unknown"}
+              </DataGridCell>
+            </DataGridRow>
+            <DataGridRow>
+              <DataGridHeadCell>Access Mode</DataGridHeadCell>
+              <DataGridCell>
+                {clusterDetails.cluster?.spec?.accessMode ?? "unknown"}
+              </DataGridCell>
+            </DataGridRow>
+            {clusterDetails.clusterStatus?.message && (
               <DataGridRow>
-                <DataGridHeadCell>State</DataGridHeadCell>
+                <DataGridHeadCell>Message</DataGridHeadCell>
                 <DataGridCell>
-                  {clusterDetails.clusterStatus?.state}
+                  {clusterDetails.clusterStatus?.message}
                 </DataGridCell>
               </DataGridRow>
+            )}
+            {clusterDetails.cluster?.metadata?.labels && (
               <DataGridRow>
-                <DataGridHeadCell>Age</DataGridHeadCell>
-                <DataGridCell>{clusterAge}</DataGridCell>
-              </DataGridRow>
-              <DataGridRow>
-                <DataGridHeadCell>Kubernetes Version</DataGridHeadCell>
+                <DataGridHeadCell>Labels</DataGridHeadCell>
                 <DataGridCell>
-                  {clusterDetails.cluster?.status?.kubernetesVersion ??
-                    "unknown"}
-                </DataGridCell>
-              </DataGridRow>
-              <DataGridRow>
-                <DataGridHeadCell>Access Mode</DataGridHeadCell>
-                <DataGridCell>
-                  {clusterDetails.cluster?.spec?.accessMode ?? "unknown"}
-                </DataGridCell>
-              </DataGridRow>
-              {clusterDetails.clusterStatus?.message && (
-                <DataGridRow>
-                  <DataGridHeadCell>Message</DataGridHeadCell>
-                  <DataGridCell>
-                    {clusterDetails.clusterStatus?.message}
-                  </DataGridCell>
-                </DataGridRow>
-              )}
-              {clusterDetails.cluster?.metadata?.labels && (
-                <DataGridRow>
-                  <DataGridHeadCell>Labels</DataGridHeadCell>
-                  <DataGridCell>
-                    <Stack gap="2" alignment="start" wrap={true}>
-                      {Object.keys(
-                        clusterDetails.cluster?.metadata?.labels!
-                      ).map((labelKey) => {
+                  <Stack gap="2" alignment="start" wrap={true}>
+                    {Object.keys(clusterDetails.cluster?.metadata?.labels!).map(
+                      (labelKey) => {
                         const labelValue =
                           clusterDetails.cluster?.metadata?.labels![labelKey]
                         return (
@@ -106,37 +119,37 @@ const ClusterDetail: React.FC<any> = () => {
                             pillValue={labelValue}
                           />
                         )
-                      })}
-                    </Stack>
-                  </DataGridCell>
-                </DataGridRow>
-              )}
-              {clusterDetails.cluster?.status?.statusConditions?.conditions && (
-                <DataGridRow>
-                  <DataGridHeadCell>Conditions</DataGridHeadCell>
-                  <DataGridCell>
-                    <ConditionList
-                      conditionArray={
-                        clusterDetails.cluster?.status?.statusConditions
-                          ?.conditions
                       }
-                    />
-                  </DataGridCell>
-                </DataGridRow>
-              )}
-              {clusterDetails.plugins && (
-                <ClusterPluginList plugins={clusterDetails.plugins} />
-              )}
-            </DataGrid>
+                    )}
+                  </Stack>
+                </DataGridCell>
+              </DataGridRow>
+            )}
+            {clusterDetails.cluster?.status?.statusConditions?.conditions && (
+              <DataGridRow>
+                <DataGridHeadCell>Conditions</DataGridHeadCell>
+                <DataGridCell>
+                  <ConditionList
+                    conditionArray={
+                      clusterDetails.cluster?.status?.statusConditions
+                        ?.conditions
+                    }
+                  />
+                </DataGridCell>
+              </DataGridRow>
+            )}
+            {clusterDetails.plugins && (
+              <ClusterPluginList plugins={clusterDetails.plugins} />
+            )}
+          </DataGrid>
 
-            {clusterDetails.cluster?.status?.nodes &&
-              Object.keys(clusterDetails.cluster?.status?.nodes).length > 0 && (
-                <Container px={false} py>
-                  <h2 className="text-xl font-bold mb-2 mt-8">Nodes</h2>
-                  <NodeList cluster={clusterDetails.cluster} />
-                </Container>
-              )}
-          </>
+          {clusterDetails.cluster?.status?.nodes &&
+            Object.keys(clusterDetails.cluster?.status?.nodes).length > 0 && (
+              <Container px={false} py>
+                <h2 className="text-xl font-bold mb-2 mt-8">Nodes</h2>
+                <NodeList cluster={clusterDetails.cluster} />
+              </Container>
+            )}
         </Container>
       </PanelBody>
     </Panel>

--- a/ui/cluster-admin/src/components/ClusterEdit.tsx
+++ b/ui/cluster-admin/src/components/ClusterEdit.tsx
@@ -1,0 +1,107 @@
+import cluster from "cluster"
+import useStore from "../store"
+
+import {
+  Container,
+  Panel,
+  PanelBody,
+  TextInput,
+  Form,
+  FormRow,
+  FormSection,
+  Stack,
+  Button,
+} from "juno-ui-components"
+import KeyValueInput from "./KeyValueInput"
+import ResultMessageComponent, { ResultMessage } from "./ResultMessage"
+import React from "react"
+import { useClusterApi } from "../hooks/useClusterApi"
+
+const ClusterEdit: React.FC<any> = () => {
+  const clusterInEdit = useStore((state) => state.clusterInEdit)
+  clusterInEdit?.spec
+  const setClusterInEdit = useStore((state) => state.setClusterInEdit)
+
+  const [submitMessage, setSubmitResultMessage] = React.useState<ResultMessage>(
+    { message: "", ok: false }
+  )
+
+  const { updateCluster } = useClusterApi()
+
+  const onPanelClose = () => {
+    setClusterInEdit(undefined)
+  }
+
+  const setLabels = (labels: { [key: string]: string }) => {
+    setClusterInEdit({
+      ...clusterInEdit,
+      metadata: {
+        ...clusterInEdit?.metadata,
+        labels: labels,
+      },
+    })
+  }
+
+  const onSubmit = async () => {
+    let clusterUpdatePromise = updateCluster(clusterInEdit!)
+    clusterUpdatePromise.then((response) => {
+      setSubmitResultMessage(response)
+    })
+  }
+
+  return (
+    <Panel
+      heading={clusterInEdit!.metadata?.name! || "Not found"}
+      opened={!!clusterInEdit}
+      onClose={onPanelClose}
+      size="large"
+    >
+      <PanelBody>
+        <Container px={false} py>
+          <Form>
+            <FormSection title="General">
+              <FormRow>
+                <TextInput
+                  id="metadata.name"
+                  label="Name"
+                  placeholder="Name of this Cluster"
+                  value={clusterInEdit!.metadata?.name}
+                  disabled={true}
+                />
+              </FormRow>
+              <FormRow>
+                <TextInput
+                  id="spec.accessmode"
+                  label="Accessmode"
+                  placeholder="Accessmode of this Cluster"
+                  value={clusterInEdit!.spec?.accessMode}
+                  disabled={true}
+                />
+              </FormRow>
+              <FormRow>
+                <KeyValueInput
+                  data={clusterInEdit!.metadata?.labels}
+                  setData={setLabels}
+                  title="Labels"
+                  dataName="Label"
+                ></KeyValueInput>
+              </FormRow>
+            </FormSection>
+            <FormSection>
+              <Stack distribution="end" gap="2">
+                {submitMessage.message != "" && (
+                  <ResultMessageComponent submitMessage={submitMessage} />
+                )}
+                <Button onClick={onSubmit} variant="primary">
+                  Update Cluster
+                </Button>
+              </Stack>
+            </FormSection>
+          </Form>
+        </Container>
+      </PanelBody>
+    </Panel>
+  )
+}
+
+export default ClusterEdit

--- a/ui/cluster-admin/src/components/ClusterEdit.tsx
+++ b/ui/cluster-admin/src/components/ClusterEdit.tsx
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import cluster from "cluster"
 import useStore from "../store"
 

--- a/ui/cluster-admin/src/components/KeyValueInput.tsx
+++ b/ui/cluster-admin/src/components/KeyValueInput.tsx
@@ -1,0 +1,118 @@
+/*
+ * SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from "react"
+import {
+  Button,
+  Stack,
+  TextInput,
+  FormSection,
+  InputGroup,
+  FormRow,
+} from "juno-ui-components"
+/*
+ * This Element provides a form section for entering and editing key-value pairs.
+ * The key-value data and the setData function are passed as props.
+ * A mutateValue function can be passed as a prop to modify the value before it is stored.
+ */
+
+export interface KeyValueInputProps {
+  data?: { [key: string]: string }
+  setData: (data: { [key: string]: string }) => void
+  mutateValue?: (value: string) => string
+  title?: string
+  dataName?: string
+  isSecret?: boolean
+}
+const KeyValueInput: React.FC<KeyValueInputProps> = (
+  props: KeyValueInputProps
+) => {
+  const dataName = props.dataName ? props.dataName : "Data"
+  const isSecret = props.isSecret ? props.isSecret : false
+  const handleDataEntryChange = (key, value: string) => {
+    // key is in format dataKey.key or dataValue.key
+    let keyInfo = key.split(".")
+    let keyIdentifier = keyInfo[0]
+    let keyData = keyInfo[1]
+
+    switch (keyIdentifier) {
+      case "dataKey":
+        // remove entry with old key and add new entry with new key
+        let data = { ...props.data }
+        let dataValue = data[keyData]
+        delete data[keyData]
+        data[value] = dataValue
+        props.setData(data)
+        break
+      case "dataValue":
+        if (props.mutateValue) {
+          value = props.mutateValue(value)
+        }
+        props.setData({
+          ...props.data,
+          [keyData]: value,
+        })
+        break
+      default:
+        console.log("keyIdentifier not found")
+        break
+    }
+  }
+
+  const deleteDataEntry = (key: string) => {
+    let data = { ...props.data }
+    delete data[key]
+    props.setData(data)
+  }
+
+  const addNewDataEntry = () => {
+    props.setData({
+      ...props.data,
+      "": "",
+    })
+  }
+
+  return (
+    <FormSection title={props.title}>
+      {props.data &&
+        Object.keys(props.data).length > 0 &&
+        Object.keys(props.data).map((dataKey) => (
+          <FormRow>
+            <InputGroup>
+              <TextInput
+                id={"dataKey." + dataKey}
+                label={`${dataName} Key`}
+                value={dataKey}
+                onBlur={(e) =>
+                  handleDataEntryChange("dataKey." + dataKey, e.target.value)
+                }
+              />
+
+              <TextInput
+                id={"dataValue" + dataKey}
+                type={isSecret ? "password" : "text"}
+                label={`${dataName} Value`}
+                value={props.data![dataKey]}
+                onBlur={(e) =>
+                  handleDataEntryChange("dataValue." + dataKey, e.target.value)
+                }
+              />
+              <Button
+                icon="deleteForever"
+                onClick={() => deleteDataEntry(dataKey)}
+              />
+            </InputGroup>
+          </FormRow>
+        ))}
+      <Button
+        icon="addCircle"
+        label={`Add ${dataName}`}
+        onClick={addNewDataEntry}
+      />
+    </FormSection>
+  )
+}
+
+export default KeyValueInput

--- a/ui/cluster-admin/src/components/ResultMessage.tsx
+++ b/ui/cluster-admin/src/components/ResultMessage.tsx
@@ -1,0 +1,35 @@
+/*
+ * SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Message } from "juno-ui-components"
+export type ResultMessage = {
+  message: string
+  ok: boolean
+  variant?: "warning" | "success" | "error"
+}
+
+interface ResultMessageProps {
+  submitMessage: ResultMessage
+  onMessageDismiss?: () => void
+}
+
+const ResultMessageComponent: React.FC<ResultMessageProps> = (
+  props: ResultMessageProps
+) => {
+  // if variant is not set, we deduct from ok
+  if (!props.submitMessage.variant)
+    props.submitMessage.variant = props.submitMessage.ok ? "success" : "error"
+  return (
+    <Message
+      autoDismissTimeout={3000}
+      autoDismiss={props.submitMessage.ok}
+      onDismiss={props.onMessageDismiss}
+      variant={props.submitMessage.variant}
+      text={props.submitMessage.message}
+    />
+  )
+}
+
+export default ResultMessageComponent

--- a/ui/cluster-admin/src/hooks/useApi.ts
+++ b/ui/cluster-admin/src/hooks/useApi.ts
@@ -1,0 +1,193 @@
+/*
+ * SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { useCallback } from "react"
+import { Secret, Cluster, Plugin } from "../../../types/types"
+import useClient from "./useClient"
+import useNamespace from "./useNamespace"
+
+export type AllowedApiObject = Plugin | Cluster | Secret
+
+export type ApiResponse = {
+  ok: boolean
+  message: string
+  response?: AllowedApiObject
+}
+
+export const useApi = (debug?: boolean) => {
+  const { namespace } = useNamespace()
+  const { client: client } = useClient()
+
+  const isDebug = debug ?? true
+
+  const get = useCallback(
+    async <T extends AllowedApiObject>(
+      url: string,
+      object: T
+    ): Promise<ApiResponse> => {
+      let response: T
+
+      if (!client || !namespace) {
+        return { ok: false, message: "Client or namespace not available" }
+      }
+
+      return await client
+        .get(url + "/" + object.metadata!.name!)
+        .then((res) => {
+          if (res.kind !== object.kind) {
+            isDebug &&
+              console.log(
+                `ERROR: Failed to get ${object.kind}, did not get ${
+                  object.kind
+                }: ${JSON.stringify(res)}`
+              )
+            return {
+              ok: false,
+              message: `Failed getting ${object.kind}`,
+              response: res as T,
+            }
+          }
+          return {
+            ok: true,
+            response: res as T,
+            message: `Successfully got ${object.kind}`,
+          }
+        })
+        .catch((error) => {
+          isDebug && console.log(`ERROR: Failed to get ${object.kind}`, error)
+          return {
+            ok: false,
+            message: `Failed getting ${object.kind}: ${error}`,
+          }
+        })
+    },
+    [client, namespace]
+  )
+
+  const create = useCallback(
+    async <T extends AllowedApiObject>(
+      url: string,
+      object: T
+    ): Promise<ApiResponse> => {
+      if (!client || !namespace) {
+        return { ok: false, message: "Client or namespace not available" }
+      }
+
+      return await client
+        .post(url, object)
+        .then((res) => {
+          if (res.kind !== object.kind) {
+            isDebug &&
+              console.log(
+                `ERROR: Failed to create ${object.kind}, did not get ${
+                  object.kind
+                }: ${JSON.stringify(res)}`
+              )
+            return { ok: false, message: `Failed creating ${object.kind}` }
+          }
+          return {
+            ok: true,
+            response: res as T,
+            message: `Successfully created ${object.kind}`,
+          }
+        })
+        .catch((error) => {
+          isDebug &&
+            console.log(`ERROR: Failed to create ${object.kind}`, error)
+          return {
+            ok: false,
+            message: `Failed creating ${object.kind}: ${error}`,
+          }
+        })
+    },
+    [client, namespace]
+  )
+
+  const update = useCallback(
+    async <T extends AllowedApiObject>(
+      url: string,
+      object: T
+    ): Promise<ApiResponse> => {
+      if (!client || !namespace) {
+        return { ok: false, message: "Client or namespace not available" }
+      }
+
+      return await client
+        .put(url + "/" + object.metadata!.name!, object)
+        .then((res) => {
+          if (res.kind !== object.kind) {
+            isDebug &&
+              console.log(
+                `ERROR: Failed to update ${object.kind}, did not get ${
+                  object.kind
+                }: ${JSON.stringify(res)}`
+              )
+            return { ok: false, message: `Failed updating ${object.kind}` }
+          }
+          return {
+            ok: true,
+            response: res as T,
+            message: `Successfully updated ${object.kind}`,
+          }
+        })
+        .catch((error) => {
+          isDebug &&
+            console.log(`ERROR: Failed to update ${object.kind}`, error)
+          return {
+            ok: false,
+            message: `Failed updating ${object.kind}: ${error}`,
+          }
+        })
+    },
+    [client, namespace]
+  )
+
+  const deleteObject = useCallback(
+    async <T extends AllowedApiObject>(
+      url: string,
+      object: T
+    ): Promise<ApiResponse> => {
+      if (!client || !namespace) {
+        return { ok: false, message: "Client or namespace not available" }
+      }
+
+      return await client
+        .delete(url + "/" + object.metadata!.name!)
+        .then((res) => {
+          if (
+            res.kind == object.kind ||
+            (res.kind == "Status" && res.status == "Success")
+          ) {
+            return { ok: true, message: `Successfully deleted ${object.kind}` }
+          }
+          isDebug &&
+            console.log(
+              `ERROR: Failed to delete ${object.kind} did not get ${
+                object.kind
+              }: ${JSON.stringify(res)}`
+            )
+          return { ok: false, message: `Failed deleting ${object.kind}` }
+        })
+        .catch((error) => {
+          isDebug &&
+            console.log(`ERROR: Failed to delete ${object.kind}`, error)
+          return {
+            ok: false,
+            message: `Failed deleting ${object.kind}: ${error}`,
+          }
+        })
+    },
+    [client, namespace]
+  )
+
+  return {
+    get: get,
+    create: create,
+    update: update,
+    deleteObject: deleteObject,
+  }
+}
+
+export default useApi

--- a/ui/cluster-admin/src/hooks/useClusterApi.ts
+++ b/ui/cluster-admin/src/hooks/useClusterApi.ts
@@ -1,0 +1,44 @@
+import { Cluster } from "../../../types/types"
+import useApi, { ApiResponse } from "./useApi"
+import useNamespace from "./useNamespace"
+
+export type ClusterApiResponse = {
+  ok: boolean
+  message: string
+  response?: Cluster
+}
+
+export const useClusterApi = () => {
+  const { get, create, update, deleteObject } = useApi()
+  const { namespace } = useNamespace()
+
+  const getCluster = (cluster: Cluster): Promise<ClusterApiResponse> => {
+    return get<Cluster>(
+      `/apis/greenhouse.sap/v1alpha1/namespaces/${namespace}/clusters`,
+      cluster
+    ) as Promise<ClusterApiResponse>
+  }
+
+  const createCluster = (cluster: Cluster): Promise<ClusterApiResponse> => {
+    return create<Cluster>(
+      `/apis/greenhouse.sap/v1alpha1/namespaces/${namespace}/clusters`,
+      cluster
+    ) as Promise<ClusterApiResponse>
+  }
+
+  const updateCluster = (cluster: Cluster): Promise<ClusterApiResponse> => {
+    return update<Cluster>(
+      `/apis/greenhouse.sap/v1alpha1/namespaces/${namespace}/clusters`,
+      cluster
+    ) as Promise<ClusterApiResponse>
+  }
+
+  const deleteCluster = (cluster: Cluster): Promise<ClusterApiResponse> => {
+    return deleteObject<Cluster>(
+      `/apis/greenhouse.sap/v1alpha1/namespaces/${namespace}/clusters`,
+      cluster
+    ) as Promise<ClusterApiResponse>
+  }
+
+  return { getCluster, createCluster, updateCluster, deleteCluster }
+}

--- a/ui/cluster-admin/src/hooks/useClusterApi.ts
+++ b/ui/cluster-admin/src/hooks/useClusterApi.ts
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { Cluster } from "../../../types/types"
 import useApi, { ApiResponse } from "./useApi"
 import useNamespace from "./useNamespace"

--- a/ui/cluster-admin/src/store.ts
+++ b/ui/cluster-admin/src/store.ts
@@ -41,6 +41,9 @@ export interface State {
   setShowOnBoardCluster: (showOnBoardCluster: boolean) => void
   showDownloadKubeConfig: boolean
   setShowDownloadKubeConfig: (showDownloadKubeConfig: boolean) => void
+
+  clusterInEdit?: Cluster
+  setClusterInEdit: (cluster?: Cluster) => void
 }
 
 // global zustand store. See how this works here: https://github.com/pmndrs/zustand
@@ -146,6 +149,9 @@ const useStore = create<State>((set) => ({
       showDownloadKubeConfig: showDownloadKubeConfig,
     }))
   },
+
+  clusterInEdit: undefined,
+  setClusterInEdit: (cluster) => set((state) => ({ clusterInEdit: cluster })),
 }))
 
 export default useStore


### PR DESCRIPTION
This adds an edit screen to the `Cluster` admin view.
As for now only with the possibility of changing labels.

Out of scope, as this involves interaction with `Secrets`

- Creating Clusters
- Deleting Clusters
- Changing `accessmode`