### PR TITLE
chore: bump to go1.22, controller-tools v0.15

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,7 +5,7 @@
     "config:recommended"
   ],
   "constraints": {
-    "go": "1.21"
+    "go": "1.22"
   },
   "ignoreDeps": [
     "github.com/dexidp/dex"

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -29,7 +29,7 @@ jobs:
         # Use only 'javascript-typescript' to analyze code written in JavaScript, TypeScript or both
         # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
         # node-version: [ node ]
-        go-version: [ '1.21' ]
+        go-version: [ '1.22' ]
 
     steps:
     - name: Checkout repository

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.21 as builder
+FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.22 as builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/Dockerfile.dev-env
+++ b/Dockerfile.dev-env
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.21 as builder
+FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.22 as builder
 
 ARG TARGETOS
 ARG TARGETARCH
@@ -13,7 +13,7 @@ COPY . .
 RUN --mount=type=cache,target=/go/pkg/mod \
   --mount=type=cache,target=/root/.cache/go-build \
   make generate build-dev-env CGO_ENABLED=${CGO_ENABLED} GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
-  && GOBIN=/workspace/bin go install sigs.k8s.io/controller-runtime/tools/setup-envtest@bf15e44028f908c790721fc8fe67c7bf2d06a611 \
+  && GOBIN=/workspace/bin go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest \
   && cp $(/workspace/bin/setup-envtest use ${ENVTEST_K8S_VERSION} -p path)/* /usr/local/bin
 
 

--- a/Dockerfile.headscalectl
+++ b/Dockerfile.headscalectl
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.21 as builder
+FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.22 as builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/Dockerfile.tailscale
+++ b/Dockerfile.tailscale
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.21 as builder
+FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.22 as builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/Dockerfile.tcp-proxy
+++ b/Dockerfile.tcp-proxy
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.21 as builder
+FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.22 as builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/Makefile
+++ b/Makefile
@@ -126,8 +126,8 @@ HELMIFY ?= $(LOCALBIN)/helmify
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v5.4.2
-CONTROLLER_TOOLS_VERSION ?= v0.14.0
-GOLINT_VERSION ?= v1.55.2
+CONTROLLER_TOOLS_VERSION ?= v0.15.0
+GOLINT_VERSION ?= v1.59.0
 GINKGOLINTER_VERSION ?= v0.16.2
 
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"

--- a/charts/manager/crds/greenhouse.sap_clusters.yaml
+++ b/charts/manager/crds/greenhouse.sap_clusters.yaml
@@ -6,7 +6,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.15.0
   name: clusters.greenhouse.sap
 spec:
   group: greenhouse.sap

--- a/charts/manager/crds/greenhouse.sap_organizations.yaml
+++ b/charts/manager/crds/greenhouse.sap_organizations.yaml
@@ -6,7 +6,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.15.0
   name: organizations.greenhouse.sap
 spec:
   group: greenhouse.sap

--- a/charts/manager/crds/greenhouse.sap_plugindefinitions.yaml
+++ b/charts/manager/crds/greenhouse.sap_plugindefinitions.yaml
@@ -6,7 +6,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.15.0
   name: plugindefinitions.greenhouse.sap
 spec:
   group: greenhouse.sap

--- a/charts/manager/crds/greenhouse.sap_pluginpresets.yaml
+++ b/charts/manager/crds/greenhouse.sap_pluginpresets.yaml
@@ -6,7 +6,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.15.0
   name: pluginpresets.greenhouse.sap
 spec:
   group: greenhouse.sap

--- a/charts/manager/crds/greenhouse.sap_plugins.yaml
+++ b/charts/manager/crds/greenhouse.sap_plugins.yaml
@@ -6,7 +6,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.15.0
   name: plugins.greenhouse.sap
 spec:
   group: greenhouse.sap

--- a/charts/manager/crds/greenhouse.sap_teammemberships.yaml
+++ b/charts/manager/crds/greenhouse.sap_teammemberships.yaml
@@ -6,7 +6,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.15.0
   name: teammemberships.greenhouse.sap
 spec:
   group: greenhouse.sap

--- a/charts/manager/crds/greenhouse.sap_teamrolebindings.yaml
+++ b/charts/manager/crds/greenhouse.sap_teamrolebindings.yaml
@@ -6,7 +6,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.15.0
   name: teamrolebindings.greenhouse.sap
 spec:
   group: greenhouse.sap

--- a/charts/manager/crds/greenhouse.sap_teamroles.yaml
+++ b/charts/manager/crds/greenhouse.sap_teamroles.yaml
@@ -6,7 +6,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.15.0
   name: teamroles.greenhouse.sap
 spec:
   group: greenhouse.sap

--- a/charts/manager/crds/greenhouse.sap_teams.yaml
+++ b/charts/manager/crds/greenhouse.sap_teams.yaml
@@ -6,7 +6,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.15.0
   name: teams.greenhouse.sap
 spec:
   group: greenhouse.sap

--- a/docs/reference/api/index.html
+++ b/docs/reference/api/index.html
@@ -326,7 +326,7 @@ p {
             <p><h1>Greenhouse</h1></p>
             <p>PlusOne operations platform</p>
             <p>
-                <div class="app-desc">Version: 5195a82</div>
+                <div class="app-desc">Version: 479ed6d</div>
             </p>
           </div>
         </div>
@@ -884,11 +884,11 @@ g,0<c.length&&(c=Aa[c[0]])&&(a.c[e]=c))}a.c[e]||(c=Aa[e])&&(a.c[e]=c);for(c=0;c<
   "properties" : {
     "apiVersion" : {
       "type" : "string",
-      "description" : "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
+      "description" : "APIVersion defines the versioned schema of this representation of an object.\\nServers should convert recognized schemas to the latest internal value, and\\nmay reject unrecognized values.\\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
     },
     "kind" : {
       "type" : "string",
-      "description" : "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+      "description" : "Kind is a string value representing the REST resource this object represents.\\nServers may infer this from the endpoint the client submits requests to.\\nCannot be updated.\\nIn CamelCase.\\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
     },
     "metadata" : {
       "type" : "object"
@@ -1032,7 +1032,7 @@ g,0<c.length&&(c=Aa[c[0]])&&(a.c[e]=c))}a.c[e]||(c=Aa[e])&&(a.c[e]=c);for(c=0;c<
     "conditions" : {
       "type" : "array",
       "items" : {
-        "$ref" : "#/components/schemas/Plugin_status_statusConditions_conditions"
+        "$ref" : "#/components/schemas/Cluster_status_statusConditions_conditions"
       },
       "x-kubernetes-list-map-keys" : [ "type" ],
       "x-kubernetes-list-type" : "map"
@@ -1046,7 +1046,7 @@ g,0<c.length&&(c=Aa[c[0]])&&(a.c[e]=c))}a.c[e]||(c=Aa[e])&&(a.c[e]=c);for(c=0;c<
     "conditions" : {
       "type" : "array",
       "items" : {
-        "$ref" : "#/components/schemas/Plugin_status_statusConditions_conditions"
+        "$ref" : "#/components/schemas/Cluster_status_statusConditions_conditions"
       },
       "x-kubernetes-list-map-keys" : [ "type" ],
       "x-kubernetes-list-type" : "map"
@@ -1054,17 +1054,45 @@ g,0<c.length&&(c=Aa[c[0]])&&(a.c[e]=c))}a.c[e]||(c=Aa[e])&&(a.c[e]=c);for(c=0;c<
   },
   "description" : "StatusConditions contain the different conditions that constitute the status of the Cluster."
 };
+    defs["Cluster_status_statusConditions_conditions"] = {
+  "required" : [ "lastTransitionTime", "status", "type" ],
+  "type" : "object",
+  "properties" : {
+    "lastTransitionTime" : {
+      "type" : "string",
+      "description" : "LastTransitionTime is the last time the condition transitioned from one status to another.",
+      "format" : "date-time"
+    },
+    "message" : {
+      "type" : "string",
+      "description" : "Message is an optional human readable message indicating details about the last transition."
+    },
+    "reason" : {
+      "type" : "string",
+      "description" : "Reason is a one-word, CamelCase reason for the condition's last transition."
+    },
+    "status" : {
+      "type" : "string",
+      "description" : "Status of the condition."
+    },
+    "type" : {
+      "type" : "string",
+      "description" : "Type of the condition."
+    }
+  },
+  "description" : "Condition contains additional information on the state of a resource."
+};
     defs["Organization"] = {
   "title" : "Organization",
   "type" : "object",
   "properties" : {
     "apiVersion" : {
       "type" : "string",
-      "description" : "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
+      "description" : "APIVersion defines the versioned schema of this representation of an object.\\nServers should convert recognized schemas to the latest internal value, and\\nmay reject unrecognized values.\\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
     },
     "kind" : {
       "type" : "string",
-      "description" : "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+      "description" : "Kind is a string value representing the REST resource this object represents.\\nServers may infer this from the endpoint the client submits requests to.\\nCannot be updated.\\nIn CamelCase.\\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
     },
     "metadata" : {
       "type" : "object"
@@ -1095,7 +1123,7 @@ g,0<c.length&&(c=Aa[c[0]])&&(a.c[e]=c))}a.c[e]||(c=Aa[e])&&(a.c[e]=c);for(c=0;c<
     },
     "displayName" : {
       "type" : "string",
-      "description" : "DisplayName is an optional name for the organization to be displayed in the Greenhouse UI. Defaults to a normalized version of metadata.name."
+      "description" : "DisplayName is an optional name for the organization to be displayed in the Greenhouse UI.\\nDefaults to a normalized version of metadata.name."
     },
     "mappedOrgAdminIdPGroup" : {
       "type" : "string",
@@ -1129,7 +1157,7 @@ g,0<c.length&&(c=Aa[c[0]])&&(a.c[e]=c))}a.c[e]||(c=Aa[e])&&(a.c[e]=c);for(c=0;c<
     },
     "redirectURI" : {
       "type" : "string",
-      "description" : "RedirectURI is the redirect URI. If none is specified, the Greenhouse ID proxy will be used."
+      "description" : "RedirectURI is the redirect URI.\\nIf none is specified, the Greenhouse ID proxy will be used."
     }
   },
   "description" : "OIDConfig configures the OIDC provider."
@@ -1170,11 +1198,11 @@ g,0<c.length&&(c=Aa[c[0]])&&(a.c[e]=c))}a.c[e]||(c=Aa[e])&&(a.c[e]=c);for(c=0;c<
   "properties" : {
     "apiVersion" : {
       "type" : "string",
-      "description" : "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
+      "description" : "APIVersion defines the versioned schema of this representation of an object.\\nServers should convert recognized schemas to the latest internal value, and\\nmay reject unrecognized values.\\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
     },
     "kind" : {
       "type" : "string",
-      "description" : "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+      "description" : "Kind is a string value representing the REST resource this object represents.\\nServers may infer this from the endpoint the client submits requests to.\\nCannot be updated.\\nIn CamelCase.\\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
     },
     "metadata" : {
       "type" : "object"
@@ -1198,11 +1226,11 @@ g,0<c.length&&(c=Aa[c[0]])&&(a.c[e]=c))}a.c[e]||(c=Aa[e])&&(a.c[e]=c);for(c=0;c<
   "properties" : {
     "apiVersion" : {
       "type" : "string",
-      "description" : "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
+      "description" : "APIVersion defines the versioned schema of this representation of an object.\\nServers should convert recognized schemas to the latest internal value, and\\nmay reject unrecognized values.\\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
     },
     "kind" : {
       "type" : "string",
-      "description" : "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+      "description" : "Kind is a string value representing the REST resource this object represents.\\nServers may infer this from the endpoint the client submits requests to.\\nCannot be updated.\\nIn CamelCase.\\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
     },
     "metadata" : {
       "type" : "object"
@@ -1235,14 +1263,14 @@ g,0<c.length&&(c=Aa[c[0]])&&(a.c[e]=c))}a.c[e]||(c=Aa[e])&&(a.c[e]=c);for(c=0;c<
     },
     "docMarkDownUrl" : {
       "type" : "string",
-      "description" : "DocMarkDownUrl specifies the URL to the markdown documentation file for this plugin. Source needs to allow all CORS origins."
+      "description" : "DocMarkDownUrl specifies the URL to the markdown documentation file for this plugin.\\nSource needs to allow all CORS origins."
     },
     "helmChart" : {
       "$ref" : "#/components/schemas/PluginDefinition_spec_helmChart"
     },
     "icon" : {
       "type" : "string",
-      "description" : "Icon specifies the icon to be used for this plugin in the Greenhouse UI. Icons can be either: - A string representing a juno icon in camel case from this list: https://github.com/sapcc/juno/blob/main/libs/juno-ui-components/src/components/Icon/Icon.component.js#L6-L52 - A publicly accessable image reference to a .png file. Will be displayed 100x100px"
+      "description" : "Icon specifies the icon to be used for this plugin in the Greenhouse UI.\\nIcons can be either:\\n- A string representing a juno icon in camel case from this list: https://github.com/sapcc/juno/blob/main/libs/juno-ui-components/src/components/Icon/Icon.component.js#L6-L52\\n- A publicly accessable image reference to a .png file. Will be displayed 100x100px"
     },
     "options" : {
       "type" : "array",
@@ -1260,7 +1288,7 @@ g,0<c.length&&(c=Aa[c[0]])&&(a.c[e]=c))}a.c[e]||(c=Aa[e])&&(a.c[e]=c);for(c=0;c<
     },
     "weight" : {
       "type" : "integer",
-      "description" : "Weight configures the order in which Plugins are shown in the Greenhouse UI. Defaults to alphabetical sorting if not provided or on conflict.",
+      "description" : "Weight configures the order in which Plugins are shown in the Greenhouse UI.\\nDefaults to alphabetical sorting if not provided or on conflict.",
       "format" : "int32"
     }
   },
@@ -1330,7 +1358,7 @@ g,0<c.length&&(c=Aa[c[0]])&&(a.c[e]=c))}a.c[e]||(c=Aa[e])&&(a.c[e]=c);for(c=0;c<
     },
     "url" : {
       "type" : "string",
-      "description" : "URL specifies the url to a built javascript asset. By default, assets are loaded from the Juno asset server using the provided name and version."
+      "description" : "URL specifies the url to a built javascript asset.\\nBy default, assets are loaded from the Juno asset server using the provided name and version."
     },
     "version" : {
       "type" : "string",
@@ -1345,11 +1373,11 @@ g,0<c.length&&(c=Aa[c[0]])&&(a.c[e]=c))}a.c[e]||(c=Aa[e])&&(a.c[e]=c);for(c=0;c<
   "properties" : {
     "apiVersion" : {
       "type" : "string",
-      "description" : "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
+      "description" : "APIVersion defines the versioned schema of this representation of an object.\\nServers should convert recognized schemas to the latest internal value, and\\nmay reject unrecognized values.\\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
     },
     "kind" : {
       "type" : "string",
-      "description" : "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+      "description" : "Kind is a string value representing the REST resource this object represents.\\nServers may infer this from the endpoint the client submits requests to.\\nCannot be updated.\\nIn CamelCase.\\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
     },
     "metadata" : {
       "type" : "object"
@@ -1395,7 +1423,7 @@ g,0<c.length&&(c=Aa[c[0]])&&(a.c[e]=c))}a.c[e]||(c=Aa[e])&&(a.c[e]=c);for(c=0;c<
       "additionalProperties" : {
         "type" : "string"
       },
-      "description" : "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed."
+      "description" : "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed."
     }
   },
   "description" : "ClusterSelector is a label selector to select the clusters the plugin bundle should be deployed to.",
@@ -1411,17 +1439,17 @@ g,0<c.length&&(c=Aa[c[0]])&&(a.c[e]=c))}a.c[e]||(c=Aa[e])&&(a.c[e]=c);for(c=0;c<
     },
     "operator" : {
       "type" : "string",
-      "description" : "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist."
+      "description" : "operator represents a key's relationship to a set of values.\\nValid operators are In, NotIn, Exists and DoesNotExist."
     },
     "values" : {
       "type" : "array",
-      "description" : "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+      "description" : "values is an array of string values. If the operator is In or NotIn,\\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\\nthe values array must be empty. This array is replaced during a strategic\\nmerge patch.",
       "items" : {
         "type" : "string"
       }
     }
   },
-  "description" : "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values."
+  "description" : "A label selector requirement is a selector that contains values, a key, and an operator that\\nrelates the key and values."
 };
     defs["PluginPreset_spec_plugin"] = {
   "required" : [ "disabled", "pluginDefinition" ],
@@ -1437,13 +1465,13 @@ g,0<c.length&&(c=Aa[c[0]])&&(a.c[e]=c))}a.c[e]||(c=Aa[e])&&(a.c[e]=c);for(c=0;c<
     },
     "displayName" : {
       "type" : "string",
-      "description" : "DisplayName is an optional name for the Plugin to be displayed in the Greenhouse UI. This is especially helpful to distinguish multiple instances of a PluginDefinition in the same context. Defaults to a normalized version of metadata.name."
+      "description" : "DisplayName is an optional name for the Plugin to be displayed in the Greenhouse UI.\\nThis is especially helpful to distinguish multiple instances of a PluginDefinition in the same context.\\nDefaults to a normalized version of metadata.name."
     },
     "optionValues" : {
       "type" : "array",
       "description" : "Values are the values for a PluginDefinition instance.",
       "items" : {
-        "$ref" : "#/components/schemas/Plugin_spec_optionValues"
+        "$ref" : "#/components/schemas/PluginPreset_spec_plugin_optionValues"
       }
     },
     "pluginDefinition" : {
@@ -1452,10 +1480,52 @@ g,0<c.length&&(c=Aa[c[0]])&&(a.c[e]=c))}a.c[e]||(c=Aa[e])&&(a.c[e]=c);for(c=0;c<
     },
     "releaseNamespace" : {
       "type" : "string",
-      "description" : "ReleaseNamespace is the namespace in the remote cluster to which the backend is deployed. Defaults to the Greenhouse managed namespace if not set."
+      "description" : "ReleaseNamespace is the namespace in the remote cluster to which the backend is deployed.\\nDefaults to the Greenhouse managed namespace if not set."
     }
   },
   "description" : "PluginSpec is the spec of the plugin to be deployed by the PluginPreset."
+};
+    defs["PluginPreset_spec_plugin_optionValues"] = {
+  "required" : [ "name" ],
+  "type" : "object",
+  "properties" : {
+    "name" : {
+      "type" : "string",
+      "description" : "Name of the values."
+    },
+    "value" : {
+      "description" : "Value is the actual value in plain text.",
+      "x-kubernetes-preserve-unknown-fields" : true
+    },
+    "valueFrom" : {
+      "$ref" : "#/components/schemas/PluginPreset_spec_plugin_valueFrom"
+    }
+  },
+  "description" : "PluginOptionValue is the value for a PluginOption."
+};
+    defs["PluginPreset_spec_plugin_valueFrom"] = {
+  "type" : "object",
+  "properties" : {
+    "secret" : {
+      "$ref" : "#/components/schemas/PluginPreset_spec_plugin_valueFrom_secret"
+    }
+  },
+  "description" : "ValueFrom references a potentially confidential value in another source."
+};
+    defs["PluginPreset_spec_plugin_valueFrom_secret"] = {
+  "required" : [ "key", "name" ],
+  "type" : "object",
+  "properties" : {
+    "key" : {
+      "type" : "string",
+      "description" : "Key in the secret to select the value from."
+    },
+    "name" : {
+      "type" : "string",
+      "description" : "Name of the secret in the same namespace."
+    }
+  },
+  "description" : "Secret references the secret containing the value."
 };
     defs["PluginPreset_status"] = {
   "type" : "object",
@@ -1472,7 +1542,7 @@ g,0<c.length&&(c=Aa[c[0]])&&(a.c[e]=c))}a.c[e]||(c=Aa[e])&&(a.c[e]=c);for(c=0;c<
     "conditions" : {
       "type" : "array",
       "items" : {
-        "$ref" : "#/components/schemas/Plugin_status_statusConditions_conditions"
+        "$ref" : "#/components/schemas/Cluster_status_statusConditions_conditions"
       },
       "x-kubernetes-list-map-keys" : [ "type" ],
       "x-kubernetes-list-type" : "map"
@@ -1494,13 +1564,13 @@ g,0<c.length&&(c=Aa[c[0]])&&(a.c[e]=c))}a.c[e]||(c=Aa[e])&&(a.c[e]=c);for(c=0;c<
     },
     "displayName" : {
       "type" : "string",
-      "description" : "DisplayName is an optional name for the Plugin to be displayed in the Greenhouse UI. This is especially helpful to distinguish multiple instances of a PluginDefinition in the same context. Defaults to a normalized version of metadata.name."
+      "description" : "DisplayName is an optional name for the Plugin to be displayed in the Greenhouse UI.\\nThis is especially helpful to distinguish multiple instances of a PluginDefinition in the same context.\\nDefaults to a normalized version of metadata.name."
     },
     "optionValues" : {
       "type" : "array",
       "description" : "Values are the values for a PluginDefinition instance.",
       "items" : {
-        "$ref" : "#/components/schemas/Plugin_spec_optionValues"
+        "$ref" : "#/components/schemas/PluginPreset_spec_plugin_optionValues"
       }
     },
     "pluginDefinition" : {
@@ -1509,52 +1579,10 @@ g,0<c.length&&(c=Aa[c[0]])&&(a.c[e]=c))}a.c[e]||(c=Aa[e])&&(a.c[e]=c);for(c=0;c<
     },
     "releaseNamespace" : {
       "type" : "string",
-      "description" : "ReleaseNamespace is the namespace in the remote cluster to which the backend is deployed. Defaults to the Greenhouse managed namespace if not set."
+      "description" : "ReleaseNamespace is the namespace in the remote cluster to which the backend is deployed.\\nDefaults to the Greenhouse managed namespace if not set."
     }
   },
   "description" : "PluginSpec defines the desired state of Plugin"
-};
-    defs["Plugin_spec_optionValues"] = {
-  "required" : [ "name" ],
-  "type" : "object",
-  "properties" : {
-    "name" : {
-      "type" : "string",
-      "description" : "Name of the values."
-    },
-    "value" : {
-      "description" : "Value is the actual value in plain text.",
-      "x-kubernetes-preserve-unknown-fields" : true
-    },
-    "valueFrom" : {
-      "$ref" : "#/components/schemas/Plugin_spec_valueFrom"
-    }
-  },
-  "description" : "PluginOptionValue is the value for a PluginOption."
-};
-    defs["Plugin_spec_valueFrom"] = {
-  "type" : "object",
-  "properties" : {
-    "secret" : {
-      "$ref" : "#/components/schemas/Plugin_spec_valueFrom_secret"
-    }
-  },
-  "description" : "ValueFrom references a potentially confidential value in another source."
-};
-    defs["Plugin_spec_valueFrom_secret"] = {
-  "required" : [ "key", "name" ],
-  "type" : "object",
-  "properties" : {
-    "key" : {
-      "type" : "string",
-      "description" : "Key in the secret to select the value from."
-    },
-    "name" : {
-      "type" : "string",
-      "description" : "Name of the secret in the same namespace."
-    }
-  },
-  "description" : "Secret references the secret containing the value."
 };
     defs["Plugin_status"] = {
   "type" : "object",
@@ -1568,7 +1596,7 @@ g,0<c.length&&(c=Aa[c[0]])&&(a.c[e]=c))}a.c[e]||(c=Aa[e])&&(a.c[e]=c);for(c=0;c<
       "additionalProperties" : {
         "$ref" : "#/components/schemas/Plugin_status_exposedServices"
       },
-      "description" : "ExposedServices provides an overview of the Plugins services that are centrally exposed. It maps the exposed URL to the service found in the manifest."
+      "description" : "ExposedServices provides an overview of the Plugins services that are centrally exposed.\\nIt maps the exposed URL to the service found in the manifest."
     },
     "helmChart" : {
       "$ref" : "#/components/schemas/Plugin_status_helmChart"
@@ -1656,7 +1684,7 @@ g,0<c.length&&(c=Aa[c[0]])&&(a.c[e]=c))}a.c[e]||(c=Aa[e])&&(a.c[e]=c);for(c=0;c<
       "description" : "Status is the status of a HelmChart release."
     }
   },
-  "description" : "HelmReleaseStatus reflects the status of the latest HelmChart release. This is only configured if the pluginDefinition is backed by HelmChart."
+  "description" : "HelmReleaseStatus reflects the status of the latest HelmChart release.\\nThis is only configured if the pluginDefinition is backed by HelmChart."
 };
     defs["Plugin_status_statusConditions"] = {
   "type" : "object",
@@ -1664,41 +1692,13 @@ g,0<c.length&&(c=Aa[c[0]])&&(a.c[e]=c))}a.c[e]||(c=Aa[e])&&(a.c[e]=c);for(c=0;c<
     "conditions" : {
       "type" : "array",
       "items" : {
-        "$ref" : "#/components/schemas/Plugin_status_statusConditions_conditions"
+        "$ref" : "#/components/schemas/Cluster_status_statusConditions_conditions"
       },
       "x-kubernetes-list-map-keys" : [ "type" ],
       "x-kubernetes-list-type" : "map"
     }
   },
   "description" : "StatusConditions contain the different conditions that constitute the status of the Plugin."
-};
-    defs["Plugin_status_statusConditions_conditions"] = {
-  "required" : [ "lastTransitionTime", "status", "type" ],
-  "type" : "object",
-  "properties" : {
-    "lastTransitionTime" : {
-      "type" : "string",
-      "description" : "LastTransitionTime is the last time the condition transitioned from one status to another.",
-      "format" : "date-time"
-    },
-    "message" : {
-      "type" : "string",
-      "description" : "Message is an optional human readable message indicating details about the last transition."
-    },
-    "reason" : {
-      "type" : "string",
-      "description" : "Reason is a one-word, CamelCase reason for the condition's last transition."
-    },
-    "status" : {
-      "type" : "string",
-      "description" : "Status of the condition."
-    },
-    "type" : {
-      "type" : "string",
-      "description" : "Type of the condition."
-    }
-  },
-  "description" : "Condition contains additional information on the state of a resource."
 };
     defs["Plugin_status_uiApplication"] = {
   "required" : [ "name", "version" ],
@@ -1710,7 +1710,7 @@ g,0<c.length&&(c=Aa[c[0]])&&(a.c[e]=c))}a.c[e]||(c=Aa[e])&&(a.c[e]=c);for(c=0;c<
     },
     "url" : {
       "type" : "string",
-      "description" : "URL specifies the url to a built javascript asset. By default, assets are loaded from the Juno asset server using the provided name and version."
+      "description" : "URL specifies the url to a built javascript asset.\\nBy default, assets are loaded from the Juno asset server using the provided name and version."
     },
     "version" : {
       "type" : "string",
@@ -1725,11 +1725,11 @@ g,0<c.length&&(c=Aa[c[0]])&&(a.c[e]=c))}a.c[e]||(c=Aa[e])&&(a.c[e]=c);for(c=0;c<
   "properties" : {
     "apiVersion" : {
       "type" : "string",
-      "description" : "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
+      "description" : "APIVersion defines the versioned schema of this representation of an object.\\nServers should convert recognized schemas to the latest internal value, and\\nmay reject unrecognized values.\\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
     },
     "kind" : {
       "type" : "string",
-      "description" : "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+      "description" : "Kind is a string value representing the REST resource this object represents.\\nServers may infer this from the endpoint the client submits requests to.\\nCannot be updated.\\nIn CamelCase.\\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
     },
     "metadata" : {
       "type" : "object"
@@ -1754,11 +1754,11 @@ g,0<c.length&&(c=Aa[c[0]])&&(a.c[e]=c))}a.c[e]||(c=Aa[e])&&(a.c[e]=c);for(c=0;c<
   "properties" : {
     "apiVersion" : {
       "type" : "string",
-      "description" : "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
+      "description" : "APIVersion defines the versioned schema of this representation of an object.\\nServers should convert recognized schemas to the latest internal value, and\\nmay reject unrecognized values.\\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
     },
     "kind" : {
       "type" : "string",
-      "description" : "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+      "description" : "Kind is a string value representing the REST resource this object represents.\\nServers may infer this from the endpoint the client submits requests to.\\nCannot be updated.\\nIn CamelCase.\\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
     },
     "metadata" : {
       "type" : "object"
@@ -1834,11 +1834,11 @@ g,0<c.length&&(c=Aa[c[0]])&&(a.c[e]=c))}a.c[e]||(c=Aa[e])&&(a.c[e]=c);for(c=0;c<
   "properties" : {
     "apiVersion" : {
       "type" : "string",
-      "description" : "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
+      "description" : "APIVersion defines the versioned schema of this representation of an object.\\nServers should convert recognized schemas to the latest internal value, and\\nmay reject unrecognized values.\\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
     },
     "kind" : {
       "type" : "string",
-      "description" : "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+      "description" : "Kind is a string value representing the REST resource this object represents.\\nServers may infer this from the endpoint the client submits requests to.\\nCannot be updated.\\nIn CamelCase.\\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
     },
     "metadata" : {
       "type" : "object"
@@ -1863,11 +1863,11 @@ g,0<c.length&&(c=Aa[c[0]])&&(a.c[e]=c))}a.c[e]||(c=Aa[e])&&(a.c[e]=c);for(c=0;c<
   "properties" : {
     "apiVersion" : {
       "type" : "string",
-      "description" : "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
+      "description" : "APIVersion defines the versioned schema of this representation of an object.\\nServers should convert recognized schemas to the latest internal value, and\\nmay reject unrecognized values.\\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
     },
     "kind" : {
       "type" : "string",
-      "description" : "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+      "description" : "Kind is a string value representing the REST resource this object represents.\\nServers may infer this from the endpoint the client submits requests to.\\nCannot be updated.\\nIn CamelCase.\\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
     },
     "metadata" : {
       "type" : "object"
@@ -1930,14 +1930,14 @@ g,0<c.length&&(c=Aa[c[0]])&&(a.c[e]=c))}a.c[e]||(c=Aa[e])&&(a.c[e]=c);for(c=0;c<
   "properties" : {
     "apiGroups" : {
       "type" : "array",
-      "description" : "APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of the enumerated resources in any API group will be allowed. \"\" represents the core API group and \"*\" represents all API groups.",
+      "description" : "APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of\\nthe enumerated resources in any API group will be allowed. \"\" represents the core API group and \"*\" represents all API groups.",
       "items" : {
         "type" : "string"
       }
     },
     "nonResourceURLs" : {
       "type" : "array",
-      "description" : "NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path Since non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding. Rules can either apply to API resources (such as \"pods\" or \"secrets\") or non-resource URL paths (such as \"/api\"),  but not both.",
+      "description" : "NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path\\nSince non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding.\\nRules can either apply to API resources (such as \"pods\" or \"secrets\") or non-resource URL paths (such as \"/api\"),  but not both.",
       "items" : {
         "type" : "string"
       }
@@ -1964,7 +1964,7 @@ g,0<c.length&&(c=Aa[c[0]])&&(a.c[e]=c))}a.c[e]||(c=Aa[e])&&(a.c[e]=c);for(c=0;c<
       }
     }
   },
-  "description" : "PolicyRule holds information that describes a policy rule, but does not contain information about who the rule applies to or which namespace the rule applies to."
+  "description" : "PolicyRule holds information that describes a policy rule, but does not contain information\\nabout who the rule applies to or which namespace the rule applies to."
 };
     defs["Team_spec"] = {
   "type" : "object",

--- a/docs/reference/api/openapi.yaml
+++ b/docs/reference/api/openapi.yaml
@@ -1,44 +1,34 @@
 openapi: 3.0.0
 info:
   title: Greenhouse
-  version: 5195a82
+  version: 479ed6d
   description: PlusOne operations platform
 paths:
-  /Plugin:
-    post:
-      responses:
-        default:
-          description: Plugin
-  /Organization:
-    post:
-      responses:
-        default:
-          description: Organization
-  /TeamRole:
-    post:
-      responses:
-        default:
-          description: TeamRole
-  /PluginPreset:
-    post:
-      responses:
-        default:
-          description: PluginPreset
   /Cluster:
     post:
       responses:
         default:
           description: Cluster
+  /Organization:
+    post:
+      responses:
+        default:
+          description: Organization
   /PluginDefinition:
     post:
       responses:
         default:
           description: PluginDefinition
-  /Team:
+  /PluginPreset:
     post:
       responses:
         default:
-          description: Team
+          description: PluginPreset
+  /Plugin:
+    post:
+      responses:
+        default:
+          description: Plugin
   /TeamMembership:
     post:
       responses:
@@ -49,477 +39,18 @@ paths:
       responses:
         default:
           description: TeamRoleBinding
+  /TeamRole:
+    post:
+      responses:
+        default:
+          description: TeamRole
+  /Team:
+    post:
+      responses:
+        default:
+          description: Team
 components:
   schemas:
-    Plugin:
-      xml:
-        name: greenhouse.sap
-        namespace: v1alpha1
-      title: Plugin
-      description: Plugin is the Schema for the plugins API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: PluginSpec defines the desired state of Plugin
-          properties:
-            clusterName:
-              description: ClusterName is the name of the cluster the plugin is deployed to. If not set, the plugin is deployed to the greenhouse cluster.
-              type: string
-            disabled:
-              description: Disabled indicates that the plugin is administratively disabled.
-              type: boolean
-            displayName:
-              description: DisplayName is an optional name for the Plugin to be displayed in the Greenhouse UI. This is especially helpful to distinguish multiple instances of a PluginDefinition in the same context. Defaults to a normalized version of metadata.name.
-              type: string
-            optionValues:
-              description: Values are the values for a PluginDefinition instance.
-              items:
-                description: PluginOptionValue is the value for a PluginOption.
-                properties:
-                  name:
-                    description: Name of the values.
-                    type: string
-                  value:
-                    description: Value is the actual value in plain text.
-                    x-kubernetes-preserve-unknown-fields: true
-                  valueFrom:
-                    description: ValueFrom references a potentially confidential value in another source.
-                    properties:
-                      secret:
-                        description: Secret references the secret containing the value.
-                        properties:
-                          key:
-                            description: Key in the secret to select the value from.
-                            type: string
-                          name:
-                            description: Name of the secret in the same namespace.
-                            type: string
-                        required:
-                          - key
-                          - name
-                        type: object
-                    type: object
-                required:
-                  - name
-                type: object
-              type: array
-            pluginDefinition:
-              description: PluginDefinition is the name of the PluginDefinition this instance is for.
-              type: string
-            releaseNamespace:
-              description: ReleaseNamespace is the namespace in the remote cluster to which the backend is deployed. Defaults to the Greenhouse managed namespace if not set.
-              type: string
-          required:
-            - disabled
-            - pluginDefinition
-          type: object
-        status:
-          description: PluginStatus defines the observed state of Plugin
-          properties:
-            description:
-              description: Description provides additional details of the plugin.
-              type: string
-            exposedServices:
-              additionalProperties:
-                description: Service references a Kubernetes service of a Plugin.
-                properties:
-                  name:
-                    description: Name is the name of the service in the target cluster.
-                    type: string
-                  namespace:
-                    description: Namespace is the namespace of the service in the target cluster.
-                    type: string
-                  port:
-                    description: Port is the port of the service.
-                    format: int32
-                    type: integer
-                  protocol:
-                    description: Protocol is the protocol of the service.
-                    type: string
-                required:
-                  - name
-                  - namespace
-                  - port
-                type: object
-              description: ExposedServices provides an overview of the Plugins services that are centrally exposed. It maps the exposed URL to the service found in the manifest.
-              type: object
-            helmChart:
-              description: HelmChart contains a reference the helm chart used for the deployed pluginDefinition version.
-              properties:
-                name:
-                  description: Name of the HelmChart chart.
-                  type: string
-                repository:
-                  description: Repository of the HelmChart chart.
-                  type: string
-                version:
-                  description: Version of the HelmChart chart.
-                  type: string
-              required:
-                - name
-                - repository
-                - version
-              type: object
-            helmReleaseStatus:
-              description: HelmReleaseStatus reflects the status of the latest HelmChart release. This is only configured if the pluginDefinition is backed by HelmChart.
-              properties:
-                firstDeployed:
-                  description: FirstDeployed is the timestamp of the first deployment of the release.
-                  format: date-time
-                  type: string
-                lastDeployed:
-                  description: LastDeployed is the timestamp of the last deployment of the release.
-                  format: date-time
-                  type: string
-                status:
-                  description: Status is the status of a HelmChart release.
-                  type: string
-              required:
-                - status
-              type: object
-            statusConditions:
-              description: StatusConditions contain the different conditions that constitute the status of the Plugin.
-              properties:
-                conditions:
-                  items:
-                    description: Condition contains additional information on the state of a resource.
-                    properties:
-                      lastTransitionTime:
-                        description: LastTransitionTime is the last time the condition transitioned from one status to another.
-                        format: date-time
-                        type: string
-                      message:
-                        description: Message is an optional human readable message indicating details about the last transition.
-                        type: string
-                      reason:
-                        description: Reason is a one-word, CamelCase reason for the condition's last transition.
-                        type: string
-                      status:
-                        description: Status of the condition.
-                        type: string
-                      type:
-                        description: Type of the condition.
-                        type: string
-                    required:
-                      - lastTransitionTime
-                      - status
-                      - type
-                    type: object
-                  type: array
-                  x-kubernetes-list-map-keys:
-                    - type
-                  x-kubernetes-list-type: map
-              type: object
-            uiApplication:
-              description: UIApplication contains a reference to the frontend that is used for the deployed pluginDefinition version.
-              properties:
-                name:
-                  description: Name of the UI application.
-                  type: string
-                url:
-                  description: URL specifies the url to a built javascript asset. By default, assets are loaded from the Juno asset server using the provided name and version.
-                  type: string
-                version:
-                  description: Version of the frontend application.
-                  type: string
-              required:
-                - name
-                - version
-              type: object
-            version:
-              description: Version contains the latest pluginDefinition version the config was last applied with successfully.
-              type: string
-            weight:
-              description: Weight configures the order in which Plugins are shown in the Greenhouse UI.
-              format: int32
-              type: integer
-          type: object
-      type: object
-    Organization:
-      xml:
-        name: greenhouse.sap
-        namespace: v1alpha1
-      title: Organization
-      description: Organization is the Schema for the organizations API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: OrganizationSpec defines the desired state of Organization
-          properties:
-            authentication:
-              description: Authentication configures the organizations authentication mechanism.
-              properties:
-                oidc:
-                  description: OIDConfig configures the OIDC provider.
-                  properties:
-                    clientIDReference:
-                      description: ClientIDReference references the Kubernetes secret containing the client id.
-                      properties:
-                        key:
-                          description: Key in the secret to select the value from.
-                          type: string
-                        name:
-                          description: Name of the secret in the same namespace.
-                          type: string
-                      required:
-                        - key
-                        - name
-                      type: object
-                    clientSecretReference:
-                      description: ClientSecretReference references the Kubernetes secret containing the client secret.
-                      properties:
-                        key:
-                          description: Key in the secret to select the value from.
-                          type: string
-                        name:
-                          description: Name of the secret in the same namespace.
-                          type: string
-                      required:
-                        - key
-                        - name
-                      type: object
-                    issuer:
-                      description: Issuer is the URL of the identity service.
-                      type: string
-                    redirectURI:
-                      description: RedirectURI is the redirect URI. If none is specified, the Greenhouse ID proxy will be used.
-                      type: string
-                  required:
-                    - clientIDReference
-                    - clientSecretReference
-                    - issuer
-                  type: object
-              type: object
-            description:
-              description: Description provides additional details of the organization.
-              type: string
-            displayName:
-              description: DisplayName is an optional name for the organization to be displayed in the Greenhouse UI. Defaults to a normalized version of metadata.name.
-              type: string
-            mappedOrgAdminIdPGroup:
-              description: MappedOrgAdminIDPGroup is the IDP group ID identifying org admins
-              type: string
-          type: object
-        status:
-          description: OrganizationStatus defines the observed state of an Organization
-          type: object
-      type: object
-    TeamRole:
-      xml:
-        name: greenhouse.sap
-        namespace: v1alpha1
-      title: TeamRole
-      description: TeamRole is the Schema for the TeamRoles API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: TeamRoleSpec defines the desired state of a TeamRole
-          properties:
-            rules:
-              description: Rules is a list of rbacv1.PolicyRules used on a managed RBAC (Cluster)Role
-              items:
-                description: PolicyRule holds information that describes a policy rule, but does not contain information about who the rule applies to or which namespace the rule applies to.
-                properties:
-                  apiGroups:
-                    description: APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of the enumerated resources in any API group will be allowed. "" represents the core API group and "*" represents all API groups.
-                    items:
-                      type: string
-                    type: array
-                  nonResourceURLs:
-                    description: NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path Since non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding. Rules can either apply to API resources (such as "pods" or "secrets") or non-resource URL paths (such as "/api"),  but not both.
-                    items:
-                      type: string
-                    type: array
-                  resourceNames:
-                    description: ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.
-                    items:
-                      type: string
-                    type: array
-                  resources:
-                    description: Resources is a list of resources this rule applies to. '*' represents all resources.
-                    items:
-                      type: string
-                    type: array
-                  verbs:
-                    description: Verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs.
-                    items:
-                      type: string
-                    type: array
-                required:
-                  - verbs
-                type: object
-              type: array
-          type: object
-        status:
-          description: TeamRoleStatus defines the observed state of a TeamRole
-          type: object
-      type: object
-    PluginPreset:
-      xml:
-        name: greenhouse.sap
-        namespace: v1alpha1
-      title: PluginPreset
-      description: PluginPreset is the Schema for the PluginPresets API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: PluginPresetSpec defines the desired state of PluginPreset
-          properties:
-            clusterSelector:
-              description: ClusterSelector is a label selector to select the clusters the plugin bundle should be deployed to.
-              properties:
-                matchExpressions:
-                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                  items:
-                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
-                    properties:
-                      key:
-                        description: key is the label key that the selector applies to.
-                        type: string
-                      operator:
-                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
-                        type: string
-                      values:
-                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
-                        items:
-                          type: string
-                        type: array
-                    required:
-                      - key
-                      - operator
-                    type: object
-                  type: array
-                matchLabels:
-                  additionalProperties:
-                    type: string
-                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
-                  type: object
-              type: object
-              x-kubernetes-map-type: atomic
-            plugin:
-              description: PluginSpec is the spec of the plugin to be deployed by the PluginPreset.
-              properties:
-                clusterName:
-                  description: ClusterName is the name of the cluster the plugin is deployed to. If not set, the plugin is deployed to the greenhouse cluster.
-                  type: string
-                disabled:
-                  description: Disabled indicates that the plugin is administratively disabled.
-                  type: boolean
-                displayName:
-                  description: DisplayName is an optional name for the Plugin to be displayed in the Greenhouse UI. This is especially helpful to distinguish multiple instances of a PluginDefinition in the same context. Defaults to a normalized version of metadata.name.
-                  type: string
-                optionValues:
-                  description: Values are the values for a PluginDefinition instance.
-                  items:
-                    description: PluginOptionValue is the value for a PluginOption.
-                    properties:
-                      name:
-                        description: Name of the values.
-                        type: string
-                      value:
-                        description: Value is the actual value in plain text.
-                        x-kubernetes-preserve-unknown-fields: true
-                      valueFrom:
-                        description: ValueFrom references a potentially confidential value in another source.
-                        properties:
-                          secret:
-                            description: Secret references the secret containing the value.
-                            properties:
-                              key:
-                                description: Key in the secret to select the value from.
-                                type: string
-                              name:
-                                description: Name of the secret in the same namespace.
-                                type: string
-                            required:
-                              - key
-                              - name
-                            type: object
-                        type: object
-                    required:
-                      - name
-                    type: object
-                  type: array
-                pluginDefinition:
-                  description: PluginDefinition is the name of the PluginDefinition this instance is for.
-                  type: string
-                releaseNamespace:
-                  description: ReleaseNamespace is the namespace in the remote cluster to which the backend is deployed. Defaults to the Greenhouse managed namespace if not set.
-                  type: string
-              required:
-                - disabled
-                - pluginDefinition
-              type: object
-          required:
-            - clusterSelector
-            - plugin
-          type: object
-        status:
-          description: PluginPresetStatus defines the observed state of PluginPreset
-          properties:
-            statusConditions:
-              description: StatusConditions contain the different conditions that constitute the status of the PluginPreset.
-              properties:
-                conditions:
-                  items:
-                    description: Condition contains additional information on the state of a resource.
-                    properties:
-                      lastTransitionTime:
-                        description: LastTransitionTime is the last time the condition transitioned from one status to another.
-                        format: date-time
-                        type: string
-                      message:
-                        description: Message is an optional human readable message indicating details about the last transition.
-                        type: string
-                      reason:
-                        description: Reason is a one-word, CamelCase reason for the condition's last transition.
-                        type: string
-                      status:
-                        description: Status of the condition.
-                        type: string
-                      type:
-                        description: Type of the condition.
-                        type: string
-                    required:
-                      - lastTransitionTime
-                      - status
-                      - type
-                    type: object
-                  type: array
-                  x-kubernetes-list-map-keys:
-                    - type
-                  x-kubernetes-list-type: map
-              type: object
-          type: object
-      type: object
     Cluster:
       xml:
         name: greenhouse.sap
@@ -528,10 +59,10 @@ components:
       description: Cluster is the Schema for the clusters API
       properties:
         apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          description: 'APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
-          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          description: 'Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object
@@ -679,6 +210,82 @@ components:
               type: object
           type: object
       type: object
+    Organization:
+      xml:
+        name: greenhouse.sap
+        namespace: v1alpha1
+      title: Organization
+      description: Organization is the Schema for the organizations API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: OrganizationSpec defines the desired state of Organization
+          properties:
+            authentication:
+              description: Authentication configures the organizations authentication mechanism.
+              properties:
+                oidc:
+                  description: OIDConfig configures the OIDC provider.
+                  properties:
+                    clientIDReference:
+                      description: ClientIDReference references the Kubernetes secret containing the client id.
+                      properties:
+                        key:
+                          description: Key in the secret to select the value from.
+                          type: string
+                        name:
+                          description: Name of the secret in the same namespace.
+                          type: string
+                      required:
+                        - key
+                        - name
+                      type: object
+                    clientSecretReference:
+                      description: ClientSecretReference references the Kubernetes secret containing the client secret.
+                      properties:
+                        key:
+                          description: Key in the secret to select the value from.
+                          type: string
+                        name:
+                          description: Name of the secret in the same namespace.
+                          type: string
+                      required:
+                        - key
+                        - name
+                      type: object
+                    issuer:
+                      description: Issuer is the URL of the identity service.
+                      type: string
+                    redirectURI:
+                      description: RedirectURI is the redirect URI.\nIf none is specified, the Greenhouse ID proxy will be used.
+                      type: string
+                  required:
+                    - clientIDReference
+                    - clientSecretReference
+                    - issuer
+                  type: object
+              type: object
+            description:
+              description: Description provides additional details of the organization.
+              type: string
+            displayName:
+              description: DisplayName is an optional name for the organization to be displayed in the Greenhouse UI.\nDefaults to a normalized version of metadata.name.
+              type: string
+            mappedOrgAdminIdPGroup:
+              description: MappedOrgAdminIDPGroup is the IDP group ID identifying org admins
+              type: string
+          type: object
+        status:
+          description: OrganizationStatus defines the observed state of an Organization
+          type: object
+      type: object
     PluginDefinition:
       xml:
         name: greenhouse.sap
@@ -687,10 +294,10 @@ components:
       description: PluginDefinition is the Schema for the PluginDefinitions API
       properties:
         apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          description: 'APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
-          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          description: 'Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object
@@ -704,7 +311,7 @@ components:
               description: DisplayName provides a human-readable label for the pluginDefinition.
               type: string
             docMarkDownUrl:
-              description: DocMarkDownUrl specifies the URL to the markdown documentation file for this plugin. Source needs to allow all CORS origins.
+              description: DocMarkDownUrl specifies the URL to the markdown documentation file for this plugin.\nSource needs to allow all CORS origins.
               type: string
             helmChart:
               description: HelmChart specifies where the Helm Chart for this pluginDefinition can be found.
@@ -724,7 +331,7 @@ components:
                 - version
               type: object
             icon:
-              description: 'Icon specifies the icon to be used for this plugin in the Greenhouse UI. Icons can be either: - A string representing a juno icon in camel case from this list: https://github.com/sapcc/juno/blob/main/libs/juno-ui-components/src/components/Icon/Icon.component.js#L6-L52 - A publicly accessable image reference to a .png file. Will be displayed 100x100px'
+              description: 'Icon specifies the icon to be used for this plugin in the Greenhouse UI.\nIcons can be either:\n- A string representing a juno icon in camel case from this list: https://github.com/sapcc/juno/blob/main/libs/juno-ui-components/src/components/Icon/Icon.component.js#L6-L52\n- A publicly accessable image reference to a .png file. Will be displayed 100x100px'
               type: string
             options:
               description: RequiredValues is a list of values required to create an instance of this PluginDefinition.
@@ -771,7 +378,7 @@ components:
                   description: Name of the UI application.
                   type: string
                 url:
-                  description: URL specifies the url to a built javascript asset. By default, assets are loaded from the Juno asset server using the provided name and version.
+                  description: URL specifies the url to a built javascript asset.\nBy default, assets are loaded from the Juno asset server using the provided name and version.
                   type: string
                 version:
                   description: Version of the frontend application.
@@ -784,7 +391,7 @@ components:
               description: Version of this pluginDefinition
               type: string
             weight:
-              description: Weight configures the order in which Plugins are shown in the Greenhouse UI. Defaults to alphabetical sorting if not provided or on conflict.
+              description: Weight configures the order in which Plugins are shown in the Greenhouse UI.\nDefaults to alphabetical sorting if not provided or on conflict.
               format: int32
               type: integer
           required:
@@ -794,33 +401,340 @@ components:
           description: PluginDefinitionStatus defines the observed state of PluginDefinition
           type: object
       type: object
-    Team:
+    PluginPreset:
       xml:
         name: greenhouse.sap
         namespace: v1alpha1
-      title: Team
-      description: Team is the Schema for the teams API
+      title: PluginPreset
+      description: PluginPreset is the Schema for the PluginPresets API
       properties:
         apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          description: 'APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
-          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          description: 'Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object
         spec:
-          description: TeamSpec defines the desired state of Team
+          description: PluginPresetSpec defines the desired state of PluginPreset
           properties:
-            description:
-              description: Description provides additional details of the team.
-              type: string
-            mappedIdPGroup:
-              description: IdP group id matching team.
-              type: string
+            clusterSelector:
+              description: ClusterSelector is a label selector to select the clusters the plugin bundle should be deployed to.
+              properties:
+                matchExpressions:
+                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                  items:
+                    description: A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.
+                    properties:
+                      key:
+                        description: key is the label key that the selector applies to.
+                        type: string
+                      operator:
+                        description: operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.
+                        type: string
+                      values:
+                        description: values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.
+                        items:
+                          type: string
+                        type: array
+                    required:
+                      - key
+                      - operator
+                    type: object
+                  type: array
+                matchLabels:
+                  additionalProperties:
+                    type: string
+                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is "key", the\noperator is "In", and the values array contains only "value". The requirements are ANDed.
+                  type: object
+              type: object
+              x-kubernetes-map-type: atomic
+            plugin:
+              description: PluginSpec is the spec of the plugin to be deployed by the PluginPreset.
+              properties:
+                clusterName:
+                  description: ClusterName is the name of the cluster the plugin is deployed to. If not set, the plugin is deployed to the greenhouse cluster.
+                  type: string
+                disabled:
+                  description: Disabled indicates that the plugin is administratively disabled.
+                  type: boolean
+                displayName:
+                  description: DisplayName is an optional name for the Plugin to be displayed in the Greenhouse UI.\nThis is especially helpful to distinguish multiple instances of a PluginDefinition in the same context.\nDefaults to a normalized version of metadata.name.
+                  type: string
+                optionValues:
+                  description: Values are the values for a PluginDefinition instance.
+                  items:
+                    description: PluginOptionValue is the value for a PluginOption.
+                    properties:
+                      name:
+                        description: Name of the values.
+                        type: string
+                      value:
+                        description: Value is the actual value in plain text.
+                        x-kubernetes-preserve-unknown-fields: true
+                      valueFrom:
+                        description: ValueFrom references a potentially confidential value in another source.
+                        properties:
+                          secret:
+                            description: Secret references the secret containing the value.
+                            properties:
+                              key:
+                                description: Key in the secret to select the value from.
+                                type: string
+                              name:
+                                description: Name of the secret in the same namespace.
+                                type: string
+                            required:
+                              - key
+                              - name
+                            type: object
+                        type: object
+                    required:
+                      - name
+                    type: object
+                  type: array
+                pluginDefinition:
+                  description: PluginDefinition is the name of the PluginDefinition this instance is for.
+                  type: string
+                releaseNamespace:
+                  description: ReleaseNamespace is the namespace in the remote cluster to which the backend is deployed.\nDefaults to the Greenhouse managed namespace if not set.
+                  type: string
+              required:
+                - disabled
+                - pluginDefinition
+              type: object
+          required:
+            - clusterSelector
+            - plugin
           type: object
         status:
-          description: TeamStatus defines the observed state of Team
+          description: PluginPresetStatus defines the observed state of PluginPreset
+          properties:
+            statusConditions:
+              description: StatusConditions contain the different conditions that constitute the status of the PluginPreset.
+              properties:
+                conditions:
+                  items:
+                    description: Condition contains additional information on the state of a resource.
+                    properties:
+                      lastTransitionTime:
+                        description: LastTransitionTime is the last time the condition transitioned from one status to another.
+                        format: date-time
+                        type: string
+                      message:
+                        description: Message is an optional human readable message indicating details about the last transition.
+                        type: string
+                      reason:
+                        description: Reason is a one-word, CamelCase reason for the condition's last transition.
+                        type: string
+                      status:
+                        description: Status of the condition.
+                        type: string
+                      type:
+                        description: Type of the condition.
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+              type: object
+          type: object
+      type: object
+    Plugin:
+      xml:
+        name: greenhouse.sap
+        namespace: v1alpha1
+      title: Plugin
+      description: Plugin is the Schema for the plugins API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: PluginSpec defines the desired state of Plugin
+          properties:
+            clusterName:
+              description: ClusterName is the name of the cluster the plugin is deployed to. If not set, the plugin is deployed to the greenhouse cluster.
+              type: string
+            disabled:
+              description: Disabled indicates that the plugin is administratively disabled.
+              type: boolean
+            displayName:
+              description: DisplayName is an optional name for the Plugin to be displayed in the Greenhouse UI.\nThis is especially helpful to distinguish multiple instances of a PluginDefinition in the same context.\nDefaults to a normalized version of metadata.name.
+              type: string
+            optionValues:
+              description: Values are the values for a PluginDefinition instance.
+              items:
+                description: PluginOptionValue is the value for a PluginOption.
+                properties:
+                  name:
+                    description: Name of the values.
+                    type: string
+                  value:
+                    description: Value is the actual value in plain text.
+                    x-kubernetes-preserve-unknown-fields: true
+                  valueFrom:
+                    description: ValueFrom references a potentially confidential value in another source.
+                    properties:
+                      secret:
+                        description: Secret references the secret containing the value.
+                        properties:
+                          key:
+                            description: Key in the secret to select the value from.
+                            type: string
+                          name:
+                            description: Name of the secret in the same namespace.
+                            type: string
+                        required:
+                          - key
+                          - name
+                        type: object
+                    type: object
+                required:
+                  - name
+                type: object
+              type: array
+            pluginDefinition:
+              description: PluginDefinition is the name of the PluginDefinition this instance is for.
+              type: string
+            releaseNamespace:
+              description: ReleaseNamespace is the namespace in the remote cluster to which the backend is deployed.\nDefaults to the Greenhouse managed namespace if not set.
+              type: string
+          required:
+            - disabled
+            - pluginDefinition
+          type: object
+        status:
+          description: PluginStatus defines the observed state of Plugin
+          properties:
+            description:
+              description: Description provides additional details of the plugin.
+              type: string
+            exposedServices:
+              additionalProperties:
+                description: Service references a Kubernetes service of a Plugin.
+                properties:
+                  name:
+                    description: Name is the name of the service in the target cluster.
+                    type: string
+                  namespace:
+                    description: Namespace is the namespace of the service in the target cluster.
+                    type: string
+                  port:
+                    description: Port is the port of the service.
+                    format: int32
+                    type: integer
+                  protocol:
+                    description: Protocol is the protocol of the service.
+                    type: string
+                required:
+                  - name
+                  - namespace
+                  - port
+                type: object
+              description: ExposedServices provides an overview of the Plugins services that are centrally exposed.\nIt maps the exposed URL to the service found in the manifest.
+              type: object
+            helmChart:
+              description: HelmChart contains a reference the helm chart used for the deployed pluginDefinition version.
+              properties:
+                name:
+                  description: Name of the HelmChart chart.
+                  type: string
+                repository:
+                  description: Repository of the HelmChart chart.
+                  type: string
+                version:
+                  description: Version of the HelmChart chart.
+                  type: string
+              required:
+                - name
+                - repository
+                - version
+              type: object
+            helmReleaseStatus:
+              description: HelmReleaseStatus reflects the status of the latest HelmChart release.\nThis is only configured if the pluginDefinition is backed by HelmChart.
+              properties:
+                firstDeployed:
+                  description: FirstDeployed is the timestamp of the first deployment of the release.
+                  format: date-time
+                  type: string
+                lastDeployed:
+                  description: LastDeployed is the timestamp of the last deployment of the release.
+                  format: date-time
+                  type: string
+                status:
+                  description: Status is the status of a HelmChart release.
+                  type: string
+              required:
+                - status
+              type: object
+            statusConditions:
+              description: StatusConditions contain the different conditions that constitute the status of the Plugin.
+              properties:
+                conditions:
+                  items:
+                    description: Condition contains additional information on the state of a resource.
+                    properties:
+                      lastTransitionTime:
+                        description: LastTransitionTime is the last time the condition transitioned from one status to another.
+                        format: date-time
+                        type: string
+                      message:
+                        description: Message is an optional human readable message indicating details about the last transition.
+                        type: string
+                      reason:
+                        description: Reason is a one-word, CamelCase reason for the condition's last transition.
+                        type: string
+                      status:
+                        description: Status of the condition.
+                        type: string
+                      type:
+                        description: Type of the condition.
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+              type: object
+            uiApplication:
+              description: UIApplication contains a reference to the frontend that is used for the deployed pluginDefinition version.
+              properties:
+                name:
+                  description: Name of the UI application.
+                  type: string
+                url:
+                  description: URL specifies the url to a built javascript asset.\nBy default, assets are loaded from the Juno asset server using the provided name and version.
+                  type: string
+                version:
+                  description: Version of the frontend application.
+                  type: string
+              required:
+                - name
+                - version
+              type: object
+            version:
+              description: Version contains the latest pluginDefinition version the config was last applied with successfully.
+              type: string
+            weight:
+              description: Weight configures the order in which Plugins are shown in the Greenhouse UI.
+              format: int32
+              type: integer
           type: object
       type: object
     TeamMembership:
@@ -831,10 +745,10 @@ components:
       description: TeamMembership is the Schema for the teammemberships API
       properties:
         apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          description: 'APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
-          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          description: 'Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object
@@ -887,10 +801,10 @@ components:
       description: TeamRoleBinding is the Schema for the rolebindings API
       properties:
         apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          description: 'APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
-          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          description: 'Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object
@@ -914,5 +828,91 @@ components:
           type: object
         status:
           description: TeamRoleBindingStatus defines the observed state of the TeamRoleBinding
+          type: object
+      type: object
+    TeamRole:
+      xml:
+        name: greenhouse.sap
+        namespace: v1alpha1
+      title: TeamRole
+      description: TeamRole is the Schema for the TeamRoles API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: TeamRoleSpec defines the desired state of a TeamRole
+          properties:
+            rules:
+              description: Rules is a list of rbacv1.PolicyRules used on a managed RBAC (Cluster)Role
+              items:
+                description: PolicyRule holds information that describes a policy rule, but does not contain information\nabout who the rule applies to or which namespace the rule applies to.
+                properties:
+                  apiGroups:
+                    description: APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of\nthe enumerated resources in any API group will be allowed. "" represents the core API group and "*" represents all API groups.
+                    items:
+                      type: string
+                    type: array
+                  nonResourceURLs:
+                    description: NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path\nSince non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding.\nRules can either apply to API resources (such as "pods" or "secrets") or non-resource URL paths (such as "/api"),  but not both.
+                    items:
+                      type: string
+                    type: array
+                  resourceNames:
+                    description: ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.
+                    items:
+                      type: string
+                    type: array
+                  resources:
+                    description: Resources is a list of resources this rule applies to. '*' represents all resources.
+                    items:
+                      type: string
+                    type: array
+                  verbs:
+                    description: Verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs.
+                    items:
+                      type: string
+                    type: array
+                required:
+                  - verbs
+                type: object
+              type: array
+          type: object
+        status:
+          description: TeamRoleStatus defines the observed state of a TeamRole
+          type: object
+      type: object
+    Team:
+      xml:
+        name: greenhouse.sap
+        namespace: v1alpha1
+      title: Team
+      description: Team is the Schema for the teams API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: TeamSpec defines the desired state of Team
+          properties:
+            description:
+              description: Description provides additional details of the team.
+              type: string
+            mappedIdPGroup:
+              description: IdP group id matching team.
+              type: string
+          type: object
+        status:
+          description: TeamStatus defines the observed state of Team
           type: object
       type: object

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloudoperators/greenhouse
 
-go 1.21
+go 1.22
 
 replace (
 	// DEX import matches version v2.39.1.


### PR DESCRIPTION
## Description
This PR bumps GO to v1.22. 
Now we can use sigs-k/controller-tools v0.15 in the Makefile.
_Dockerfile.dev-env_ can be unpinned to use sigs-k/controller-runtime@latest


Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [x] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->
- Related Issue # (issue)
- Closes # (issue)
- Fixes # (issue)

> Remove if not applicable

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [x] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
