### PR TITLE
fix(ui): remove default verbose output on api calls

### DIFF
--- a/ui/.gitignore
+++ b/ui/.gitignore
@@ -1,5 +1,5 @@
 **/node_modules
-**/secretProps.json
+**/secretProps.json*
 **/build
 **/public/build/
 **/webhook-certs/

--- a/ui/cluster-admin/package-lock.json
+++ b/ui/cluster-admin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "greenhouse-cluster-admin",
-  "version": "1.6.12",
+  "version": "1.6.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "greenhouse-cluster-admin",
-      "version": "1.6.12",
+      "version": "1.6.13",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/jest": "^27.5.2",

--- a/ui/cluster-admin/package.json
+++ b/ui/cluster-admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "greenhouse-cluster-admin",
-  "version": "1.6.12",
+  "version": "1.6.13",
   "author": "Services-Team",
   "contributors": [
     "Uwe Mayer"

--- a/ui/cluster-admin/src/hooks/useApi.ts
+++ b/ui/cluster-admin/src/hooks/useApi.ts
@@ -17,7 +17,7 @@ export const useApi = (debug?: boolean) => {
   const { client: client } = useClient()
 
   // toggle verbosity
-  const isDebug = debug ?? true
+  const isDebug = debug ?? false
 
   const get = useCallback(
     async <T extends AllowedApiObject>(

--- a/ui/plugin-admin/package-lock.json
+++ b/ui/plugin-admin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "greenhouse-plugin-admin",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "greenhouse-plugin-admin",
-      "version": "1.0.10",
+      "version": "1.0.11",
       "license": "Apache-2.0",
       "dependencies": {
         "github-markdown-css": "^5.5.1",

--- a/ui/plugin-admin/package.json
+++ b/ui/plugin-admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "greenhouse-plugin-admin",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "author": "UI-Team",
   "contributors": [
     "Tilman Haupt"

--- a/ui/plugin-admin/secretProps.template.json
+++ b/ui/plugin-admin/secretProps.template.json
@@ -1,9 +1,9 @@
 {
-  "endpoint": "https://endpoint/api/v1",
+  "endpoint": "http://127.0.0.1:8090/",
+  "environment": "development",
   "appDependencies": {
     "auth": {
-      "authIssuerUrl": "https://auth.backend.com/",
-      "authClientId": "clientId"
+      "mock": true
     }
   }
 }

--- a/ui/plugin-admin/src/plugindefinitions/hooks/useApi.ts
+++ b/ui/plugin-admin/src/plugindefinitions/hooks/useApi.ts
@@ -17,7 +17,7 @@ export const useApi = (debug?: boolean) => {
   const { client: client } = useClient()
 
   // toggle verbosity
-  const isDebug = debug ?? true
+  const isDebug = debug ?? false
 
   const get = useCallback(
     async <T extends AllowedApiObject>(

--- a/ui/secret-admin/package-lock.json
+++ b/ui/secret-admin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "greenhouse-secret-admin",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "greenhouse-secret-admin",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "license": "Apache-2.0",
       "dependencies": {
         "github-markdown-css": "^5.5.1",

--- a/ui/secret-admin/package.json
+++ b/ui/secret-admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "greenhouse-secret-admin",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "author": "greenhouse",
   "contributors": [
     "Uwe Mayer"

--- a/ui/secret-admin/src/hooks/useApi.ts
+++ b/ui/secret-admin/src/hooks/useApi.ts
@@ -17,7 +17,7 @@ export const useApi = (debug?: boolean) => {
   const { client: client } = useClient()
 
   // toggle verbosity
-  const isDebug = debug ?? true
+  const isDebug = debug ?? false
 
   const get = useCallback(
     async <T extends AllowedApiObject>(


### PR DESCRIPTION
This sets default verbosity on UI API calls to `silent`

We use `GET` request to check if a user is authorized. We do not need a defaulted verbose output for failures.