### PR TITLE
fix(team_webhook): concurrent write on map

### DIFF
--- a/pkg/admission/team_webhook.go
+++ b/pkg/admission/team_webhook.go
@@ -18,12 +18,6 @@ import (
 	greenhousev1alpha1 "github.com/cloudoperators/greenhouse/pkg/apis/greenhouse/v1alpha1"
 )
 
-var (
-	labelsWhiteList = map[string]struct{}{
-		"support-group": {},
-	}
-)
-
 // Webhook for the Team custom resource.
 
 func SetupTeamWebhookWithManager(mgr ctrl.Manager) error {
@@ -67,6 +61,10 @@ func ValidateDeleteTeam(_ context.Context, _ client.Client, _ runtime.Object) (a
 }
 
 func validateGreenhouseLabels(team *greenhousev1alpha1.Team, ctx context.Context, c client.Client) error {
+	labelsWhiteList := map[string]struct{}{
+		"support-group": {},
+	}
+
 	pluginDefinitions := greenhousev1alpha1.PluginDefinitionList{}
 	if err := c.List(ctx, &pluginDefinitions); !apierrors.IsNotFound(err) && err != nil {
 		return err


### PR DESCRIPTION
## Description

The Greenhouse controller manager crashed due to concurrent writes to a map.
The map in question was in the global scope.

```bash
fatal error: concurrent map writes

goroutine 145342 [running]:
github.com/cloudoperators/greenhouse/pkg/admission.validateGreenhouseLabels(0xc000b81040, {0x26c1910, 0xc000b8d530}, {0x26d2e80, 0xc00011b050})
	/workspace/pkg/admission/team_webhook.go:75 +0x165
github.com/cloudoperators/greenhouse/pkg/admission.ValidateUpdateTeam({0x26c1910?, 0xc000b8d530?}, {0x26d2e80?, 0xc00011b050?}, {0x17d5a7a?, 0xc000b81040?}, {0x26a98d8?, 0xc000b81040?})
	/workspace/pkg/admission/team_webhook.go:62 +0x4c
github.com/cloudoperators/greenhouse/pkg/admission.(*customValidator).ValidateUpdate(0xc000b81040?, {0x26c1910?, 0xc000b8d530?}, {0x26a98d8?, 0xc000b81180?}, {0x26a98d8?, 0xc000b81040?})
	/workspace/pkg/admission/utils.go:86 +0x5d
```

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->
- Related Issue # (issue)
- Closes # (issue)
- Fixes # (issue)

> Remove if not applicable

## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [ ] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
