### PR TITLE
fix(website): Remove local-dev link from homepage

### DIFF
--- a/docs/contribute/local-dev.md
+++ b/docs/contribute/local-dev.md
@@ -1,7 +1,7 @@
 ---
 title: "Local development setup"
 linkTitle: "Local development setup"
-landingSectionIndex: true
+landingSectionIndex: false
 weight: 100
 description: >
   How to run a local Greenhouse setup for development


### PR DESCRIPTION
## Description
This removes the landing page link to local-dev setup from the website home.
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

