### PR TITLE
feat(alerts): added predefindedFilters to pluginConfig for alerts

### DIFF
--- a/charts/greenhouse/templates/pluginconfig-alerts.yaml
+++ b/charts/greenhouse/templates/pluginconfig-alerts.yaml
@@ -31,6 +31,9 @@ spec:
     - name: silenceTemplates
       value:
         {{ .Values.alerts.silenceTemplates | toYaml | nindent 8 }}
+    - name: predefinedFilters
+      value:
+        {{ .Values.alerts.predefinedFilters | toYaml | nindent 8 }}
     - name: alerts.alertmanager.ingress.hosts
       value:
       - {{ required ".Values.alerts.ingress.host missing" .Values.alerts.ingress.host }}


### PR DESCRIPTION
## Description

Allow configuration of filter tabs in Alerts via predefinedFilters.

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

- Related Issue https://github.com/cloudoperators/greenhouse-extensions/issues/258

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [ ] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
