### PR TITLE
feat(plugin): make exposed port configurable by name

### DIFF
--- a/pkg/apis/well_known.go
+++ b/pkg/apis/well_known.go
@@ -55,7 +55,7 @@ const (
 	// LabelKeyExposeService is applied to services that are part of a PluginDefinitions Helm chart to expose them via the central Greenhouse infrastructure.
 	LabelKeyExposeService = "greenhouse.sap/expose"
 
-	// LabelKeyExposePortName is specifying the port to be exposed by name. LabelKeyExposeService needs to be set. By default the first port is always exposed.
+	// LabelKeyExposePortName is specifying the port to be exposed by name. LabelKeyExposeService needs to be set. Defaults to the first port if the named port is not found.
 	LabelKeyExposePortName = "greenhouse.sap/exposePortName"
 )
 

--- a/pkg/apis/well_known.go
+++ b/pkg/apis/well_known.go
@@ -54,6 +54,9 @@ const (
 
 	// LabelKeyExposeService is applied to services that are part of a PluginDefinitions Helm chart to expose them via the central Greenhouse infrastructure.
 	LabelKeyExposeService = "greenhouse.sap/expose"
+
+	// LabelKeyExposePortName is specifying the port to be exposed by name. LabelKeyExposeService needs to be set. By default the first port is always exposed.
+	LabelKeyExposePortName = "greenhouse.sap/exposePortName"
 )
 
 // TeamRole and TeamRoleBinding constants

--- a/pkg/apis/well_known.go
+++ b/pkg/apis/well_known.go
@@ -55,8 +55,8 @@ const (
 	// LabelKeyExposeService is applied to services that are part of a PluginDefinitions Helm chart to expose them via the central Greenhouse infrastructure.
 	LabelKeyExposeService = "greenhouse.sap/expose"
 
-	// LabelKeyExposePortName is specifying the port to be exposed by name. LabelKeyExposeService needs to be set. Defaults to the first port if the named port is not found.
-	LabelKeyExposePortName = "greenhouse.sap/exposePortName"
+	// LabelKeyExposeNamedPort is specifying the port to be exposed by name. LabelKeyExposeService needs to be set. Defaults to the first port if the named port is not found.
+	LabelKeyExposeNamedPort = "greenhouse.sap/exposeNamedPort"
 )
 
 // TeamRole and TeamRoleBinding constants

--- a/pkg/controllers/plugin/util.go
+++ b/pkg/controllers/plugin/util.go
@@ -5,12 +5,13 @@ package plugin
 
 import (
 	"fmt"
-	"regexp"
 
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+
+	greenhouseapis "github.com/cloudoperators/greenhouse/pkg/apis"
 )
 
 func getPortForExposedService(o runtime.Object) (*corev1.ServicePort, error) {
@@ -24,13 +25,7 @@ func getPortForExposedService(o runtime.Object) (*corev1.ServicePort, error) {
 	}
 
 	//Check for matching of named port set by label
-	r, _ := regexp.Compile("/exposeNamedPort")
-	var namedPort string
-	for labelName, labelValue := range svc.Labels {
-		if r.MatchString(labelName) {
-			namedPort = labelValue
-		}
-	}
+	var namedPort string = svc.Labels[greenhouseapis.LabelKeyExposeNamedPort]
 
 	if namedPort != "" {
 		for _, port := range svc.Spec.Ports {

--- a/pkg/controllers/plugin/util.go
+++ b/pkg/controllers/plugin/util.go
@@ -10,6 +10,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+
+	greenhouseapis "github.com/cloudoperators/greenhouse/pkg/apis"
 )
 
 func getPortForExposedService(o runtime.Object) (*corev1.ServicePort, error) {
@@ -17,10 +19,20 @@ func getPortForExposedService(o runtime.Object) (*corev1.ServicePort, error) {
 	if err != nil {
 		return nil, err
 	}
-	// For now, always use the first port.
+
 	if svc.Spec.Ports == nil || len(svc.Spec.Ports) == 0 {
 		return nil, errors.New("service has no ports")
 	}
+	// Check for matching of named port set by label
+	if greenhouseapis.LabelKeyExposePortName != "" {
+		for _, port := range svc.Spec.Ports {
+			if port.Name == greenhouseapis.LabelKeyExposePortName {
+				return port.DeepCopy(), nil
+			}
+		}
+	}
+
+	// Default to first port
 	return svc.Spec.Ports[0].DeepCopy(), nil
 }
 

--- a/pkg/controllers/plugin/util_test.go
+++ b/pkg/controllers/plugin/util_test.go
@@ -39,4 +39,46 @@ var _ = Describe("validate utility functions", Ordered, func() {
 		Ω(port.Port).
 			Should(Equal(portNumber), "the port should be 80")
 	})
+	It("should get named port from an unstructured service object", func() {
+		var portNumber1 int32 = 80
+		var portNumber2 int32 = 443
+		// Mock an unstructured object with ports
+		unstructuredObj := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Service",
+				"metadata": map[string]interface{}{
+					"name":      "example-service",
+					"namespace": "default",
+					"labels": map[string]string{
+						"greenhouse.sap/exposeNamedPort": "https",
+					},
+				},
+				"spec": map[string]interface{}{
+					"type": "ClusterIP",
+					"ports": []interface{}{
+						map[string]interface{}{
+							"name":     "http",
+							"port":     portNumber1,
+							"protocol": "TCP",
+						},
+						map[string]interface{}{
+							"name":     "https",
+							"port":     portNumber2,
+							"protocol": "TCP",
+						},
+					},
+				},
+			},
+		}
+		port, err := getPortForExposedService(unstructuredObj)
+		Ω(err).
+			ShouldNot(HaveOccurred(), "there should be no error getting ports from an unstructured service object")
+		Ω(port).
+			ShouldNot(BeNil(), "the port should not be nil")
+		Ω(port).
+			ShouldNot(Equal(portNumber1), "the port should not be 80")
+		Ω(port.Port).
+			Should(Equal(portNumber2), "the port should be 443")
+	})
 })


### PR DESCRIPTION
## Description
This PR adds the feature to specify a port by name for being exposed. Beforehand it would always default to the first port.


## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert


## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Added to documentation?

https://github.com/cloudoperators/greenhouse-extensions/pull/173

- [ ] 📜 README.md
- [x] 🤝 Documentation pages updated
- [ ] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
