### PR TITLE
fix(dev-env): use 8090 for envtest, fix bootstrap

### DIFF
--- a/dev-env/docker-compose.yaml
+++ b/dev-env/docker-compose.yaml
@@ -8,7 +8,7 @@ services:
       - ./envtest:/envtest
       - ./webhook-certs:/webhook-certs
     ports:
-      - "3005:8090"
+      - "8090:8090"
     environment:
       # one of ["test-org-admin", "test-org-member"] - leave unset for "cluster-admin"
       - DEV_ENV_CONTEXT
@@ -50,7 +50,7 @@ services:
     volumes:
       - ./envtest:/envtest
       - ./bootstrap:/bootstrap
-    command: kubectl apply -f /core-bootstrap -f /bootstrap #-f /bootstrap/additional_resources
+    command: kubectl apply -f /core-bootstrap #-f /bootstrap/additional_resources
     depends_on:
       - greenhouse
     network_mode: service:envtest

--- a/dev-env/network-host.docker-compose.yaml
+++ b/dev-env/network-host.docker-compose.yaml
@@ -48,7 +48,7 @@ services:
     volumes:
       - ./envtest:/envtest
       - ./bootstrap:/bootstrap
-    command: kubectl apply -f /core-bootstrap -f /bootstrap #-f /bootstrap/additional_resources
+    command: kubectl apply -f /core-bootstrap #-f /bootstrap/additional_resources
     depends_on:
       - greenhouse
     network_mode: service:envtest


### PR DESCRIPTION
## Description

With the move the exposed port changed to 3005. The KubeConfig still refers to 8090. 
Changes the `kubectl apply` during bootstrap to match the folder structure.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->
- Related Issue # (issue)
- Closes # (issue)
- Fixes # (issue)

> Remove if not applicable

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [x] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
