### PR TITLE
Fix(proxy): Fixes the proxy alert expression

### DIFF
--- a/charts/manager/alerts/proxies.alerts
+++ b/charts/manager/alerts/proxies.alerts
@@ -6,7 +6,7 @@ groups:
         description: '{{ $value | humanizePercentage }} of {{ $labels.method }} requests failed for {{ $labels.service }}'
         summary: 'Errors high for proxy {{$labels.service}}'
       expr: |
-        (sum by (service, method) (rate(http_requests_total{code!="200"}[5m])))/(sum by (service, method) (rate(http_requests_total{code="200"}[5m]))) > 0.1
+        (sum by (service, method) (rate(http_requests_total{code=~"4.."}[5m]) or rate(http_requests_total{code=~"5.."}[5m]))) / (sum by (service, method) (rate(http_requests_total[5m]))) > 0.1
       for: 15m
       labels:
         severity: warning


### PR DESCRIPTION
## Description
This changes the alert to 
- only alert on `4xx` and `5xx` request responses. 
- calculate the percentage of failing requests to the sum of all requests



## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert
