### PR TITLE
fix(team-membership): Do not spin up pods on failure

### DIFF
--- a/charts/team-membership/templates/cronjob.yaml
+++ b/charts/team-membership/templates/cronjob.yaml
@@ -56,5 +56,5 @@ spec:
             - /team-membership
             resources:
               {{- toYaml .Values.resources | nindent 14 }}
-          restartPolicy: "Never"
+          restartPolicy: "OnFailure"
       


### PR DESCRIPTION
## Description
This PR stops the team-membership cronjob to spin up new pods when they fail.

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

