### PR TITLE
fix(dev-env): Failing docker builds

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -39,8 +39,8 @@ jobs:
             Imagename: greenhouse-tailscale
           - Dockerfiles: Dockerfile.tcp-proxy
             Imagename: greenhouse-tcp-proxy
-          - Dockerfiles: Dockerfile.dev-ui
-            Imagename: greenhouse-dev-ui
+          # - Dockerfiles: Dockerfile.dev-ui
+          #   Imagename: greenhouse-dev-ui
 
     permissions:
       contents: read
@@ -155,8 +155,8 @@ jobs:
             Imagename: greenhouse-tailscale
           - Dockerfiles: Dockerfile.tcp-proxy
             Imagename: greenhouse-tcp-proxy
-          - Dockerfiles: Dockerfile.dev-ui
-            Imagename: greenhouse-dev-ui
+          # - Dockerfiles: Dockerfile.dev-ui
+          #   Imagename: greenhouse-dev-ui
 
     name: Vulnerability Scan
     needs: build

--- a/Dockerfile.dev-env
+++ b/Dockerfile.dev-env
@@ -32,7 +32,7 @@ COPY --from=builder /workspace/charts/manager/templates/webhooks.yaml ./config/w
 COPY --from=builder /usr/local/bin ./usr/local/bin
 # some resources that are bootstrapped by default
 COPY --from=builder /workspace/dev-env/bootstrap/core /core-bootstrap
-COPY --from=git /greenhouse-extensions/service-proxy/plugin.yaml /core-bootstrap
+COPY --from=git /greenhouse-extensions/service-proxy/plugindefinition.yaml /core-bootstrap
 
 # upgrade all installed packages to fix potential CVEs in advance
 RUN apk upgrade --no-cache --no-progress \

--- a/dev-env/docker-compose.yaml
+++ b/dev-env/docker-compose.yaml
@@ -40,6 +40,9 @@ services:
       - PORT=3000
     ports:
       - "3000:3000"
+    build:
+      context: ./../
+      dockerfile: Dockerfile.dev-ui
   bootstrap:
     image: ghcr.io/cloudoperators/greenhouse-dev-env:main
     environment:

--- a/dev-env/network-host.docker-compose.yaml
+++ b/dev-env/network-host.docker-compose.yaml
@@ -38,6 +38,9 @@ services:
     environment:
       - PORT=3000
     network_mode: host
+    build:
+      context: ./../
+      dockerfile: Dockerfile.dev-ui
   bootstrap:
     image: ghcr.io/cloudoperators/greenhouse-dev-env:main
     environment:

--- a/docs/contribute/local-dev.md
+++ b/docs/contribute/local-dev.md
@@ -105,6 +105,12 @@ Note that not setting `headscaleAPIURL`, `headscaleAPIKey` or `tailscaleProxy` w
 
 ## Greenhouse UI
 
+Build the latest `dev-ui` image by running:
+
+```bash
+$ docker build --platform linux/amd64 -t ghcr.io/cloudoperators/greenhouse-dev-ui:main -f Dockerfile.dev-ui  .
+```
+
 To run the Greenhouse UI locally you can either run the docker image exposing port `3000` or in `host` network:
 
 ```bash
@@ -142,6 +148,12 @@ docker compose up
 ```
 
 from the `./dev-env` folder.
+
+You might need to build the `dev-ui` image by hand:
+
+```bash
+docker compose build greenhouse-ui
+```
 
 The [network-host.docker-compose.yaml](https://github.com/cloudoperators/greenhouse/blob/main/dev-env/network-host.docker-compose.yaml) provides the same setup starting all containers in host network mode.
 


### PR DESCRIPTION
## Description
This fixes the failing builds for `Dockerfile.dev-env` and `Dockerfile.dev-ui` after https://github.com/cloudoperators/greenhouse/pull/353

- `dev-ui` needs to be build locally
- `dev-env` still had a reference to `plugin.yaml` file refactored to `plugindefinition.yaml` by https://github.com/cloudoperators/greenhouse-extensions/pull/225

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

