### PR TITLE
refac(teamrbac): introduce helpers for testing

### DIFF
--- a/pkg/controllers/teamrbac/suite_test.go
+++ b/pkg/controllers/teamrbac/suite_test.go
@@ -9,20 +9,15 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 
 	"github.com/cloudoperators/greenhouse/pkg/admission"
-	greenhouseapis "github.com/cloudoperators/greenhouse/pkg/apis"
-	greenhousev1alpha1 "github.com/cloudoperators/greenhouse/pkg/apis/greenhouse/v1alpha1"
 	"github.com/cloudoperators/greenhouse/pkg/test"
 	//+kubebuilder:scaffold:imports
 )
 
 const (
-	testTeamName     = "test-team"
 	testTeamIDPGroup = "test-idp-group"
 )
 
@@ -34,47 +29,6 @@ var (
 	remoteK8sClient  client.Client
 	remoteTestEnv    *envtest.Environment
 )
-
-var testCluster = &greenhousev1alpha1.Cluster{
-	TypeMeta: metav1.TypeMeta{
-		Kind:       "Cluster",
-		APIVersion: greenhousev1alpha1.GroupVersion.String(),
-	},
-	ObjectMeta: metav1.ObjectMeta{
-		Name:      "test-cluster",
-		Namespace: test.TestNamespace,
-	},
-	Spec: greenhousev1alpha1.ClusterSpec{
-		AccessMode: greenhousev1alpha1.ClusterAccessModeDirect,
-	},
-}
-
-var testClusterK8sSecret = &corev1.Secret{
-	TypeMeta: metav1.TypeMeta{
-		Kind:       "Secret",
-		APIVersion: corev1.GroupName,
-	},
-	ObjectMeta: metav1.ObjectMeta{
-		Name:      "test-cluster",
-		Namespace: test.TestNamespace,
-	},
-	Type: greenhouseapis.SecretTypeKubeConfig,
-}
-
-var testTeam = &greenhousev1alpha1.Team{
-	TypeMeta: metav1.TypeMeta{
-		Kind:       "Team",
-		APIVersion: greenhousev1alpha1.GroupVersion.String(),
-	},
-	ObjectMeta: metav1.ObjectMeta{
-		Name:      testTeamName,
-		Namespace: test.TestNamespace,
-	},
-	Spec: greenhousev1alpha1.TeamSpec{
-		Description:    "Test Team",
-		MappedIDPGroup: testTeamIDPGroup,
-	},
-}
 
 func TestRBACController(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/pkg/controllers/teamrbac/teamrolebinding_controller_test.go
+++ b/pkg/controllers/teamrbac/teamrolebinding_controller_test.go
@@ -10,9 +10,7 @@ import (
 	. "github.com/onsi/gomega"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	greenhouseapis "github.com/cloudoperators/greenhouse/pkg/apis"
@@ -20,109 +18,31 @@ import (
 	"github.com/cloudoperators/greenhouse/pkg/test"
 )
 
-var testRole = &greenhousev1alpha1.TeamRole{
-	TypeMeta: metav1.TypeMeta{
-		Kind:       "TeamRole",
-		APIVersion: greenhousev1alpha1.GroupVersion.String(),
-	},
-	ObjectMeta: metav1.ObjectMeta{
-		Name:      "test-teamrole",
-		Namespace: test.TestNamespace,
-	},
-	Spec: greenhousev1alpha1.TeamRoleSpec{
-		Rules: []rbacv1.PolicyRule{
-			{
-				APIGroups: []string{"*"},
-				Resources: []string{"*"},
-				Verbs:     []string{"*"},
-			},
-		},
-	},
-}
-
-var roleUT *greenhousev1alpha1.TeamRole
-
-var testRoleBinding = &greenhousev1alpha1.TeamRoleBinding{
-	TypeMeta: metav1.TypeMeta{
-		Kind:       "TeamRoleBinding",
-		APIVersion: greenhousev1alpha1.GroupVersion.String(),
-	},
-	ObjectMeta: metav1.ObjectMeta{
-		Name:      "test-teamrolebinding",
-		Namespace: test.TestNamespace,
-	},
-	Spec: greenhousev1alpha1.TeamRoleBindingSpec{
-		TeamRoleRef: "test-teamrole",
-		TeamRef:     testTeamName,
-		ClusterName: testCluster.Name,
-		Namespaces:  []string{test.TestNamespace},
-	},
-}
-
-var testClusterRoleBinding = &greenhousev1alpha1.TeamRoleBinding{
-	TypeMeta: metav1.TypeMeta{
-		Kind:       "TeamRoleBinding",
-		APIVersion: greenhousev1alpha1.GroupVersion.String(),
-	},
-	ObjectMeta: metav1.ObjectMeta{
-		Name:      "test-clusterrolebinding",
-		Namespace: test.TestNamespace,
-	},
-	Spec: greenhousev1alpha1.TeamRoleBindingSpec{
-		TeamRoleRef: "test-teamrole",
-		TeamRef:     testTeamName,
-		ClusterName: testCluster.Name,
-	},
-}
+var (
+	setup      *test.TestSetup
+	clusterUT  *greenhousev1alpha1.Cluster
+	teamUT     *greenhousev1alpha1.Team
+	teamRoleUT *greenhousev1alpha1.TeamRole
+)
 
 var _ = Describe("Validate ClusterRole & RoleBinding on Remote Cluster", Ordered, func() {
-	BeforeAll(func() {
-		By("creating a cluster")
-		Expect(test.K8sClient.Create(test.Ctx, testCluster)).Should(Succeed(), "there should be no error creating the cluster resource")
-
-		// kubeConfigController ensures the namespace within the remote cluster -- we have to create it
-		By("creating the namespace on the cluster")
-		err := remoteK8sClient.Create(test.Ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: test.TestNamespace}})
-		Expect(err).ShouldNot(HaveOccurred(), "there should be no error creating the namespace")
-
-		By("creating a secret with a valid kubeconfig for a remote cluster")
-		testClusterK8sSecret.Data = map[string][]byte{
-			greenhouseapis.KubeConfigKey: remoteKubeConfig,
-		}
-		Expect(test.K8sClient.Create(test.Ctx, testClusterK8sSecret)).Should(Succeed())
-
-		By("creating a team")
-		Expect(test.K8sClient.Create(test.Ctx, testTeam)).Should(Succeed())
-	})
-
 	BeforeEach(func() {
-		// create updates the object with the latest version. deepcopy to avoid failures due to existing resource version
-		roleUT = testRole.DeepCopy()
-		// create Role on the central cluster"
-		err := k8sClient.Create(test.Ctx, roleUT)
-		Expect(err).NotTo(HaveOccurred())
+		setup = test.NewTestSetup(test.Ctx, test.K8sClient, "teamrbac")
+		clusterUT = setup.OnboardCluster(test.Ctx, "test-cluster", remoteKubeConfig)
+
+		teamUT = setup.CreateTeam(test.Ctx, "test-team", test.WithMappedIDPGroup(testTeamIDPGroup))
+
+		By("creating a TeamRole on the central cluster")
+		teamRoleUT = setup.CreateTeamRole(test.Ctx, "test-role")
 	})
 
-	// Delete all TeamRoleBindings and TeamRoles after each test, ensure that Remote Cluster is cleaned up
-	// This ensures the deletion of the Remote Resources is working correctly.
 	AfterEach(func() {
-		// get and delete all TeamRoleBindings on the central cluster
-		rbList := &greenhousev1alpha1.TeamRoleBindingList{}
-		err := k8sClient.List(test.Ctx, rbList)
-		Expect(err).NotTo(HaveOccurred())
-		for _, rb := range rbList.Items {
-			rb := rb
-			err := k8sClient.Delete(test.Ctx, &rb)
-			Expect(err).NotTo(HaveOccurred())
-		}
-		Eventually(func() bool {
-			err := k8sClient.List(test.Ctx, rbList)
-			if err != nil || len(rbList.Items) > 0 {
-				return false
-			}
-			return true
-		}).Should(BeTrue(), "there should be no TeamRoleBindings left to list on the central cluster")
+		test.EventuallyDeleted(test.Ctx, test.K8sClient, teamRoleUT)
+	})
 
+	// After all tests are run ensure there are no resources left behind on the remote cluster
+	// This ensures the deletion of the Remote Resources is working correctly.
+	AfterAll(func() {
 		// check that all ClusterRoleBindings are eventually deleted on the remote cluster
 		remoteCRBList := &rbacv1.ClusterRoleBindingList{}
 		listOpts := []client.ListOption{
@@ -146,23 +66,6 @@ var _ = Describe("Validate ClusterRole & RoleBinding on Remote Cluster", Ordered
 			return true
 		}).Should(BeTrue(), "there should be no RoleBindings left to list on the remote cluster")
 
-		// get and delete all TeamRoles on the central cluster
-		rList := &greenhousev1alpha1.TeamRoleList{}
-		err = k8sClient.List(test.Ctx, rList)
-		Expect(err).NotTo(HaveOccurred())
-		for _, r := range rList.Items {
-			r := r
-			err := k8sClient.Delete(test.Ctx, &r)
-			Expect(err).NotTo(HaveOccurred())
-		}
-		Eventually(func() bool {
-			err := k8sClient.List(test.Ctx, rList)
-			if err != nil || len(rList.Items) > 0 {
-				return false
-			}
-			return true
-		}).Should(BeTrue(), "there should be no TeamRoles left to list on the central cluster")
-
 		// check that all ClusterRoles are eventually deleted on the remote cluster
 		remoteList := &rbacv1.ClusterRoleList{}
 		listOpts = []client.ListOption{
@@ -180,279 +83,288 @@ var _ = Describe("Validate ClusterRole & RoleBinding on Remote Cluster", Ordered
 	Context("When creating a Greenhouse TeamRoleBinding with namespaces on the central cluster", func() {
 		It("Should create a ClusterRole and RoleBinding on the remote cluster", func() {
 			By("creating a TeamRoleBinding on the central cluster")
-			err := k8sClient.Create(test.Ctx, testRoleBinding.DeepCopy())
-			Expect(err).NotTo(HaveOccurred())
+			trb := setup.CreateTeamRoleBinding(test.Ctx, "test-rolebinding",
+				test.WithTeamRoleRef(teamRoleUT.Name),
+				test.WithTeamRef(teamUT.Name),
+				test.WithClusterName(clusterUT.Name),
+				test.WithNamespaces(setup.Namespace()))
 
 			By("validating the RoleBinding created on the remote cluster")
 			remoteRoleBinding := &rbacv1.RoleBinding{}
 			remoteRoleBindingName := types.NamespacedName{
-				Name:      testRoleBinding.GetRBACName(),
-				Namespace: testRoleBinding.Namespace,
+				Name:      trb.GetRBACName(),
+				Namespace: trb.Namespace,
 			}
-			Eventually(func() bool {
-				err = remoteK8sClient.Get(context.TODO(), remoteRoleBindingName, remoteRoleBinding)
-				if err != nil {
-					return false
-				}
+			Eventually(func(g Gomega) bool {
+				g.Expect(remoteK8sClient.Get(context.TODO(), remoteRoleBindingName, remoteRoleBinding)).To(Succeed(), "there should be no error getting the RoleBinding from the Remote Cluster")
 				return !remoteRoleBinding.CreationTimestamp.IsZero()
 			}).Should(BeTrue(), "there should be no error getting the RoleBinding")
 			Expect(remoteRoleBinding.RoleRef.Name).To(HavePrefix(greenhouseapis.RBACPrefix))
-			Expect(remoteRoleBinding.RoleRef.Name).To(ContainSubstring(testRole.Name))
+			Expect(remoteRoleBinding.RoleRef.Name).To(ContainSubstring(teamRoleUT.Name))
 
 			By("validating the ClusterRole created on the remote cluster")
 			remoteClusterRole := &rbacv1.ClusterRole{}
 			remoteClusterRoleName := types.NamespacedName{
-				Name: testRole.GetRBACName(),
+				Name: teamRoleUT.GetRBACName(),
 			}
-			Eventually(func() bool {
-				err = remoteK8sClient.Get(test.Ctx, remoteClusterRoleName, remoteClusterRole)
-				if err != nil {
-					return false
-				}
+			Eventually(func(g Gomega) bool {
+				g.Expect(remoteK8sClient.Get(test.Ctx, remoteClusterRoleName, remoteClusterRole)).To(Succeed(), "there should be no error getting the ClusterRole from the Remote Cluster")
 				return !remoteClusterRole.CreationTimestamp.IsZero()
 			}).Should(BeTrue(), "there should be no error getting the ClusterRole")
 			Expect(remoteClusterRole.Name).To(HavePrefix(greenhouseapis.RBACPrefix))
-			Expect(remoteClusterRole.Name).To(ContainSubstring(testRole.Name))
-			Expect(remoteClusterRole.Rules).To(Equal(testRole.Spec.Rules))
+			Expect(remoteClusterRole.Name).To(ContainSubstring(teamRoleUT.Name))
+			Expect(remoteClusterRole.Rules).To(Equal(teamRoleUT.Spec.Rules))
+
+			By("cleaning up the test")
+			test.EventuallyDeleted(test.Ctx, test.K8sClient, trb)
 		})
 	})
 
 	Context("When creating a Greenhouse TeamRoleBinding without namespaces on the central cluster", func() {
 		It("Should create a ClusterRole and ClusterRoleBinding on the remote cluster", func() {
 			By("creating a TeamRoleBinding without Namespaces on the central cluster")
-			err := k8sClient.Create(test.Ctx, testClusterRoleBinding.DeepCopy())
-			Expect(err).NotTo(HaveOccurred())
+			trb := setup.CreateTeamRoleBinding(test.Ctx, "test-teamrolebinding",
+				test.WithTeamRoleRef(teamRoleUT.Name),
+				test.WithTeamRef(teamUT.Name),
+				test.WithClusterName(clusterUT.Name))
 
 			By("validating the ClusterRoleBinding created on the remote cluster")
 			remoteClusterRoleBinding := &rbacv1.ClusterRoleBinding{}
 			remoteRoleBindingName := types.NamespacedName{
-				Name:      greenhouseapis.RBACPrefix + testClusterRoleBinding.Name,
-				Namespace: testClusterRoleBinding.Namespace,
+				Name:      greenhouseapis.RBACPrefix + trb.Name,
+				Namespace: trb.Namespace,
 			}
-			Eventually(func() bool {
-				err = remoteK8sClient.Get(context.TODO(), remoteRoleBindingName, remoteClusterRoleBinding)
-				if err != nil {
-					return false
-				}
+			Eventually(func(g Gomega) bool {
+				g.Expect(remoteK8sClient.Get(context.TODO(), remoteRoleBindingName, remoteClusterRoleBinding)).To(Succeed(), "there should be no error getting the ClusterRoleBinding from the Remote Cluster")
 				return !remoteClusterRoleBinding.CreationTimestamp.IsZero()
 			}).Should(BeTrue(), "there should be no error getting the ClusterRoleBinding")
 			Expect(remoteClusterRoleBinding.RoleRef.Name).To(HavePrefix(greenhouseapis.RBACPrefix))
-			Expect(remoteClusterRoleBinding.RoleRef.Name).To(ContainSubstring(testRole.Name))
+			Expect(remoteClusterRoleBinding.RoleRef.Name).To(ContainSubstring(teamRoleUT.Name))
 
 			By("validating the ClusterRole created on the remote cluster")
 			remoteClusterRole := &rbacv1.ClusterRole{}
 			remoteClusterRoleName := types.NamespacedName{
-				Name: testRole.GetRBACName(),
+				Name: teamRoleUT.GetRBACName(),
 			}
-			Eventually(func() bool {
-				err = remoteK8sClient.Get(test.Ctx, remoteClusterRoleName, remoteClusterRole)
-				if err != nil {
-					return false
-				}
+			Eventually(func(g Gomega) bool {
+				g.Expect(remoteK8sClient.Get(test.Ctx, remoteClusterRoleName, remoteClusterRole)).To(Succeed(), "there should be no error getting the ClusterRole from the Remote Cluster")
 				return !remoteClusterRole.CreationTimestamp.IsZero()
 			}).Should(BeTrue(), "there should be no error getting the ClusterRole")
 			Expect(remoteClusterRole.Name).To(HavePrefix(greenhouseapis.RBACPrefix))
-			Expect(remoteClusterRole.Name).To(ContainSubstring(testRole.Name))
-			Expect(remoteClusterRole.Rules).To(Equal(testRole.Spec.Rules))
+			Expect(remoteClusterRole.Name).To(ContainSubstring(teamRoleUT.Name))
+			Expect(remoteClusterRole.Rules).To(Equal(teamRoleUT.Spec.Rules))
+
+			By("cleaning up the test")
+			test.EventuallyDeleted(test.Ctx, test.K8sClient, trb)
 		})
 	})
 
 	Context("When creating a Greenhouse TeamRoleBinding with and without namespaces on the central cluster", func() {
 		It("Should create a ClusterRole, ClusterRoleBinding and TeamRoleBinding on the remote cluster", func() {
 			By("creating a TeamRoleBinding without Namespaces on the central cluster")
-			err := k8sClient.Create(test.Ctx, testClusterRoleBinding.DeepCopy())
-			Expect(err).NotTo(HaveOccurred())
+			trb := setup.CreateTeamRoleBinding(test.Ctx, "test-teamrolebinding",
+				test.WithTeamRoleRef(teamRoleUT.Name),
+				test.WithTeamRef(teamUT.Name),
+				test.WithClusterName(clusterUT.Name))
 
 			By("validating the ClusterRoleBinding created on the remote cluster")
 			remoteClusterRoleBinding := &rbacv1.ClusterRoleBinding{}
 			remoteClusterRoleBindingName := types.NamespacedName{
-				Name:      greenhouseapis.RBACPrefix + testClusterRoleBinding.Name,
-				Namespace: testClusterRoleBinding.Namespace,
+				Name:      greenhouseapis.RBACPrefix + trb.Name,
+				Namespace: trb.Namespace,
 			}
-			Eventually(func() bool {
-				err = remoteK8sClient.Get(context.TODO(), remoteClusterRoleBindingName, remoteClusterRoleBinding)
-				if err != nil {
-					return false
-				}
+			Eventually(func(g Gomega) bool {
+				g.Expect(remoteK8sClient.Get(context.TODO(), remoteClusterRoleBindingName, remoteClusterRoleBinding)).To(Succeed(), "there should be no error getting the ClusterRoleBinding from the Remote Cluster")
 				return !remoteClusterRoleBinding.CreationTimestamp.IsZero()
 			}).Should(BeTrue(), "there should be no error getting the ClusterRoleBinding")
 			Expect(remoteClusterRoleBinding.RoleRef.Name).To(HavePrefix(greenhouseapis.RBACPrefix))
-			Expect(remoteClusterRoleBinding.RoleRef.Name).To(ContainSubstring(testRole.Name))
+			Expect(remoteClusterRoleBinding.RoleRef.Name).To(ContainSubstring(teamRoleUT.Name))
 
 			By("validating the ClusterRole created on the remote cluster")
 			remoteClusterRole := &rbacv1.ClusterRole{}
 			remoteClusterRoleName := types.NamespacedName{
-				Name: testRole.GetRBACName(),
+				Name: teamRoleUT.GetRBACName(),
 			}
-			Eventually(func() bool {
-				err = remoteK8sClient.Get(test.Ctx, remoteClusterRoleName, remoteClusterRole)
-				if err != nil {
-					return false
-				}
+			Eventually(func(g Gomega) bool {
+				g.Expect(remoteK8sClient.Get(test.Ctx, remoteClusterRoleName, remoteClusterRole)).To(Succeed(), "there should be no error getting the ClusterRole from the Remote Cluster")
 				return !remoteClusterRole.CreationTimestamp.IsZero()
 			}).Should(BeTrue(), "there should be no error getting the ClusterRole")
 			Expect(remoteClusterRole.Name).To(HavePrefix(greenhouseapis.RBACPrefix))
-			Expect(remoteClusterRole.Name).To(ContainSubstring(testRole.Name))
-			Expect(remoteClusterRole.Rules).To(Equal(testRole.Spec.Rules))
+			Expect(remoteClusterRole.Name).To(ContainSubstring(teamRoleUT.Name))
+			Expect(remoteClusterRole.Rules).To(Equal(teamRoleUT.Spec.Rules))
 
 			By("creating a TeamRoleBinding on the central cluster")
-			err = k8sClient.Create(test.Ctx, testRoleBinding.DeepCopy())
-			Expect(err).NotTo(HaveOccurred())
+			trbNoNamespaces := setup.CreateTeamRoleBinding(test.Ctx, "teamrolebinding",
+				test.WithTeamRoleRef(teamRoleUT.Name),
+				test.WithTeamRef(teamUT.Name),
+				test.WithClusterName(clusterUT.Name),
+				test.WithNamespaces(setup.Namespace()))
 
 			By("validating the RoleBinding created on the remote cluster")
 			remoteRoleBinding := &rbacv1.RoleBinding{}
 			remoteRoleBindingName := types.NamespacedName{
-				Name:      testRoleBinding.GetRBACName(),
-				Namespace: testRoleBinding.Namespace,
+				Name:      trbNoNamespaces.GetRBACName(),
+				Namespace: trbNoNamespaces.Namespace,
 			}
-			Eventually(func() bool {
-				err = remoteK8sClient.Get(context.TODO(), remoteRoleBindingName, remoteRoleBinding)
-				if err != nil {
-					return false
-				}
+			Eventually(func(g Gomega) bool {
+				g.Expect(remoteK8sClient.Get(context.TODO(), remoteRoleBindingName, remoteRoleBinding)).To(Succeed(), "there should be no error getting the RoleBinding from the Remote Cluster")
 				return !remoteRoleBinding.CreationTimestamp.IsZero()
 			}).Should(BeTrue(), "there should be no error getting the RoleBinding")
 			Expect(remoteRoleBinding.RoleRef.Name).To(HavePrefix(greenhouseapis.RBACPrefix))
-			Expect(remoteRoleBinding.RoleRef.Name).To(ContainSubstring(testRole.Name))
+			Expect(remoteRoleBinding.RoleRef.Name).To(ContainSubstring(teamRoleUT.Name))
+
+			By("cleaning up the test")
+			test.EventuallyDeleted(test.Ctx, test.K8sClient, trb)
+			test.EventuallyDeleted(test.Ctx, test.K8sClient, trbNoNamespaces)
 		})
 	})
 
 	Context("When updating Greenhouse TeamRole & TeamRoleBinding w/wo Namespaces on the central cluster", func() {
-		It("Should reconcile the ClusterRole, ClusterRoleBinding and RoleBinding on the remote cluster", func() {
-			clusterRoleBindingUT := testClusterRoleBinding.DeepCopy()
+		It("Should reconcile the ClusterRole, ClusterRoleBinding for a TeamRoleBinding without Namespaces on the remote cluster", func() {
 			By("creating a TeamRoleBinding without Namespaces on the central cluster")
-			err := k8sClient.Create(test.Ctx, clusterRoleBindingUT)
-			Expect(err).NotTo(HaveOccurred())
+			trb := setup.CreateTeamRoleBinding(test.Ctx, "test-teamrolebinding",
+				test.WithTeamRoleRef(teamRoleUT.Name),
+				test.WithTeamRef(teamUT.Name),
+				test.WithClusterName(clusterUT.Name))
 
 			By("validating the ClusterRoleBinding created on the remote cluster")
 			remoteClusterRoleBinding := &rbacv1.ClusterRoleBinding{}
 			remoteClusterRoleBindingName := types.NamespacedName{
-				Name:      greenhouseapis.RBACPrefix + testClusterRoleBinding.Name,
-				Namespace: testClusterRoleBinding.Namespace,
+				Name:      trb.GetRBACName(),
+				Namespace: trb.Namespace,
 			}
-			Eventually(func() bool {
-				err = remoteK8sClient.Get(context.TODO(), remoteClusterRoleBindingName, remoteClusterRoleBinding)
-				if err != nil {
-					return false
-				}
+			Eventually(func(g Gomega) bool {
+				g.Expect(remoteK8sClient.Get(context.TODO(), remoteClusterRoleBindingName, remoteClusterRoleBinding)).To(Succeed(), "there should be no error getting the ClusterRoleBinding from the Remote Cluster")
 				return !remoteClusterRoleBinding.CreationTimestamp.IsZero()
 			}).Should(BeTrue(), "there should be no error getting the ClusterRoleBinding")
 			Expect(remoteClusterRoleBinding.RoleRef.Name).To(HavePrefix(greenhouseapis.RBACPrefix))
-			Expect(remoteClusterRoleBinding.RoleRef.Name).To(ContainSubstring(testRole.Name))
+			Expect(remoteClusterRoleBinding.RoleRef.Name).To(ContainSubstring(teamRoleUT.Name))
 
 			By("validating the ClusterRole created on the remote cluster")
 			remoteClusterRole := &rbacv1.ClusterRole{}
 			remoteClusterRoleName := types.NamespacedName{
-				Name: testRole.GetRBACName(),
+				Name: teamRoleUT.GetRBACName(),
 			}
-			Eventually(func() bool {
-				err = remoteK8sClient.Get(test.Ctx, remoteClusterRoleName, remoteClusterRole)
-				if err != nil {
-					return false
-				}
+			Eventually(func(g Gomega) bool {
+				g.Expect(remoteK8sClient.Get(test.Ctx, remoteClusterRoleName, remoteClusterRole)).To(Succeed(), "there should be no error getting the ClusterRole from the Remote Cluster")
 				return !remoteClusterRole.CreationTimestamp.IsZero()
 			}).Should(BeTrue(), "there should be no error getting the ClusterRole")
 			Expect(remoteClusterRole.Name).To(HavePrefix(greenhouseapis.RBACPrefix))
-			Expect(remoteClusterRole.Name).To(ContainSubstring(testRole.Name))
-			Expect(remoteClusterRole.Rules).To(Equal(testRole.Spec.Rules))
+			Expect(remoteClusterRole.Name).To(ContainSubstring(teamRoleUT.Name))
+			Expect(remoteClusterRole.Rules).To(Equal(teamRoleUT.Spec.Rules))
 
-			By("creating a TeamRoleBinding on the central cluster")
-			roleBindingUT := testRoleBinding.DeepCopy()
-			err = k8sClient.Create(test.Ctx, roleBindingUT)
-			Expect(err).NotTo(HaveOccurred())
+			By("updating the Greenhouse TeamRole on the central cluster")
+			teamRoleUT.Spec.Rules[0].Verbs = []string{"get"}
+			Expect(k8sClient.Update(test.Ctx, teamRoleUT)).To(Succeed(), "there should be no error updating the TeamRole on the central cluster")
+			Eventually(func(g Gomega) bool {
+				g.Expect(remoteK8sClient.Get(test.Ctx, remoteClusterRoleName, remoteClusterRole)).To(Succeed(), "there should be no error getting the ClusterRole from the remote cluster")
+				return g.Expect(remoteClusterRole.Rules).To(Equal(teamRoleUT.Spec.Rules))
+			}).Should(BeTrue(), "there should be no error getting the ClusterRole from the remote cluster")
 
-			By("validating the TeamRoleBinding created on the remote cluster")
+			By("cleaning up the test")
+			test.EventuallyDeleted(test.Ctx, test.K8sClient, trb)
+		})
+		It("Should reconcile the ClusterRole, RoleBindings for a TeamRoleBinding with Namespaces on the remote cluster", func() {
+			By("creating a TeamRoleBinding with Namespaces on the central cluster")
+			trb := setup.CreateTeamRoleBinding(test.Ctx, "test-teamrolebinding",
+				test.WithTeamRoleRef(teamRoleUT.Name),
+				test.WithTeamRef(teamUT.Name),
+				test.WithClusterName(clusterUT.Name),
+				test.WithNamespaces(setup.Namespace()))
+
+			By("validating the ClusterRole created on the remote cluster")
+			remoteClusterRole := &rbacv1.ClusterRole{}
+			remoteClusterRoleName := types.NamespacedName{
+				Name: teamRoleUT.GetRBACName(),
+			}
+			Eventually(func(g Gomega) bool {
+				g.Expect(remoteK8sClient.Get(test.Ctx, remoteClusterRoleName, remoteClusterRole)).To(Succeed(), "there should be no error getting the ClusterRole from the Remote Cluster")
+				return !remoteClusterRole.CreationTimestamp.IsZero()
+			}).Should(BeTrue(), "there should be no error getting the ClusterRole")
+			Expect(remoteClusterRole.Name).To(HavePrefix(greenhouseapis.RBACPrefix))
+			Expect(remoteClusterRole.Name).To(ContainSubstring(teamRoleUT.Name))
+			Expect(remoteClusterRole.Rules).To(Equal(teamRoleUT.Spec.Rules))
+
+			By("validating the RoleBindings are created on the remote cluster")
 			remoteRoleBinding := &rbacv1.RoleBinding{}
 			remoteRoleBindingName := types.NamespacedName{
-				Name:      testRoleBinding.GetRBACName(),
-				Namespace: testRoleBinding.Namespace,
+				Name:      trb.GetRBACName(),
+				Namespace: trb.Namespace,
 			}
-			Eventually(func() bool {
-				err = remoteK8sClient.Get(context.TODO(), remoteRoleBindingName, remoteRoleBinding)
-				if err != nil {
-					return false
-				}
+			Eventually(func(g Gomega) bool {
+				g.Expect(remoteK8sClient.Get(context.TODO(), remoteRoleBindingName, remoteRoleBinding)).To(Succeed(), "there should be no error getting the RoleBinding from the Remote Cluster")
 				return !remoteRoleBinding.CreationTimestamp.IsZero()
 			}).Should(BeTrue(), "there should be no error getting the TeamRoleBinding")
 			Expect(remoteRoleBinding.RoleRef.Name).To(HavePrefix(greenhouseapis.RBACPrefix))
-			Expect(remoteRoleBinding.RoleRef.Name).To(ContainSubstring(testRole.Name))
+			Expect(remoteRoleBinding.RoleRef.Name).To(ContainSubstring(teamRoleUT.Name))
 
 			By("updating the Greenhouse TeamRole on the central cluster")
-			roleUT.Spec.Rules[0].Verbs = []string{"get"}
-			err = k8sClient.Update(test.Ctx, roleUT)
+			teamRoleUT.Spec.Rules[0].Verbs = []string{"get"}
+			err := k8sClient.Update(test.Ctx, teamRoleUT)
 			Expect(err).NotTo(HaveOccurred())
 			Eventually(func(g Gomega) bool {
-				err = remoteK8sClient.Get(test.Ctx, remoteClusterRoleName, remoteClusterRole)
-				if err != nil {
-					return false
-				}
-				return g.Expect(remoteClusterRole.Rules).To(Equal(roleUT.Spec.Rules))
+				g.Expect(remoteK8sClient.Get(test.Ctx, remoteClusterRoleName, remoteClusterRole)).To(Succeed(), "there should be no error getting the ClusterRole from the remote cluster")
+				return g.Expect(remoteClusterRole.Rules).To(Equal(teamRoleUT.Spec.Rules))
 			}).Should(BeTrue(), "there should be no error getting the ClusterRole from the remote cluster")
+
+			By("cleaning up the test")
+			test.EventuallyDeleted(test.Ctx, test.K8sClient, trb)
 		})
 	})
 	Context("When tampering with a RoleBinding on the Remote Cluster", func() {
 		It("should reconcile the remote RoleBinding", func() {
 			By("creating a TeamRoleBinding without Namespaces on the central cluster")
-			roleBindingUT := testClusterRoleBinding.DeepCopy()
-			err := k8sClient.Create(test.Ctx, roleBindingUT)
-			Expect(err).NotTo(HaveOccurred())
+			trb := setup.CreateTeamRoleBinding(test.Ctx, "test-teamrolebinding",
+				test.WithTeamRoleRef(teamRoleUT.Name),
+				test.WithTeamRef(teamUT.Name),
+				test.WithClusterName(clusterUT.Name))
 
 			By("validating the ClusterRoleBinding created on the remote cluster")
 			remoteClusterRoleBinding := &rbacv1.ClusterRoleBinding{}
 			remoteClusterRoleBindingName := types.NamespacedName{
-				Name:      greenhouseapis.RBACPrefix + roleBindingUT.Name,
-				Namespace: roleBindingUT.Namespace,
+				Name:      greenhouseapis.RBACPrefix + trb.Name,
+				Namespace: trb.Namespace,
 			}
-			Eventually(func() bool {
-				err = remoteK8sClient.Get(context.TODO(), remoteClusterRoleBindingName, remoteClusterRoleBinding)
-				if err != nil {
-					return false
-				}
+			Eventually(func(g Gomega) bool {
+				g.Expect(remoteK8sClient.Get(context.TODO(), remoteClusterRoleBindingName, remoteClusterRoleBinding)).To(Succeed(), "there should be no error getting the ClusterRoleBinding from the Remote Cluster")
 				return !remoteClusterRoleBinding.CreationTimestamp.IsZero()
 			}).Should(BeTrue(), "there should be no error getting the ClusterRoleBinding")
 			Expect(remoteClusterRoleBinding.RoleRef.Name).To(HavePrefix(greenhouseapis.RBACPrefix))
-			Expect(remoteClusterRoleBinding.RoleRef.Name).To(ContainSubstring(testRole.Name))
+			Expect(remoteClusterRoleBinding.RoleRef.Name).To(ContainSubstring(teamRoleUT.Name))
 
 			By("validating the ClusterRole created on the remote cluster")
 			remoteClusterRole := &rbacv1.ClusterRole{}
 			remoteClusterRoleName := types.NamespacedName{
-				Name: testRole.GetRBACName(),
+				Name: teamRoleUT.GetRBACName(),
 			}
 			Eventually(func(g Gomega) bool {
-				err = remoteK8sClient.Get(test.Ctx, remoteClusterRoleName, remoteClusterRole)
-				if err != nil {
-					return false
-				}
-				return g.Expect(remoteClusterRole.Rules).To(Equal(testRole.Spec.Rules)) &&
+				g.Expect(remoteK8sClient.Get(test.Ctx, remoteClusterRoleName, remoteClusterRole)).To(Succeed(), "there should be no error getting the ClusterRole from the Remote Cluster")
+				return g.Expect(remoteClusterRole.Rules).To(Equal(teamRoleUT.Spec.Rules)) &&
 					!remoteClusterRole.CreationTimestamp.IsZero()
 			}).Should(BeTrue(), "there should be no error getting the ClusterRole")
 			Expect(remoteClusterRole.Name).To(HavePrefix(greenhouseapis.RBACPrefix))
-			Expect(remoteClusterRole.Name).To(ContainSubstring(testRole.Name))
-			Expect(remoteClusterRole.Rules).To(Equal(testRole.Spec.Rules))
+			Expect(remoteClusterRole.Name).To(ContainSubstring(teamRoleUT.Name))
+			Expect(remoteClusterRole.Rules).To(Equal(teamRoleUT.Spec.Rules))
 
 			By("altering the RoleBinding on the remote cluster")
-			err = remoteK8sClient.Get(test.Ctx, remoteClusterRoleBindingName, remoteClusterRoleBinding)
-			Expect(err).NotTo(HaveOccurred(), "there should be no error getting the ClusterRoleBinding from the remote cluster")
+			Expect(remoteK8sClient.Get(test.Ctx, remoteClusterRoleBindingName, remoteClusterRoleBinding)).To(Succeed(), "there should be no error getting the ClusterRoleBinding from the remote cluster")
 			expected := remoteClusterRoleBinding.DeepCopy().Subjects
 			remoteClusterRoleBinding.Subjects = append(remoteClusterRoleBinding.Subjects, rbacv1.Subject{Kind: "User", Name: "foobar", APIGroup: "rbac.authorization.k8s.io"})
-			err = remoteK8sClient.Update(test.Ctx, remoteClusterRoleBinding)
-			Expect(err).NotTo(HaveOccurred(), "there should be no error updating the ClusterRoleBinding on the remote cluster")
+			Expect(remoteK8sClient.Update(test.Ctx, remoteClusterRoleBinding)).To(Succeed(), "there should be no error updating the ClusterRoleBinding on the remote cluster")
 
 			By("triggering the reconcile of the central cluster TeamRoleBinding with a noop update")
-			err = k8sClient.Get(test.Ctx, types.NamespacedName{Name: roleBindingUT.Name, Namespace: roleBindingUT.Namespace}, roleBindingUT)
-			Expect(err).NotTo(HaveOccurred(), "there should be no error getting the TeamRoleBinding from the central cluster")
+			Expect(k8sClient.Get(test.Ctx, types.NamespacedName{Name: trb.Name, Namespace: trb.Namespace}, trb)).To(Succeed(), "there should be no error getting the TeamRoleBinding from the central cluster")
 			// changing the labels to trigger the reconciliation in this test.
-			roleBindingUT.SetLabels(map[string]string{"foo": "bar"})
-			err = k8sClient.Update(test.Ctx, roleBindingUT)
-			Expect(err).NotTo(HaveOccurred(), "there should be no error updating the TeamRoleBinding on the central cluster")
+			trb.SetLabels(map[string]string{"foo": "bar"})
+			Expect(k8sClient.Update(test.Ctx, trb)).To(Succeed(), "there should be no error updating the TeamRoleBinding on the central cluster")
 
 			Eventually(func(g Gomega) bool {
-				err = remoteK8sClient.Get(test.Ctx, remoteClusterRoleBindingName, remoteClusterRoleBinding)
-				if err != nil {
-					return false
-				}
+				g.Expect(remoteK8sClient.Get(test.Ctx, remoteClusterRoleBindingName, remoteClusterRoleBinding)).To(Succeed(), "there should be no error getting the ClusterRoleBinding from the remote cluster")
 				return g.Expect(remoteClusterRoleBinding.Subjects).To(Equal(expected))
 			}).Should(BeTrue(), "the remote RoleBinding should eventually be reconciled")
+
+			By("cleaning up the test")
+			test.EventuallyDeleted(test.Ctx, test.K8sClient, trb)
 		})
 	})
 })

--- a/pkg/test/assert.go
+++ b/pkg/test/assert.go
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// EventuallyDeleted deletes the object and waits until it is gone.
+func EventuallyDeleted(ctx context.Context, c client.Client, obj client.Object) {
+	GinkgoHelper()
+	Expect(c.Delete(ctx, obj)).Should(Succeed(), "there should be no error deleting the object")
+	Eventually(func() bool {
+		return apierrors.IsNotFound(c.Get(ctx, client.ObjectKeyFromObject(obj), obj))
+	}).Should(BeTrue(), "there should be no error deleting the object")
+}

--- a/pkg/test/resources.go
+++ b/pkg/test/resources.go
@@ -107,6 +107,7 @@ func WithRules(rules []rbacv1.PolicyRule) func(*greenhousev1alpha1.TeamRole) {
 
 // CreateTeamRole returns a TeamRole object. Opts can be used to set the desired state of the TeamRole.
 func (t *TestSetup) CreateTeamRole(ctx context.Context, name string, opts ...func(*greenhousev1alpha1.TeamRole)) *greenhousev1alpha1.TeamRole {
+        GinkgoHelper()
 	tr := &greenhousev1alpha1.TeamRole{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "TeamRole",
@@ -159,6 +160,7 @@ func WithNamespaces(namespaces ...string) func(*greenhousev1alpha1.TeamRoleBindi
 
 // CreateTeamRoleBinding returns a TeamRoleBinding object. Opts can be used to set the desired state of the TeamRoleBinding.
 func (t *TestSetup) CreateTeamRoleBinding(ctx context.Context, name string, opts ...func(*greenhousev1alpha1.TeamRoleBinding)) *greenhousev1alpha1.TeamRoleBinding {
+        GinkgoHelper()
 	trb := &greenhousev1alpha1.TeamRoleBinding{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "TeamRoleBinding",

--- a/pkg/test/resources.go
+++ b/pkg/test/resources.go
@@ -1,0 +1,206 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/rand"
+
+	greenhouseapis "github.com/cloudoperators/greenhouse/pkg/apis"
+	greenhousev1alpha1 "github.com/cloudoperators/greenhouse/pkg/apis/greenhouse/v1alpha1"
+	"github.com/cloudoperators/greenhouse/pkg/clientutil"
+)
+
+type TestSetup struct {
+	client.Client
+	namespace string
+}
+
+func (t *TestSetup) Namespace() string {
+	return t.namespace
+}
+
+// RandomizeName returns the name with a random alphanumeric suffix
+func (t *TestSetup) RandomizeName(name string) string {
+	return name + "-" + rand.String(8)
+}
+
+// NewTestSetup creates a new TestSetup object and a new namespace on the cluster for the test
+func NewTestSetup(ctx context.Context, c client.Client, name string) *TestSetup {
+	suffix := rand.String(8)
+
+	t := &TestSetup{
+		Client:    c,
+		namespace: name + "-" + suffix,
+	}
+
+	// Create test namespace
+	err := K8sClient.Create(Ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: t.namespace}})
+	Expect(err).NotTo(HaveOccurred(), "there should be no error creating the test case namespace")
+	return t
+}
+
+// OnboardCluster creates a new Cluster and Kubernetes secret for a remote cluster and creates the namespace used for TestSetup on the remote cluster
+func (t *TestSetup) OnboardCluster(ctx context.Context, name string, kubeCfg []byte) *greenhousev1alpha1.Cluster {
+	GinkgoHelper()
+	clusterName := t.RandomizeName(name)
+	cluster := &greenhousev1alpha1.Cluster{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Cluster",
+			APIVersion: greenhousev1alpha1.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      clusterName,
+			Namespace: t.Namespace(),
+		},
+		Spec: greenhousev1alpha1.ClusterSpec{
+			AccessMode: greenhousev1alpha1.ClusterAccessModeDirect,
+		},
+	}
+	Expect(t.Create(ctx, cluster)).To(Succeed(), "there should be no error creating the cluster during onboarding")
+
+	var testClusterK8sSecret = &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Secret",
+			APIVersion: corev1.GroupName,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      clusterName,
+			Namespace: t.Namespace(),
+		},
+		Type: greenhouseapis.SecretTypeKubeConfig,
+		Data: map[string][]byte{
+			greenhouseapis.GreenHouseKubeConfigKey: kubeCfg,
+		},
+	}
+	Expect(t.Create(ctx, testClusterK8sSecret)).Should(Succeed(), "there should be no error creating the kubeconfig secret during onboarding")
+
+	restClientGetter, err := clientutil.NewRestClientGetterFromSecret(testClusterK8sSecret, t.Namespace())
+	Expect(err).NotTo(HaveOccurred(), "there should be no error creating the rest client getter from the kubeconfig secret during onboarding")
+
+	k8sClientForRemoteCluster, err := clientutil.NewK8sClientFromRestClientGetter(restClientGetter)
+	Expect(err).NotTo(HaveOccurred(), "there should be no error creating the k8s client from the rest client getter during onboarding")
+
+	var namespace = &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: t.Namespace(),
+		}}
+	Expect(k8sClientForRemoteCluster.Create(ctx, namespace)).To(Succeed(), "there should be no error creating the namespace during onboarding")
+
+	return cluster
+}
+
+// WithRules overrides the default rules of a TeamRole
+func WithRules(rules []rbacv1.PolicyRule) func(*greenhousev1alpha1.TeamRole) {
+	return func(tr *greenhousev1alpha1.TeamRole) {
+		tr.Spec.Rules = rules
+	}
+}
+
+// CreateTeamRole returns a TeamRole object. Opts can be used to set the desired state of the TeamRole.
+func (t *TestSetup) CreateTeamRole(ctx context.Context, name string, opts ...func(*greenhousev1alpha1.TeamRole)) *greenhousev1alpha1.TeamRole {
+	tr := &greenhousev1alpha1.TeamRole{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "TeamRole",
+			APIVersion: greenhousev1alpha1.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      t.RandomizeName(name),
+			Namespace: t.Namespace(),
+		},
+		Spec: greenhousev1alpha1.TeamRoleSpec{
+			Rules: []rbacv1.PolicyRule{
+				{
+					Verbs:     []string{"get"},
+					APIGroups: []string{"*"},
+					Resources: []string{"*"},
+				},
+			},
+		},
+	}
+	for _, opt := range opts {
+		opt(tr)
+	}
+	Expect(t.Create(ctx, tr)).Should(Succeed(), "there should be no error creating the TeamRole")
+	return tr
+}
+
+func WithTeamRoleRef(roleRef string) func(*greenhousev1alpha1.TeamRoleBinding) {
+	return func(trb *greenhousev1alpha1.TeamRoleBinding) {
+		trb.Spec.TeamRoleRef = roleRef
+	}
+}
+
+func WithTeamRef(teamRef string) func(*greenhousev1alpha1.TeamRoleBinding) {
+	return func(trb *greenhousev1alpha1.TeamRoleBinding) {
+		trb.Spec.TeamRef = teamRef
+	}
+}
+
+func WithClusterName(clusterName string) func(*greenhousev1alpha1.TeamRoleBinding) {
+	return func(trb *greenhousev1alpha1.TeamRoleBinding) {
+		trb.Spec.ClusterName = clusterName
+	}
+}
+
+func WithNamespaces(namespaces ...string) func(*greenhousev1alpha1.TeamRoleBinding) {
+	return func(trb *greenhousev1alpha1.TeamRoleBinding) {
+		trb.Spec.Namespaces = namespaces
+	}
+}
+
+// CreateTeamRoleBinding returns a TeamRoleBinding object. Opts can be used to set the desired state of the TeamRoleBinding.
+func (t *TestSetup) CreateTeamRoleBinding(ctx context.Context, name string, opts ...func(*greenhousev1alpha1.TeamRoleBinding)) *greenhousev1alpha1.TeamRoleBinding {
+	trb := &greenhousev1alpha1.TeamRoleBinding{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "TeamRoleBinding",
+			APIVersion: greenhousev1alpha1.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      t.RandomizeName(name),
+			Namespace: t.Namespace(),
+		},
+		Spec: greenhousev1alpha1.TeamRoleBindingSpec{},
+	}
+	for _, o := range opts {
+		o(trb)
+	}
+
+	Expect(t.Create(ctx, trb)).Should(Succeed(), "there should be no error creating the TeamRoleBinding")
+	return trb
+}
+
+func WithMappedIDPGroup(group string) func(*greenhousev1alpha1.Team) {
+	return func(t *greenhousev1alpha1.Team) {
+		t.Spec.MappedIDPGroup = group
+	}
+}
+
+// CreateTeam returns a Team object. Opts can be used to set the desired state of the Team.st
+func (t *TestSetup) CreateTeam(ctx context.Context, name string, opts ...func(*greenhousev1alpha1.Team)) *greenhousev1alpha1.Team {
+	GinkgoHelper()
+	team := &greenhousev1alpha1.Team{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Team",
+			APIVersion: greenhousev1alpha1.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      t.RandomizeName(name),
+			Namespace: t.Namespace(),
+		},
+	}
+	for _, opt := range opts {
+		opt(team)
+	}
+	Expect(t.Create(ctx, team)).Should(Succeed(), "there should be no error creating the Team")
+	return team
+}

--- a/pkg/test/resources.go
+++ b/pkg/test/resources.go
@@ -44,8 +44,7 @@ func NewTestSetup(ctx context.Context, c client.Client, name string) *TestSetup 
 	}
 
 	// Create test namespace
-	err := K8sClient.Create(Ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: t.namespace}})
-	Expect(err).NotTo(HaveOccurred(), "there should be no error creating the test case namespace")
+	Expect(t.Create(Ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: t.namespace}})).To(Succeed(), "there should be no error creating the test case namespace")
 	return t
 }
 


### PR DESCRIPTION
This PR brings in `test.TestSetup(..)` which provides some convenience around creating resources in dedicated namespace. Together with helper methods to create resources (e.g. `CreateTeamRoleBinding(..)` or `OnboardCluster(..)` this should help to reduce the manifest boilerplate required to create resources during test setups.

The test restructuring also unveiled missing propagation of errors when the reconciliation failed. They are now returned.