### PR TITLE
fix(teamrbac): Remove cluster existence check

### DIFF
--- a/pkg/admission/teamrolebinding_webhook.go
+++ b/pkg/admission/teamrolebinding_webhook.go
@@ -112,17 +112,5 @@ func validateClusterNameOrSelector(ctx context.Context, c client.Client, rb *gre
 	if rb.Spec.ClusterName == "" && (len(rb.Spec.ClusterSelector.MatchLabels) == 0 && len(rb.Spec.ClusterSelector.MatchExpressions) == 0) {
 		return apierrors.NewInvalid(rb.GroupVersionKind().GroupKind(), rb.Name, field.ErrorList{field.Invalid(field.NewPath("spec", "clusterName"), rb.Spec.ClusterName, "must specify either spec.clusterName or spec.clusterSelector")})
 	}
-
-	if rb.Spec.ClusterName != "" {
-
-		// check if the referenced cluster exists
-		var cluster greenhousev1alpha1.Cluster
-		if err := c.Get(ctx, client.ObjectKey{Namespace: rb.Namespace, Name: rb.Spec.ClusterName}, &cluster); err != nil {
-			if apierrors.IsNotFound(err) {
-				return apierrors.NewInvalid(rb.GroupVersionKind().GroupKind(), rb.Name, field.ErrorList{field.Invalid(field.NewPath("spec", "clusterName"), rb.Spec.ClusterName, "cluster does not exist")})
-			}
-			return apierrors.NewInternalError(err)
-		}
-	}
 	return nil
 }

--- a/pkg/admission/teamrolebinding_webhook_test.go
+++ b/pkg/admission/teamrolebinding_webhook_test.go
@@ -108,23 +108,6 @@ var _ = Describe("Validate Create RoleBinding", Ordered, func() {
 			Expect(err).To(HaveOccurred(), "expected an error")
 			Expect(err).To(MatchError(ContainSubstring("cannot specify both spec.clusterName and spec.clusterSelector")))
 		})
-		It("should return an error if the cluster does not exist", func() {
-			rb := &greenhousev1alpha1.TeamRoleBinding{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: test.TestNamespace,
-					Name:      "testBinding",
-				},
-				Spec: greenhousev1alpha1.TeamRoleBindingSpec{
-					TeamRoleRef: testrolename,
-					TeamRef:     testteamname,
-					ClusterName: "non-existent-cluster",
-				},
-			}
-			warns, err := ValidateCreateRoleBinding(test.Ctx, test.K8sClient, rb)
-			Expect(warns).To(BeNil(), "expected no warnings")
-			Expect(err).To(HaveOccurred(), "expected an error")
-			Expect(err).To(MatchError(ContainSubstring("cluster does not exist")))
-		})
 	})
 })
 


### PR DESCRIPTION
## Description
The cluster existence check has been removed from TeamRoleBinding Admission. With the clusterSelector it cannot be ensured that this always matches. The controller is returning appropriate events and errors during reconciliation. The existence check blocks editing if the cluster no longer exists.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->
- Related Issue # (issue)
- Closes # (issue)
- Fixes # (issue)

> Remove if not applicable

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [x] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
