### PR TITLE
feat(dev-env) add mounting a local helm chart

### DIFF
--- a/dev-env/docker-compose.yaml
+++ b/dev-env/docker-compose.yaml
@@ -29,6 +29,7 @@ services:
     volumes:
       - ./envtest:/envtest
       - ./webhook-certs:/tmp/k8s-webhook-server/serving-certs
+      - ./helm-charts:/helm-charts
     depends_on:
       envtest:
         condition: service_healthy

--- a/docs/user-guides/plugin/development.md
+++ b/docs/user-guides/plugin/development.md
@@ -68,6 +68,16 @@ The generated _PluginDefinition_ contains a `plugindefinition.yaml` file which d
 After generating the _PluginDefinition_ the `.spec.helmChart.repository` field in the `plugindefinition.yaml` contains a TODO comment. This field should be set to the repository where the Helm Chart is stored.
 For the bitnami nginx Helm Chart this would be `oci://registry-1.docker.io/bitnamicharts`.
 
+#### Specify a local Helm Chart
+
+Instead of using a chart repository hosted on a server, you can also utilize a local chart in a `*.tgz` format and place it under `dev-env/helm-charts`. You then only need to run `docker compose up` again to mount the chart to the respective folder and source it as following: 
+```yaml
+ helmChart:
+        name: helm-charts/{filename}.tgz
+        repository: 
+```
+
+
 ### Specify the UI application
 
 A _PluginDefinition_ may specify a UI application that will be integrated into the Greenhouse UI. This tutorial does not cover how to create a UI application. Therefore the section `.spec.uiApplication` in the `plugindefinition.yaml` should be removed.

--- a/docs/user-guides/plugin/development.md
+++ b/docs/user-guides/plugin/development.md
@@ -70,7 +70,7 @@ For the bitnami nginx Helm Chart this would be `oci://registry-1.docker.io/bitna
 
 #### Specify a local Helm Chart
 
-Instead of using a chart repository hosted on a server, you can also utilize a local chart in a `*.tgz` format and place it under `dev-env/helm-charts`. You then only need to run `docker compose up` again to mount the chart to the respective folder and source it as following: 
+Instead of using a chart repository hosted on a server, you can also utilize a local chart in a `*.tgz` format and place it under `dev-env/helm-charts`. While `docker compose up` running, docker will mount the chart to the respective folder and you can source it as following: 
 ```yaml
  helmChart:
         name: helm-charts/{filename}.tgz

--- a/docs/user-guides/plugin/development.md
+++ b/docs/user-guides/plugin/development.md
@@ -77,7 +77,6 @@ Instead of using a chart repository hosted on a server, you can also utilize a l
         repository: 
 ```
 
-
 ### Specify the UI application
 
 A _PluginDefinition_ may specify a UI application that will be integrated into the Greenhouse UI. This tutorial does not cover how to create a UI application. Therefore the section `.spec.uiApplication` in the `plugindefinition.yaml` should be removed.

--- a/docs/user-guides/plugin/development.md
+++ b/docs/user-guides/plugin/development.md
@@ -68,15 +68,6 @@ The generated _PluginDefinition_ contains a `plugindefinition.yaml` file which d
 After generating the _PluginDefinition_ the `.spec.helmChart.repository` field in the `plugindefinition.yaml` contains a TODO comment. This field should be set to the repository where the Helm Chart is stored.
 For the bitnami nginx Helm Chart this would be `oci://registry-1.docker.io/bitnamicharts`.
 
-#### Specify a local Helm Chart
-
-Instead of using a chart repository hosted on a server, you can also utilize a local chart in a `*.tgz` format and place it under `dev-env/helm-charts`. While `docker compose up` running, docker will mount the chart to the respective folder and you can source it as following: 
-```yaml
- helmChart:
-        name: helm-charts/{filename}.tgz
-        repository: 
-```
-
 ### Specify the UI application
 
 A _PluginDefinition_ may specify a UI application that will be integrated into the Greenhouse UI. This tutorial does not cover how to create a UI application. Therefore the section `.spec.uiApplication` in the `plugindefinition.yaml` should be removed.
@@ -138,4 +129,16 @@ Set kubectl context to "kind-remote-cluster"
 k get pods -n test-org
 NAME                                    READY   STATUS    RESTARTS   AGE
 nginx-remote-cluster-758bf47c77-pz72l   1/1     Running   0          2m11s
+```
+## Development Tips
+
+### Local Helm Charts
+
+Instead of uploading the Helm Chart to a chart repository, it is possible to load it from the filesystem of the Greenhouse container.
+This can be especially useful if you are developing your own chart for a PluginDefinition, as it speeds up the testing loop.
+The Docker compose setup mounts the `dev-env/helm-charts` directory and watches for any changes. This means you can point to this local chart in your `plugindefinition.yaml` as such:
+```yaml
+ helmChart:
+        name: helm-charts/{filename}.tgz
+        repository: 
 ```


### PR DESCRIPTION
## Description

Add mounting an additional folder `/helm-charts` to the dev-env where plugin developers can place a `*.tgz` file to make use of a local chart instead of a hosted chart. 

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [x] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

## Added to documentation?

- [ ] 📜 README.md
- [x] 🤝 Documentation pages updated
- [ ] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
