### PR TITLE
fix(plugin): reduce watches on Plugin & PluginPreset

### DIFF
--- a/pkg/apis/well_known.go
+++ b/pkg/apis/well_known.go
@@ -76,6 +76,9 @@ const (
 	// RBACPrefix is the prefix for the Role and RoleBinding names.
 	RBACPrefix = "greenhouse:"
 
+	// PluginClusterNameField is the field in the Plugin spec mapping it to a Cluster.
+	PluginClusterNameField = ".spec.clusterName"
+
 	// RolebindingRoleRefField is the field in the RoleBinding spec that references the Role.
 	RolebindingRoleRefField = ".spec.roleRef"
 

--- a/pkg/controllers/plugin/helm_controller.go
+++ b/pkg/controllers/plugin/helm_controller.go
@@ -82,9 +82,6 @@ func (r *HelmReconciler) SetupWithManager(name string, mgr ctrl.Manager) error {
 		// If a PluginDefinition was changed, reconcile relevant Plugins.
 		Watches(&greenhousev1alpha1.PluginDefinition{}, handler.EnqueueRequestsFromMapFunc(r.enqueueAllPluginsForPluginDefinition),
 			builder.WithPredicates(predicate.GenerationChangedPredicate{})).
-		// If a PluginDefinition was changed, temporarily also watch for the deprecated plugin label.
-		Watches(&greenhousev1alpha1.PluginDefinition{}, handler.EnqueueRequestsFromMapFunc(r.enqueueAllPluginsForPluginDefinitionTemp),
-			builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		// Clusters and teams are passed as values to each Helm operation. Reconcile on change.
 		Watches(&greenhousev1alpha1.Cluster{}, handler.EnqueueRequestsFromMapFunc(r.enqueueAllPlugins),
 			builder.WithPredicates(predicate.GenerationChangedPredicate{})).
@@ -423,10 +420,6 @@ func (r *HelmReconciler) enqueueAllPlugins(ctx context.Context, _ client.Object)
 
 func (r *HelmReconciler) enqueueAllPluginsInNamespace(ctx context.Context, o client.Object) []ctrl.Request {
 	return listPluginsAsReconcileRequests(ctx, r.Client, client.InNamespace(o.GetNamespace()))
-}
-
-func (r *HelmReconciler) enqueueAllPluginsForPluginDefinitionTemp(ctx context.Context, o client.Object) []ctrl.Request {
-	return listPluginsAsReconcileRequests(ctx, r.Client, client.MatchingLabels{greenhouseapis.LabelKeyPlugin: o.GetName()})
 }
 
 func (r *HelmReconciler) enqueueAllPluginsForPluginDefinition(ctx context.Context, o client.Object) []ctrl.Request {

--- a/pkg/controllers/plugin/pluginpreset_controller.go
+++ b/pkg/controllers/plugin/pluginpreset_controller.go
@@ -54,7 +54,7 @@ func (r *PluginPresetReconciler) SetupWithManager(name string, mgr ctrl.Manager)
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
 		For(&greenhousev1alpha1.PluginPreset{}).
-		Owns(&greenhousev1alpha1.Plugin{}).
+		Owns(&greenhousev1alpha1.Plugin{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		// Clusters and teams are passed as values to each Helm operation. Reconcile on change.
 		Watches(&greenhousev1alpha1.Cluster{}, handler.EnqueueRequestsFromMapFunc(r.enqueueAllPluginPresetsInNamespace),
 			builder.WithPredicates(predicate.LabelChangedPredicate{})).


### PR DESCRIPTION
## Description

- ensure PluginPreset is only reconciled when owned Plugins are changed, remove additional watch on Plugin LabelChanged
- remove Watch on deprecated Label from HelmController
- fix: ensure only plugins that refer to a cluster are queued on change


## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->
- Related Issue # (issue)
- Closes # (issue)
- Fixes # (issue)

> Remove if not applicable

## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [ ] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
