### PR TITLE
feat(dev-env): add DEX crds to installed CRDs

### DIFF
--- a/pkg/test/env.go
+++ b/pkg/test/env.go
@@ -225,7 +225,10 @@ func StartControlPlane(port string, installCRDs, installWebhooks bool) (*rest.Co
 	Expect(err).
 		NotTo(HaveOccurred(), "there must be no error finding the config directory")
 	if installCRDs {
-		crdPaths := []string{filepath.Join(absPathConfigBasePath, "manager", "crds")}
+		crdPaths := []string{
+			filepath.Join(absPathConfigBasePath, "manager", "crds"),
+			filepath.Join(absPathConfigBasePath, "idproxy", "crds"),
+		}
 		testEnv.CRDDirectoryPaths = crdPaths
 		testEnv.ErrorIfCRDPathMissing = true
 	}


### PR DESCRIPTION
## Description

The DEX CRDs are required by the `OrganizationDexController`. This ensures all possible CRDs required by Greenhouse are deployed to the devenv. 

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->
- Related Issue # (issue)
- Closes # (issue)
- Fixes # (issue)

> Remove if not applicable

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [x] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
