### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,27 +3,27 @@
 *                       @cloudoperators/Administrators
 
 /.github/               @cloudoperators/Administrators
-/.github/workflows/     @auhlig @ivogoman @kengou @onuryilmaz @uwe-mayer
-/.github/labeler.yml    @auhlig @ivogoman @kengou @onuryilmaz @uwe-mayer
-/.github/licenserc.yaml @auhlig @ivogoman @kengou @onuryilmaz @uwe-mayer
-/.github/renovate.json  @auhlig @ivogoman @kengou @onuryilmaz @uwe-mayer
+/.github/workflows/     @cloudoperators/greenhouse-backend
+/.github/labeler.yml    @cloudoperators/greenhouse-backend
+/.github/licenserc.yaml @cloudoperators/greenhouse-backend
+/.github/renovate.json  @cloudoperators/greenhouse-backend
 
-/ui/                    @andypf @artiereus @edda @hodanoori @tilmanhaupt @uwe-mayer
+/ui/                    @cloudoperators/greenhouse-frontend @uwe-mayer
 
-/docs/                  @andypf @artiereus @auhlig @edda @hodanoori @ivogoman @kengou @onuryilmaz @tilmanhaupt @uwe-mayer
-/website/               @andypf @artiereus @auhlig @edda @hodanoori @ivogoman @kengou @onuryilmaz @tilmanhaupt @uwe-mayer
-.gitignore              @andypf @artiereus @auhlig @edda @hodanoori @ivogoman @kengou @onuryilmaz @tilmanhaupt @uwe-mayer
+/docs/                  @cloudoperators/greenhouse-core
+/website/               @cloudoperators/greenhouse-core
+.gitignore              @cloudoperators/greenhouse-core
+/README.md              @cloudoperators/greenhouse-core
 
-/docs/reference/api     @auhlig @ivogoman @kengou @onuryilmaz @uwe-mayer
-/charts/                @auhlig @ivogoman @kengou @onuryilmaz @uwe-mayer
-/cmd/                   @auhlig @ivogoman @kengou @onuryilmaz @uwe-mayer
-/grafana/               @auhlig @ivogoman @kengou @onuryilmaz @uwe-mayer
-/hack/                  @auhlig @ivogoman @kengou @onuryilmaz @uwe-mayer
-/pkg/                   @auhlig @ivogoman @kengou @onuryilmaz @uwe-mayer
-/ct.yaml                @auhlig @ivogoman @kengou @onuryilmaz @uwe-mayer
-/Dockerfile             @auhlig @ivogoman @kengou @onuryilmaz @uwe-mayer
-/Dockerfile.*           @auhlig @ivogoman @kengou @onuryilmaz @uwe-mayer
-/Makefile               @auhlig @ivogoman @kengou @onuryilmaz @uwe-mayer
-/PROJECT                @auhlig @ivogoman @kengou @onuryilmaz @uwe-mayer
-/README.md              @auhlig @ivogoman @kengou @onuryilmaz @uwe-mayer
-/go.*                   @auhlig @ivogoman @kengou @onuryilmaz @uwe-mayer
+/docs/reference/api     @cloudoperators/greenhouse-backend
+/charts/                @cloudoperators/greenhouse-backend
+/cmd/                   @cloudoperators/greenhouse-backend
+/grafana/               @cloudoperators/greenhouse-backend
+/hack/                  @cloudoperators/greenhouse-backend
+/pkg/                   @cloudoperators/greenhouse-backend
+/ct.yaml                @cloudoperators/greenhouse-backend
+/Dockerfile             @cloudoperators/greenhouse-backend
+/Dockerfile.*           @cloudoperators/greenhouse-backend
+/Makefile               @cloudoperators/greenhouse-backend
+/PROJECT                @cloudoperators/greenhouse-backend
+/go.*                   @cloudoperators/greenhouse-backend


### PR DESCRIPTION
This PR changes the codeowners to teams to have a central place to administrate permissions across repositories.