### PR TITLE
feat(service-proxy): add servicemonitor to collect metrics

### DIFF
--- a/charts/greenhouse/Chart.lock
+++ b/charts/greenhouse/Chart.lock
@@ -16,12 +16,12 @@ dependencies:
   version: 0.1.0
 - name: manager
   repository: file://../manager
-  version: 0.1.2
+  version: 0.1.3
 - name: ui
   repository: file://../ui
   version: 0.1.2
 - name: demo
   repository: file://../demo
   version: 0.1.0
-digest: sha256:a189510196279b43e907787d245f56d5b1776e9ab0bc29e0e604f3a74f0a6cca
-generated: "2024-04-26T16:29:50.217155+02:00"
+digest: sha256:a079bb340ae746347a50adf578d6e74c782de2db6696d9901ec7a347c064a956
+generated: "2024-07-10T10:33:52.454067+02:00"

--- a/charts/greenhouse/Chart.yaml
+++ b/charts/greenhouse/Chart.yaml
@@ -5,7 +5,7 @@ apiVersion: v2
 name: greenhouse
 description: A Helm chart for deploying greenhouse
 type: application
-version: 0.1.11
+version: 0.1.12
 appVersion: "0.1.0"
 
 dependencies:
@@ -30,7 +30,7 @@ dependencies:
     version: 0.1.0
     repository: "file://../tailscale-proxy"
   - name: manager
-    version: 0.1.2
+    version: 0.1.3
     repository: "file://../manager"
   - name: ui
     version: 0.1.2

--- a/charts/manager/Chart.yaml
+++ b/charts/manager/Chart.yaml
@@ -16,9 +16,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.2
+version: 0.1.3
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.1.2"
+appVersion: "0.1.3"

--- a/charts/manager/templates/servicemonitor.yaml
+++ b/charts/manager/templates/servicemonitor.yaml
@@ -24,4 +24,24 @@ spec:
     matchLabels:
       app: greenhouse
       {{- include "manager.selectorLabels" . | nindent 6 }}
+
+---
+
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: greenhouse-service-proxies
+  labels:
+    plugin: kube-monitoring
+spec:
+  endpoints:
+    - honorLabels: true
+      interval: 30s
+      port: metrics
+      scheme: http
+      path: /metrics
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: service-proxy
+      app.kubernetes.io/name: service-proxy
 {{ end }}


### PR DESCRIPTION
## Description

This adds a ServiceMonitor to the Greenhouse Manager chart. This monitor will detect all service-proxy instances deployed to the organization namespaces and expose the metrics in the Central Clusters Prometheus.

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->
- Related Issue # (issue)
- Closes # (issue)
- Fixes # (issue)

> Remove if not applicable

## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [ ] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
