### PR TITLE
refac(helm): match no CRD error instead of string

### DIFF
--- a/pkg/helm/manifest.go
+++ b/pkg/helm/manifest.go
@@ -109,12 +109,7 @@ func loadManifest(restClientGetter genericclioptions.RESTClientGetter, namespace
 		Flatten().
 		Do().
 		IgnoreErrors(func(err error) bool {
-			// Ignore unknown schema errors if the CRD is not yet present.
-			// this does not work as the error is not wrapped see: https://github.com/kubernetes/kubernetes/issues/119505
-			// return meta.IsNoMatchError(err)
-			// Instead we check the error message for the string
-			return strings.Contains(err.Error(), "ensure CRDs are installed first") ||
-				strings.Contains(err.Error(), "no matches for")
+			return meta.IsNoMatchError(err)
 		})
 	if err := r.Err(); err != nil {
 		return nil, err


### PR DESCRIPTION
## Description

With 1.30 the NoKindMatchError is propagated by cli-runtime. Previously it was necessary to filter the error with string matching. https://github.com/kubernetes/kubernetes/pull/122569

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [x] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->
- Related Issue # (issue)
- Closes # (issue)
- Fixes # (issue)

> Remove if not applicable

## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [x] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
