### PR TITLE
fix(plugin): remove cluster validation during update

### DIFF
--- a/pkg/admission/plugin_webhook.go
+++ b/pkg/admission/plugin_webhook.go
@@ -125,9 +125,7 @@ func ValidateUpdatePlugin(ctx context.Context, c client.Client, old, obj runtime
 	if errList := validatePluginOptionValues(plugin.Spec.OptionValues, pluginDefinition); len(errList) > 0 {
 		return allWarns, apierrors.NewInvalid(plugin.GroupVersionKind().GroupKind(), plugin.Name, errList)
 	}
-	if err := validatePluginForCluster(ctx, c, plugin, pluginDefinition); err != nil {
-		return allWarns, err
-	}
+
 	if err := validateImmutableField(oldPlugin.Spec.ClusterName, plugin.Spec.ClusterName,
 		field.NewPath("spec", "clusterName"),
 	); err != nil {

--- a/pkg/admission/plugin_webhook_test.go
+++ b/pkg/admission/plugin_webhook_test.go
@@ -317,17 +317,19 @@ var _ = Describe("Validate pluginConfig clusterName", Ordered, func() {
 		}).Should(HaveKeyWithValue(greenhouseapis.LabelKeyCluster, "test-cluster"), "the plugin should have a matching cluster label")
 	})
 
-	It("should reject a plugin update with a wrong cluster name reference", func() {
+	It("should reject a plugin update where the clusterName changes", func() {
 		testPlugin.Spec.ClusterName = "wrong-cluster-name"
 		err := test.K8sClient.Update(test.Ctx, testPlugin)
 
-		expectClusterNotFoundError(err)
+		Expect(err).ToNot(BeNil(), "there should be an error changing the plugin's clusterName")
+		Expect(err.Error()).To(ContainSubstring("field is immutable"))
 	})
 
 	It("should not allow deletion of the clusterName reference in existing plugin", func() {
 		testPlugin.Spec.ClusterName = ""
 		err := test.K8sClient.Update(test.Ctx, testPlugin)
-		expectClusterMustBeSetError(err)
+		Expect(err).ToNot(BeNil(), "there should be an error changing the plugin's clusterName")
+		Expect(err.Error()).To(ContainSubstring("field is immutable"))
 		// reset the clusterName for following tests to pass
 		testPlugin.Spec.ClusterName = "test-cluster"
 	})


### PR DESCRIPTION
## Description

If the cluster was deleted before uninstalling the plugin then it is no longer possible to edit/delete the plugins. This fix ensures the cluster is only validated during creation. During updates it must only be ensured the cluster ref was not altered.


## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->
- Related Issue # (issue)
- Closes # (issue)
- Fixes # (issue)

> Remove if not applicable

## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [ ] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
