### PR TITLE
fix(service-proxy): git sha does not always correspond to new image

### DIFF
--- a/pkg/controllers/organization/service_proxy_controller.go
+++ b/pkg/controllers/organization/service_proxy_controller.go
@@ -20,7 +20,6 @@ import (
 	greenhousesapv1alpha1 "github.com/cloudoperators/greenhouse/pkg/apis/greenhouse/v1alpha1"
 	"github.com/cloudoperators/greenhouse/pkg/clientutil"
 	"github.com/cloudoperators/greenhouse/pkg/common"
-	"github.com/cloudoperators/greenhouse/pkg/version"
 )
 
 // ServiceProxyReconciler reconciles a ServiceProxy Plugin for a Organization object
@@ -64,10 +63,6 @@ func (r *ServiceProxyReconciler) reconcileServiceProxy(ctx context.Context, org 
 	if err != nil {
 		return fmt.Errorf("failed to marshal domain: %w", err)
 	}
-	versionJSON, err := json.Marshal(version.GitCommit)
-	if err != nil {
-		return fmt.Errorf("failed to marshal version.GitCommit: %w", err)
-	}
 
 	plugin := &greenhousesapv1alpha1.Plugin{
 		ObjectMeta: metav1.ObjectMeta{
@@ -85,10 +80,6 @@ func (r *ServiceProxyReconciler) reconcileServiceProxy(ctx context.Context, org 
 			{
 				Name:  "domain",
 				Value: &apiextensionsv1.JSON{Raw: domainJSON},
-			},
-			{
-				Name:  "image.tag",
-				Value: &apiextensionsv1.JSON{Raw: versionJSON},
 			},
 		}
 		return controllerutil.SetControllerReference(org, plugin, r.Scheme())


### PR DESCRIPTION
## Description

The git SHA of Greenhouse must not always correspond to a new image version.
Container images are only build upon code changes, this leads to service proxy being updated with an invalid image tag.
The service proxy is installed via the Plugin Mechanism, so it is possible to pin the image version in https://github.com/cloudoperators/greenhouse-extensions/tree/main/service-proxy 

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->
- Related Issue # (issue)
- Closes # (issue)
- Fixes # (issue)

> Remove if not applicable

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [ ] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
