### PR TITLE
fix(clusters): remove test flakiness

### DIFF
--- a/pkg/controllers/cluster/direct_access_controller_test.go
+++ b/pkg/controllers/cluster/direct_access_controller_test.go
@@ -12,100 +12,100 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
 
 	greenhouseapis "github.com/cloudoperators/greenhouse/pkg/apis"
+	greenhousev1alpha1 "github.com/cloudoperators/greenhouse/pkg/apis/greenhouse/v1alpha1"
 	"github.com/cloudoperators/greenhouse/pkg/clientutil"
 	clusterpkg "github.com/cloudoperators/greenhouse/pkg/controllers/cluster"
 	"github.com/cloudoperators/greenhouse/pkg/test"
 )
 
-const (
-	directAccessClusterNamespace = "direct-access"
-	directAccessClusterName      = "test-direct-access"
-)
-
 var _ = Describe("KubeConfig controller", func() {
 	Context("When reconciling a cluster resource", func() {
+		const (
+			directAccessTestCase = "direct-access"
+		)
 
-		//delete all secrets and clusters
+		var (
+			cluster = greenhousev1alpha1.Cluster{}
+
+			remoteEnvTest    *envtest.Environment
+			remoteKubeConfig []byte
+			setup            *test.TestSetup
+		)
+
 		BeforeEach(func() {
-			// Restart pristine remote environment to mitigate https://book.kubebuilder.io/reference/envtest.html#:~:text=EnvTest%20does%20not%20support%20namespace,and%20never%20actually%20be%20reclaimed
-			err := remoteEnvTest.Stop()
-			Expect(err).
-				NotTo(HaveOccurred(), "there must be no error stopping the remote environment")
-			bootstrapRemoteCluster()
-
-			Expect(test.K8sClient.Create(test.Ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: directAccessClusterNamespace}})).NotTo(HaveOccurred(), "there should be no error creating the test namespace")
-
+			_, _, remoteEnvTest, remoteKubeConfig = test.StartControlPlane("6885", false, false)
+			setup = test.NewTestSetup(test.Ctx, test.K8sClient, directAccessTestCase)
 		})
 
 		AfterEach(func() {
-			test.MustDeleteCluster(test.Ctx, test.K8sClient, types.NamespacedName{Name: directAccessClusterName, Namespace: directAccessClusterNamespace})
-			test.MustDeleteSecretWithLabel(test.Ctx, test.K8sClient, "kubeconfig")
+			test.MustDeleteCluster(test.Ctx, test.K8sClient, types.NamespacedName{Name: cluster.Name, Namespace: setup.Namespace()})
+			Expect(remoteEnvTest.Stop()).To(Succeed(), "there should be no error stopping the remote environment")
 		})
 
 		It("Should correctly have created resources in remote cluster and provided a valid greenhouse kubeconfig secret",
 			func() {
 				By("Creating a secret with a valid kubeconfig for a remote cluster")
-				validKubeConfigSecret := corev1.Secret{
-					TypeMeta: metav1.TypeMeta{
-						Kind:       "Secret",
-						APIVersion: corev1.GroupName,
-					},
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      directAccessClusterName,
-						Namespace: directAccessClusterNamespace,
-						Labels: map[string]string{
-							"greenhouse/test": "kubeconfig",
-						},
-					},
-					Data: map[string][]byte{
-						greenhouseapis.KubeConfigKey: remoteKubeConfig,
-					},
-					Type: greenhouseapis.SecretTypeKubeConfig,
+
+				secret := setup.CreateSecret(test.Ctx, directAccessTestCase,
+					test.WithSecretType(greenhouseapis.SecretTypeKubeConfig),
+					test.WithSecretData(map[string][]byte{greenhouseapis.KubeConfigKey: remoteKubeConfig}))
+
+				By("Checking the cluster resource with the same name as the secret has been created")
+				Eventually(func() error {
+					return test.K8sClient.Get(test.Ctx, types.NamespacedName{Name: secret.Name, Namespace: setup.Namespace()}, &cluster)
+				}).Should(Succeed(), fmt.Sprintf("eventually the cluster %s should exist", secret.Name))
+
+				By("checking the cluster's secret has an owner reference to the cluster")
+				expectedOwnerReference := metav1.OwnerReference{
+					Kind:       "Cluster",
+					APIVersion: "greenhouse.sap/v1alpha1",
+					UID:        cluster.UID,
+					Name:       cluster.Name,
 				}
-				Expect(test.K8sClient.Create(test.Ctx, &validKubeConfigSecret, &client.CreateOptions{})).
-					Should(Succeed(), "there should be no error creating the kubeconfig secret")
+				secretUT := corev1.Secret{}
+				Eventually(func(g Gomega) bool {
+					g.Expect(test.K8sClient.Get(test.Ctx, types.NamespacedName{Name: cluster.Name, Namespace: setup.Namespace()}, &secretUT)).To(Succeed())
+					g.Expect(secretUT.ObjectMeta.OwnerReferences).To(ContainElement(expectedOwnerReference), "the kubeconfig secret should have an owner reference to the cluster")
+					return true
+				}).Should(BeTrue(), "eventually the secret should have an owner reference to the cluster")
 
 				By("Checking namespace has been created in remote cluster")
-				config, err := clientcmd.RESTConfigFromKubeConfig(validKubeConfigSecret.Data[greenhouseapis.KubeConfigKey])
-				Expect(err).
-					ShouldNot(HaveOccurred(), "there should be no error creating a restConfig from the kubeConfig")
-				remoteK8sClient, err := clientutil.NewK8sClient(config)
-				Expect(err).
-					ShouldNot(HaveOccurred(), "there should be no error creating a new k8s client from the restConfig")
+				remoteClient, err := clientutil.NewK8sClientFromCluster(test.Ctx, test.K8sClient, &cluster)
+				Expect(err).To(BeNil(), "there should be no error creating a new k8s client from the cluster")
 
 				Eventually(func() error {
 					var namespace = new(corev1.Namespace)
-					return remoteK8sClient.Get(test.Ctx, types.NamespacedName{Namespace: "", Name: directAccessClusterNamespace}, namespace)
-				}).Should(Succeed(), fmt.Sprintf("eventually the namespace %s should exist", directAccessClusterNamespace))
+					return remoteClient.Get(test.Ctx, types.NamespacedName{Namespace: "", Name: setup.Namespace()}, namespace)
+				}).Should(Succeed(), fmt.Sprintf("eventually the namespace %s should exist", setup.Namespace()))
 
 				By("Checking service account has been created in remote cluster")
 				Eventually(func() error {
 					var serviceAccount = new(corev1.ServiceAccount)
-					return remoteK8sClient.Get(test.Ctx, types.NamespacedName{Namespace: directAccessClusterNamespace, Name: clusterpkg.ExportServiceAccountName}, serviceAccount)
-				}).Should(Succeed(), fmt.Sprintf("eventually the service account %s/%s should exist", directAccessClusterNamespace, clusterpkg.ExportServiceAccountName))
+					return remoteClient.Get(test.Ctx, types.NamespacedName{Namespace: setup.Namespace(), Name: clusterpkg.ExportServiceAccountName}, serviceAccount)
+				}).Should(Succeed(), fmt.Sprintf("eventually the service account %s/%s should exist", setup.Namespace(), clusterpkg.ExportServiceAccountName))
 
 				By("Checking clusterRoleBinding has been created in remote cluster")
 				clusterRoleBindingName := "greenhouse"
 				Eventually(func() error {
 					var clusterRoleBinding = new(rbacv1.ClusterRoleBinding)
-					return remoteK8sClient.Get(test.Ctx, types.NamespacedName{Namespace: "", Name: clusterRoleBindingName}, clusterRoleBinding)
+					return remoteClient.Get(test.Ctx, types.NamespacedName{Namespace: "", Name: clusterRoleBindingName}, clusterRoleBinding)
 				}).Should(Succeed(), fmt.Sprintf("eventually the clusterRoleBinding %s should exist", clusterRoleBindingName))
 
 				By("Checking greenhouse kubeConfig has been created and verifying validity")
 				greenhouseKubeConfigSecret := corev1.Secret{}
 				Eventually(func() map[string][]byte {
-					err := test.K8sClient.Get(test.Ctx, client.ObjectKey{Name: directAccessClusterName, Namespace: directAccessClusterNamespace}, &greenhouseKubeConfigSecret)
+					err := test.K8sClient.Get(test.Ctx, client.ObjectKey{Name: cluster.Name, Namespace: setup.Namespace()}, &greenhouseKubeConfigSecret)
 					Expect(err).ToNot(HaveOccurred())
 					return greenhouseKubeConfigSecret.Data
 				}).Should(HaveKey(greenhouseapis.GreenHouseKubeConfigKey),
 					fmt.Sprintf("eventually the secret data should contain the key %s", greenhouseapis.GreenHouseKubeConfigKey),
 				)
 
-				greenhouseRestClientGetter, err := clientutil.NewRestClientGetterFromSecret(&greenhouseKubeConfigSecret, directAccessClusterNamespace, clientutil.WithPersistentConfig())
+				greenhouseRestClientGetter, err := clientutil.NewRestClientGetterFromSecret(&greenhouseKubeConfigSecret, setup.Namespace(), clientutil.WithPersistentConfig())
 				Expect(err).NotTo(HaveOccurred(), "there should be no error getting the rest client getter from the secret")
 				greenhouseRemoteConfig, err := greenhouseRestClientGetter.ToRESTConfig()
 				Expect(err).NotTo(HaveOccurred(), "there should be no error creating a restConfig from a kubeConfig")

--- a/pkg/test/resources.go
+++ b/pkg/test/resources.go
@@ -48,39 +48,27 @@ func NewTestSetup(ctx context.Context, c client.Client, name string) *TestSetup 
 	return t
 }
 
-// WithLabel sets a label on a Cluster
+// WithAccessMode sets the ClusterAccessMode on a Cluster
+func WithAccessMode(mode greenhousev1alpha1.ClusterAccessMode) func(*greenhousev1alpha1.Cluster) {
+	return func(c *greenhousev1alpha1.Cluster) {
+		c.Spec.AccessMode = mode
+	}
+}
+
+// WithLabel sets the label on a Cluster
 func WithLabel(key, value string) func(*greenhousev1alpha1.Cluster) {
 	return func(c *greenhousev1alpha1.Cluster) {
 		if c.Labels == nil {
-			c.Labels = map[string]string{}
+			c.Labels = make(map[string]string, 1)
 		}
 		c.Labels[key] = value
 	}
 }
 
 // OnboardCluster creates a new Cluster and Kubernetes secret for a remote cluster and creates the namespace used for TestSetup on the remote cluster
-func (t *TestSetup) OnboardCluster(ctx context.Context, name string, kubeCfg []byte, clusterOpts ...func(*greenhousev1alpha1.Cluster)) *greenhousev1alpha1.Cluster {
+func (t *TestSetup) OnboardCluster(ctx context.Context, name string, kubeCfg []byte, opts ...func(*greenhousev1alpha1.Cluster)) *greenhousev1alpha1.Cluster {
 	GinkgoHelper()
-	clusterName := t.RandomizeName(name)
-	cluster := &greenhousev1alpha1.Cluster{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Cluster",
-			APIVersion: greenhousev1alpha1.GroupVersion.String(),
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      clusterName,
-			Namespace: t.Namespace(),
-		},
-		Spec: greenhousev1alpha1.ClusterSpec{
-			AccessMode: greenhousev1alpha1.ClusterAccessModeDirect,
-		},
-	}
-
-	for _, o := range clusterOpts {
-		o(cluster)
-	}
-
-	Expect(t.Create(ctx, cluster)).To(Succeed(), "there should be no error creating the cluster during onboarding")
+	cluster := t.CreateCluster(ctx, name, opts...)
 
 	var testClusterK8sSecret = &corev1.Secret{
 		TypeMeta: metav1.TypeMeta{
@@ -88,7 +76,7 @@ func (t *TestSetup) OnboardCluster(ctx context.Context, name string, kubeCfg []b
 			APIVersion: corev1.GroupName,
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      clusterName,
+			Name:      cluster.Name,
 			Namespace: t.Namespace(),
 		},
 		Type: greenhouseapis.SecretTypeKubeConfig,
@@ -110,6 +98,31 @@ func (t *TestSetup) OnboardCluster(ctx context.Context, name string, kubeCfg []b
 		}}
 	Expect(k8sClientForRemoteCluster.Create(ctx, namespace)).To(Succeed(), "there should be no error creating the namespace during onboarding")
 
+	return cluster
+}
+
+// CreateCluster creates a new Cluster resource without creating a Secret
+func (t *TestSetup) CreateCluster(ctx context.Context, name string, opts ...func(*greenhousev1alpha1.Cluster)) *greenhousev1alpha1.Cluster {
+	GinkgoHelper()
+	cluster := &greenhousev1alpha1.Cluster{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Cluster",
+			APIVersion: greenhousev1alpha1.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: t.Namespace(),
+		},
+		Spec: greenhousev1alpha1.ClusterSpec{
+			AccessMode: greenhousev1alpha1.ClusterAccessModeDirect,
+		},
+	}
+
+	for _, o := range opts {
+		o(cluster)
+	}
+
+	Expect(t.Create(ctx, cluster)).To(Succeed(), "there should be no error creating the cluster during onboarding")
 	return cluster
 }
 
@@ -241,4 +254,38 @@ func (t *TestSetup) CreateTeam(ctx context.Context, name string, opts ...func(*g
 	}
 	Expect(t.Create(ctx, team)).Should(Succeed(), "there should be no error creating the Team")
 	return team
+}
+
+// WithSecretType sets the type of the Secret
+func WithSecretType(secretType corev1.SecretType) func(*corev1.Secret) {
+	return func(s *corev1.Secret) {
+		s.Type = secretType
+	}
+}
+
+// WithSecretData sets the data of the Secret
+func WithSecretData(data map[string][]byte) func(*corev1.Secret) {
+	return func(s *corev1.Secret) {
+		s.Data = data
+	}
+}
+
+// CreateSecret returns a Secret object. Opts can be used to set the desired state of the Secret.
+func (t *TestSetup) CreateSecret(ctx context.Context, name string, opts ...func(*corev1.Secret)) *corev1.Secret {
+	GinkgoHelper()
+	secret := &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Secret",
+			APIVersion: corev1.GroupName,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: t.Namespace(),
+		},
+	}
+	for _, opt := range opts {
+		opt(secret)
+	}
+	Expect(t.Create(ctx, secret)).Should(Succeed(), "there should be no error creating the Secret")
+	return secret
 }

--- a/pkg/test/util.go
+++ b/pkg/test/util.go
@@ -8,81 +8,36 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"time"
 
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gstruct"
 	gomegaTypes "github.com/onsi/gomega/types"
-	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	greenhousev1alpha1 "github.com/cloudoperators/greenhouse/pkg/apis/greenhouse/v1alpha1"
-	"github.com/cloudoperators/greenhouse/pkg/clientutil"
 )
 
-// LabelRemoveAllFinalizersOnDeletion is used in the test context only to indicate a resource must be deleted even with finalizers present.
-const LabelRemoveAllFinalizersOnDeletion = "greenhouse.test/removeAllFinalizersOnDeletion"
-
-// MustDeleteCluster is used in the test context only and removes all clusters.
+// MustDeleteCluster is used in the test context only and removes a cluster by namespaced name.
 func MustDeleteCluster(ctx context.Context, c client.Client, id client.ObjectKey) {
+	GinkgoHelper()
 	var cluster = new(greenhousev1alpha1.Cluster)
 	Expect(c.Get(ctx, id, cluster)).
 		To(Succeed(), "there must be no error getting the cluster")
+
 	Expect(c.Delete(ctx, cluster)).
-		To(Succeed(), "there must be no error deleting cluster", "key", client.ObjectKeyFromObject(cluster))
-	if isHasLabel(cluster, LabelRemoveAllFinalizersOnDeletion) {
-		Expect(removeAllFinalizersFromObject(ctx, c, cluster)).
-			To(Succeed(), "there must be no error removing all finalizers from the cluster",
-				"key", client.ObjectKeyFromObject(cluster))
-	}
+		To(Succeed(), "there must be no error deleting object", "key", client.ObjectKeyFromObject(cluster))
 
 	Eventually(func() bool {
-		err := c.Get(ctx, id, cluster)
+		err := c.Get(ctx, client.ObjectKeyFromObject(cluster), cluster)
 		return apierrors.IsNotFound(err)
-	}, time.Minute, time.Second).
-		Should(BeFalse(), "the cluster should be deleted eventually")
-}
-
-// MustDeleteSecretWithLabel is used in the test context only and removes all secrets.
-func MustDeleteSecretWithLabel(ctx context.Context, c client.Client, l string) {
-	var secretList = new(corev1.SecretList)
-	listOpts := &client.ListOptions{LabelSelector: labels.SelectorFromSet(labels.Set{"greenhouse/test": l})}
-	Expect(c.List(ctx, secretList, listOpts)).
-		To(Succeed(), "there must be no error listing all secrets matching the label")
-	for _, secret := range secretList.Items {
-		cp := secret.DeepCopy()
-		Expect(c.Delete(ctx, cp)).
-			To(Succeed(), "there must be no error deleting secret", "key", client.ObjectKeyFromObject(cp))
-	}
-	Eventually(func() []corev1.Secret {
-		Expect(c.List(ctx, secretList, listOpts)).
-			To(Succeed(), "there must be no error listing all secrets matching the label")
-		return secretList.Items
-	}, time.Minute, time.Second).
-		Should(BeEmpty(), "there should be no secret left")
-}
-
-func isHasLabel(o client.Object, labelKey string) bool {
-	lbls := o.GetLabels()
-	if lbls == nil {
-		return false
-	}
-	_, ok := lbls[labelKey]
-	return ok
-}
-
-func removeAllFinalizersFromObject(ctx context.Context, c client.Client, o client.Object) error {
-	_, err := clientutil.Patch(ctx, c, o, func() error {
-		o.SetFinalizers(nil)
-		return nil
-	})
-	return err
+	}).
+		Should(BeFalse(), "the object should be deleted eventually")
 }
 
 // MustReturnJSONFor marshals val to JSON and returns an apiextensionsv1.JSON.


### PR DESCRIPTION
## Description

This change separates the tests from each other. Each controller runs in its own namespace, own remote devenv. Resources are cleaned up after each suite.
This should reduce flakiness in the tests and reduce test resources from one suite showing in the logs of another suite.

Also removes deletion logic for Secrets, as devenv does not include controllers for build-in resources


## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->
- Related Issue # (issue)
- Closes # (issue)
- Fixes # (issue)

> Remove if not applicable

## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [ ] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
