### PR TITLE
refac(org): use test.Setup for org rbac controller tests

### DIFF
--- a/pkg/controllers/organization/suite_test.go
+++ b/pkg/controllers/organization/suite_test.go
@@ -19,6 +19,7 @@ func TestOrganization(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
+	test.RegisterController("namespaceController", (&NamespaceReconciler{}).SetupWithManager)
 	test.RegisterController("organizationController", (&RBACReconciler{}).SetupWithManager)
 	test.RegisterWebhook("orgWebhook", admission.SetupOrganizationWebhookWithManager)
 	test.TestBeforeSuite()

--- a/pkg/test/assert.go
+++ b/pkg/test/assert.go
@@ -21,3 +21,11 @@ func EventuallyDeleted(ctx context.Context, c client.Client, obj client.Object) 
 		return apierrors.IsNotFound(c.Get(ctx, client.ObjectKeyFromObject(obj), obj))
 	}).Should(BeTrue(), "there should be no error deleting the object")
 }
+
+// EventuallyGet gets the object and retries until it is available.
+func EventuallyCreated(ctx context.Context, c client.Client, obj client.Object) {
+	GinkgoHelper()
+	Eventually(func() bool {
+		return c.Get(ctx, client.ObjectKeyFromObject(obj), obj) == nil
+	}).Should(BeTrue(), "there should be no error getting the object")
+}

--- a/pkg/test/resources.go
+++ b/pkg/test/resources.go
@@ -113,6 +113,22 @@ func (t *TestSetup) OnboardCluster(ctx context.Context, name string, kubeCfg []b
 	return cluster
 }
 
+// CreateOrganization creates a Organization within the TestSetup and returns the created Organization resource.
+func (t *TestSetup) CreateOrganization(ctx context.Context, name string) *greenhousev1alpha1.Organization {
+	GinkgoHelper()
+	org := &greenhousev1alpha1.Organization{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Organization",
+			APIVersion: greenhousev1alpha1.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+	Expect(t.Create(ctx, org)).Should(Succeed(), "there should be no error creating the Organization")
+	return org
+}
+
 // WithRules overrides the default rules of a TeamRole
 func WithRules(rules []rbacv1.PolicyRule) func(*greenhousev1alpha1.TeamRole) {
 	return func(tr *greenhousev1alpha1.TeamRole) {


### PR DESCRIPTION
## Description

Refactoring to use the `test.TestSetup` and introduce a dedicated helper to create Org objects

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [x] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->
- Related Issue # (issue)
- Closes # (issue)
- Fixes # (issue)

> Remove if not applicable

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [ ] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
