### PR TITLE
fix(teamRBAC): ensure status updated on cluster not found

### DIFF
--- a/pkg/apis/greenhouse/v1alpha1/event_types.go
+++ b/pkg/apis/greenhouse/v1alpha1/event_types.go
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha1
+
+const (
+	// Success is used if the resource was successfully reconciled
+	SuccessEvent = "Success"
+	// FailedEvent is used if the resource reconciliation failed
+	FailedEvent = "Failed"
+	// SuccessfulDeletedEvent is used if the resource was deleted successfully
+	SuccessfulDeletedEvent = "SuccessfulDeleted"
+	// FailedDeleteFailedReason is used if the delete failed
+	FailedDeleteEvent = "FailedDelete"
+)

--- a/pkg/apis/greenhouse/v1alpha1/teamrolebinding_types.go
+++ b/pkg/apis/greenhouse/v1alpha1/teamrolebinding_types.go
@@ -86,6 +86,12 @@ const (
 	// RBACReconcileFailed is the condition reason for the TeamRoleBinding when not all of the rbacv1 resources have been successfully reconciled
 	RBACReconcileFailed ConditionReason = "RBACReconcileFailed"
 
+	// EmptyClusterList is the condition reason for a resource when the clusterSelector and clusterName do not provide any existing cluster
+	EmptyClusterList ConditionReason = "EmptyClusterList"
+
+	// TeamNotFound is the condition reason when the resources refers to a non-existing Team
+	TeamNotFound ConditionReason = "TeamNotFound"
+
 	// ClusterConnectionFailed is the condition reason for the TeamRoleBinding when the connection to the cluster failed
 	ClusterConnectionFailed ConditionReason = "ClusterConnectionFailed"
 
@@ -94,13 +100,4 @@ const (
 
 	// RoleBindingFailed is the condition reason for the TeamRoleBinding when the RoleBinding could not be created
 	RoleBindingFailed ConditionReason = "RoleBindingFailed"
-)
-
-const (
-	// ReconcileFailedReason is used if the reconcile failed
-	ReconcileFailedReason = "FailedReconcile"
-	// DeletedReason is used if the resource was deleted
-	DeletedReason = "Deleted"
-	// FailedDeleteFailedReason is used if the delete failed
-	DeleteFailedReason = "FailedDelete"
 )

--- a/pkg/controllers/teamrbac/teamrolebinding_controller.go
+++ b/pkg/controllers/teamrbac/teamrolebinding_controller.go
@@ -102,7 +102,7 @@ func (r *TeamRoleBindingReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 	defer func() {
 		if statusErr := r.setStatus(ctx, trb, trbStatus); statusErr != nil {
-			log.FromContext(ctx).Error(statusErr, "Error setting status for TeamRoleBinding", "TeamRoleBinding", trb.GetName())
+			log.FromContext(ctx).Error(statusErr, "Error setting status for TeamRoleBinding")
 		}
 	}()
 
@@ -122,13 +122,13 @@ func (r *TeamRoleBindingReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	// list the clusters that either match the ClusterName or the ClusterSelector
 	clusters, err := r.listClusters(ctx, trb)
 	if err != nil {
-		trbStatus.SetConditions(greenhousev1alpha1.TrueCondition(greenhousev1alpha1.ReconcileFailedReason, "Failed to get cluster for TeamRoleBinding", ""))
-		r.recorder.Eventf(trb, corev1.EventTypeNormal, greenhousev1alpha1.ReconcileFailedReason, "Failed to list clusters", trb.GetName)
+		trbStatus.SetConditions(greenhousev1alpha1.FalseCondition(greenhousev1alpha1.RBACReady, greenhousev1alpha1.EmptyClusterList, "Failed to get clusters for TeamRoleBinding"))
 		return ctrl.Result{}, err
 	}
 	switch len(clusters.Items) {
 	case 0:
-		trbStatus.SetConditions(greenhousev1alpha1.TrueCondition(greenhousev1alpha1.ClusterListEmpty, "No clusters found for TeamRoleBinding", ""))
+		trbStatus.SetConditions(greenhousev1alpha1.FalseCondition(greenhousev1alpha1.RBACReady, greenhousev1alpha1.EmptyClusterList, ""))
+		r.recorder.Eventf(trb, corev1.EventTypeWarning, greenhousev1alpha1.FailedEvent, "No clusters found for %s", trb.GetName)
 	default:
 		trbStatus.SetConditions(greenhousev1alpha1.FalseCondition(greenhousev1alpha1.ClusterListEmpty, "", ""))
 	}
@@ -141,7 +141,8 @@ func (r *TeamRoleBindingReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	team, err := getTeam(ctx, r.Client, trb)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			r.recorder.Eventf(trb, corev1.EventTypeNormal, greenhousev1alpha1.ReconcileFailedReason, "Failed to get team %s in namespace %s", trb.Spec.TeamRef, trb.GetNamespace())
+			trbStatus.SetConditions(greenhousev1alpha1.FalseCondition(greenhousev1alpha1.RBACReady, greenhousev1alpha1.TeamNotFound, fmt.Sprintf("Failed to get team %s in namespace %s", trb.Spec.TeamRef, trb.GetNamespace())))
+			r.recorder.Eventf(trb, corev1.EventTypeWarning, greenhousev1alpha1.FailedEvent, "Failed to get team %s in namespace %s", trb.Spec.TeamRef, trb.GetNamespace())
 		}
 		return ctrl.Result{}, err
 	}
@@ -158,14 +159,14 @@ func (r *TeamRoleBindingReconciler) doReconcile(ctx context.Context, teamRole *g
 	for _, cluster := range clusters.Items {
 		remoteRestClient, err := clientutil.NewK8sClientFromCluster(ctx, r.Client, &cluster)
 		if err != nil {
-			r.recorder.Eventf(trb, corev1.EventTypeWarning, "ClusterClientError", "Error getting client for cluster %s to replicate %s", cluster.GetName(), trb.GetName())
+			r.recorder.Eventf(trb, corev1.EventTypeWarning, greenhousev1alpha1.FailedEvent, "Error getting client for cluster %s to replicate %s", cluster.GetName(), trb.GetName())
 			setPropagationStatus(&trbStatus, cluster.GetName(), metav1.ConditionFalse, greenhousev1alpha1.ClusterConnectionFailed)
 			failedClusters = append(failedClusters, cluster.GetName())
 			continue
 		}
 
 		if err := reconcileClusterRole(ctx, remoteRestClient, &cluster, cr); err != nil {
-			r.recorder.Eventf(trb, corev1.EventTypeWarning, greenhousev1alpha1.ReconcileFailedReason, "Failed to reconcile rbacv1.ClusterRole %s in cluster %s", cr.GetName(), cluster.GetName())
+			r.recorder.Eventf(trb, corev1.EventTypeWarning, greenhousev1alpha1.FailedEvent, "Failed to reconcile ClusterRole %s in cluster %s", cr.GetName(), cluster.GetName())
 			setPropagationStatus(&trbStatus, cluster.GetName(), metav1.ConditionFalse, greenhousev1alpha1.ClusterRoleFailed)
 			failedClusters = append(failedClusters, cluster.GetName())
 			continue
@@ -175,7 +176,7 @@ func (r *TeamRoleBindingReconciler) doReconcile(ctx context.Context, teamRole *g
 		case true:
 			crb := rbacClusterRoleBinding(trb, cr, team)
 			if err := reconcileClusterRoleBinding(ctx, remoteRestClient, &cluster, crb); err != nil {
-				r.recorder.Eventf(trb, corev1.EventTypeWarning, greenhousev1alpha1.ReconcileFailedReason, "Failed to reconcile ClusterRoleBinding %s in cluster %s", crb.GetName(), cluster.GetName())
+				r.recorder.Eventf(trb, corev1.EventTypeWarning, greenhousev1alpha1.FailedEvent, "Failed to reconcile ClusterRoleBinding %s in cluster %s", crb.GetName(), cluster.GetName())
 				setPropagationStatus(&trbStatus, cluster.GetName(), metav1.ConditionFalse, greenhousev1alpha1.RoleBindingFailed)
 				failedClusters = append(failedClusters, cluster.GetName())
 				continue
@@ -187,12 +188,12 @@ func (r *TeamRoleBindingReconciler) doReconcile(ctx context.Context, teamRole *g
 				rbacRoleBinding := rbacRoleBinding(trb, cr, team, namespace)
 
 				if err := reconcileRoleBinding(ctx, remoteRestClient, &cluster, rbacRoleBinding); err != nil {
-					r.recorder.Eventf(trb, corev1.EventTypeWarning, greenhousev1alpha1.ReconcileFailedReason, "Failed to reconcile RoleBinding %s in cluster %s", rbacRoleBinding.GetName(), cluster.GetName())
+					r.recorder.Eventf(trb, corev1.EventTypeWarning, greenhousev1alpha1.FailedEvent, "Failed to reconcile RoleBinding %s in cluster %s", rbacRoleBinding.GetName(), cluster.GetName())
 					setPropagationStatus(&trbStatus, cluster.GetName(), metav1.ConditionFalse, greenhousev1alpha1.RoleBindingFailed)
 					if !hasFailed {
 						hasFailed = true
-						failedClusters = append(failedClusters, cluster.GetName())
 					}
+					failedClusters = append(failedClusters, cluster.GetName())
 				}
 			}
 			if hasFailed {
@@ -215,17 +216,19 @@ func (r *TeamRoleBindingReconciler) doReconcile(ctx context.Context, teamRole *g
 func (r *TeamRoleBindingReconciler) deleteTeamRoleBinding(ctx context.Context, trb *greenhousev1alpha1.TeamRoleBinding, trbStatus greenhousev1alpha1.TeamRoleBindingStatus) (ctrl.Result, error) {
 	clusters, err := r.listClusters(ctx, trb)
 	if err != nil {
-		r.recorder.Eventf(trb, corev1.EventTypeNormal, greenhousev1alpha1.ReconcileFailedReason, "Failed to list clusters")
+		r.recorder.Eventf(trb, corev1.EventTypeWarning, greenhousev1alpha1.FailedDeleteEvent, "Failed to list clusters")
 		return ctrl.Result{}, err
 	}
 
 	// add missing clusters from the Status to the list of clusters to be processed
 	if err = r.combineClusterLists(ctx, trb.Namespace, clusters, trbStatus); err != nil {
+		r.recorder.Eventf(trb, corev1.EventTypeWarning, greenhousev1alpha1.FailedDeleteEvent, "Failed to list clusters")
 		return ctrl.Result{}, err
 	}
 
 	for _, cluster := range clusters.Items {
 		if err := r.cleanupCluster(ctx, trb, &cluster); err != nil {
+			r.recorder.Eventf(trb, corev1.EventTypeWarning, greenhousev1alpha1.FailedDeleteEvent, "Failed to remove resources for %s from cluster %s", trb.GetName(), cluster.GetName())
 			continue
 		}
 		trbStatus = removePropagationStatus(trbStatus, cluster.GetName())
@@ -234,7 +237,11 @@ func (r *TeamRoleBindingReconciler) deleteTeamRoleBinding(ctx context.Context, t
 	// all clusters have been processed, finalizer can be removed
 	if len(trbStatus.PropagationStatus) == 0 {
 		err = clientutil.RemoveFinalizer(ctx, r.Client, trb, greenhouseapis.FinalizerCleanupTeamRoleBinding)
-		return ctrl.Result{}, err
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+		r.recorder.Eventf(trb, corev1.EventTypeNormal, greenhousev1alpha1.SuccessfulDeletedEvent, "Deleted TeamRoleBinding %s from all clusters", trb.GetName())
+		return ctrl.Result{}, nil
 	}
 	return ctrl.Result{}, nil
 }
@@ -291,7 +298,7 @@ func (r *TeamRoleBindingReconciler) cleanupResources(ctx context.Context, trbSta
 func (r *TeamRoleBindingReconciler) cleanupCluster(ctx context.Context, trb *greenhousev1alpha1.TeamRoleBinding, cluster *greenhousev1alpha1.Cluster) error {
 	cl, err := clientutil.NewK8sClientFromCluster(ctx, r.Client, cluster)
 	if err != nil {
-		log.FromContext(ctx).Error(err, "Error getting client for cluster %s to delete TeamRoleBinding %s", cluster.GetName(), trb.GetName())
+		log.FromContext(ctx).Error(err, "Error getting client for cluster", "cluster", cluster.GetName())
 		return err
 	}
 
@@ -427,7 +434,7 @@ func reconcileClusterRole(ctx context.Context, cl client.Client, c *greenhousev1
 	if err != nil {
 		return err
 	}
-	log.FromContext(ctx).Info(fmt.Sprintf("%s ClusterRoleBinding", result), "name", cr.GetName(), "cluster", c.GetName())
+	log.FromContext(ctx).Info(fmt.Sprintf("%s ClusterRoleBinding", result), "clusterRole", cr.GetName(), "cluster", c.GetName())
 	return nil
 }
 
@@ -450,11 +457,11 @@ func reconcileClusterRoleBinding(ctx context.Context, cl client.Client, c *green
 	}
 	switch result {
 	case clientutil.OperationResultNone:
-		log.FromContext(ctx).Info("noop ClusterRoleBinding", "name", crb.GetName(), "cluster", c.GetName())
+		log.FromContext(ctx).Info("noop ClusterRoleBinding", "clusterRoleBinding", crb.GetName(), "cluster", c.GetName())
 	case clientutil.OperationResultCreated:
-		log.FromContext(ctx).Info("created ClusterRoleBinding", "name", crb.GetName(), "cluster", c.GetName())
+		log.FromContext(ctx).Info("created ClusterRoleBinding", "clusterRoleBinding", crb.GetName(), "cluster", c.GetName())
 	case clientutil.OperationResultUpdated:
-		log.FromContext(ctx).Info("updated ClusterRoleBinding", "name", crb.GetName(), "cluster", c.GetName())
+		log.FromContext(ctx).Info("updated ClusterRoleBinding", "clusterRoleBinding", crb.GetName(), "cluster", c.GetName())
 	}
 	return nil
 }
@@ -480,11 +487,11 @@ func reconcileRoleBinding(ctx context.Context, cl client.Client, c *greenhousev1
 	}
 	switch result {
 	case clientutil.OperationResultNone:
-		log.FromContext(ctx).Info("noop RoleBinding", "name", rb.GetName(), "cluster", c.GetName(), "namespace", rb.GetNamespace())
+		log.FromContext(ctx).Info("noop RoleBinding", "roleBinding", rb.GetName(), "cluster", c.GetName(), "namespace", rb.GetNamespace())
 	case clientutil.OperationResultCreated:
-		log.FromContext(ctx).Info("created RoleBinding", "name", rb.GetName(), "cluster", c.GetName(), "namespace", rb.GetNamespace())
+		log.FromContext(ctx).Info("created RoleBinding", "roleBinding", rb.GetName(), "cluster", c.GetName(), "namespace", rb.GetNamespace())
 	case clientutil.OperationResultUpdated:
-		log.FromContext(ctx).Info("updated RoleBinding", "name", rb.GetName(), "cluster", c.GetName(), "namespace", rb.GetNamespace())
+		log.FromContext(ctx).Info("updated RoleBinding", "roleBinding", rb.GetName(), "cluster", c.GetName(), "namespace", rb.GetNamespace())
 	}
 	return nil
 }
@@ -501,10 +508,10 @@ func (r TeamRoleBindingReconciler) deleteRoleBindings(ctx context.Context, cl cl
 
 		switch {
 		case err != nil:
-			r.recorder.Eventf(trb, corev1.EventTypeWarning, greenhousev1alpha1.DeleteFailedReason, "Failed to delete RoleBinding %s for cluster %s in namespace %s", trb.GetRBACName(), cluster.GetName(), namespace)
+			log.FromContext(ctx).Error(err, "error deleting RoleBinding", "roleBinding", trb.GetRBACName(), "cluster", cluster.GetName(), "namespace", namespace)
 			return err
 		case result == clientutil.DeletionResultDeleted:
-			r.recorder.Eventf(trb, corev1.EventTypeNormal, greenhousev1alpha1.DeletedReason, "Deleted RoleBinding %s in cluster %s in namespace %s", trb.GetRBACName(), cluster.GetName(), namespace)
+			log.FromContext(ctx).Info("deleted RoleBinding successfully", "roleBinding", trb.GetRBACName(), "cluster", cluster.GetName(), "namespace", namespace)
 		}
 	}
 	return nil
@@ -520,10 +527,10 @@ func (r TeamRoleBindingReconciler) deleteClusterRoleBinding(ctx context.Context,
 	result, err := clientutil.Delete(ctx, cl, remoteObject)
 	switch {
 	case err != nil:
-		r.recorder.Eventf(trb, corev1.EventTypeWarning, greenhousev1alpha1.DeleteFailedReason, "Failed to delete ClusterRoleBinding %s for cluster %s", trb.GetRBACName(), cluster.GetName())
+		log.FromContext(ctx).Error(err, "error deleting ClusterRoleBinding", "clusterRoleBinding", trb.GetRBACName(), "cluster", cluster.GetName())
 		return err
 	case result == clientutil.DeletionResultDeleted:
-		r.recorder.Eventf(trb, corev1.EventTypeNormal, greenhousev1alpha1.DeletedReason, "ClusterRoleBinding %s deleted from cluster %s", trb.GetRBACName(), cluster.GetName())
+		log.FromContext(ctx).Info("deleted ClusterRoleBinding successfully", "clusterRoleBinding", trb.GetRBACName(), "cluster", cluster.GetName())
 	}
 	return nil
 }
@@ -537,11 +544,10 @@ func (r TeamRoleBindingReconciler) deleteClusterRole(ctx context.Context, cl cli
 	result, err := clientutil.Delete(ctx, cl, remoteObject)
 	switch {
 	case err != nil:
-		r.recorder.Eventf(trb, corev1.EventTypeWarning, greenhousev1alpha1.DeleteFailedReason, "Error deleting ClusterRole %s for cluster %s", trb.GetRBACName(), cluster.GetName())
+		log.FromContext(ctx).Error(err, "error deleting ClusterRole", "clusterRole", trb.GetRBACName(), "cluster", cluster.GetName())
 		return err
 	case result == clientutil.DeletionResultDeleted:
-		r.recorder.Eventf(trb, corev1.EventTypeNormal, greenhousev1alpha1.DeletedReason, "ClusterRole %s deleted from cluster %s", trb.GetRBACName(), cluster.GetName())
-
+		log.FromContext(ctx).Info("deleted ClusterRole successfully", "clusterRole", trb.GetRBACName(), "cluster", cluster.GetName())
 	}
 	return nil
 }


### PR DESCRIPTION
## Description

If the cluster cannot be found by name the ClusterListEmpty status should be updated. Previous the reconcile failed without updating the status. Ready condition stayed true

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->
- Related Issue # (issue)
- Closes # (issue)
- Fixes # (issue)

> Remove if not applicable

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [ ] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
