### PR TITLE
feat(pluginpreset) Skip updating when plugin is not different (#437)

### DIFF
--- a/pkg/controllers/plugin/pluginpreset_controller.go
+++ b/pkg/controllers/plugin/pluginpreset_controller.go
@@ -236,11 +236,7 @@ func shouldSkipPlugin(plugin *greenhousev1alpha1.Plugin, preset *greenhousev1alp
 		}
 	}
 
-	if len(preset.Spec.Plugin.OptionValues) < countWithoutGlobalOption(plugin.Spec.OptionValues) {
-		return false
-	}
-
-	return true
+	return len(preset.Spec.Plugin.OptionValues) >= countWithoutGlobalOption(plugin.Spec.OptionValues)
 }
 
 func containsPluginOption(list []greenhousev1alpha1.PluginOptionValue, kv greenhousev1alpha1.PluginOptionValue) bool {

--- a/pkg/controllers/plugin/pluginpreset_controller.go
+++ b/pkg/controllers/plugin/pluginpreset_controller.go
@@ -226,10 +226,6 @@ func shouldSkipPlugin(plugin *greenhousev1alpha1.Plugin, preset *greenhousev1alp
 		return true
 	}
 
-	if preset.Spec.Plugin.PluginDefinition != plugin.Spec.PluginDefinition {
-		return false
-	}
-
 	for _, presetOptionValue := range preset.Spec.Plugin.OptionValues {
 		if !containsPluginOption(plugin.Spec.OptionValues, presetOptionValue) {
 			return false

--- a/pkg/controllers/plugin/pluginpreset_controller.go
+++ b/pkg/controllers/plugin/pluginpreset_controller.go
@@ -227,22 +227,14 @@ func shouldSkipPlugin(plugin *greenhousev1alpha1.Plugin, preset *greenhousev1alp
 	}
 
 	for _, presetOptionValue := range preset.Spec.Plugin.OptionValues {
-		if !containsPluginOption(plugin.Spec.OptionValues, presetOptionValue) {
+		if !slices.ContainsFunc(plugin.Spec.OptionValues, func(item greenhousev1alpha1.PluginOptionValue) bool {
+			return item.Name == presetOptionValue.Name && string(item.Value.Raw) == string(presetOptionValue.Value.Raw)
+		}) {
 			return false
 		}
 	}
 
 	return len(preset.Spec.Plugin.OptionValues) >= countWithoutGlobalOption(plugin.Spec.OptionValues)
-}
-
-func containsPluginOption(list []greenhousev1alpha1.PluginOptionValue, kv greenhousev1alpha1.PluginOptionValue) bool {
-	for _, item := range list {
-		if item.Name == kv.Name && string(item.Value.Raw) == string(kv.Value.Raw) {
-			return true
-		}
-	}
-
-	return false
 }
 
 func countWithoutGlobalOption(list []greenhousev1alpha1.PluginOptionValue) int {

--- a/pkg/controllers/plugin/pluginpreset_controller_test.go
+++ b/pkg/controllers/plugin/pluginpreset_controller_test.go
@@ -336,6 +336,61 @@ var _ = Describe("Plugin Preset skip changes", Ordered, func() {
 			},
 			false,
 		),
+		Entry("should not skip when one of plugin preset option has different value",
+			&greenhousev1alpha1.Plugin{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						greenhouseapis.LabelKeyPluginPreset: pluginPresetName,
+					},
+				},
+				Spec: greenhousev1alpha1.PluginSpec{
+					PluginDefinition: pluginPresetDefinitionName,
+					OptionValues: []greenhousev1alpha1.PluginOptionValue{
+						{
+							Name:  "global.greenhouse.test_parameter",
+							Value: asAPIextensionJSON(2),
+						},
+						{
+							Name:  "plugin_preset.test_parameter_1",
+							Value: asAPIextensionJSON(1),
+						},
+						{
+							Name:  "plugin_preset.test_parameter_2",
+							Value: asAPIextensionJSON(2),
+						},
+						{
+							Name:  "plugin_preset.test_parameter_4",
+							Value: asAPIextensionJSON(3),
+						},
+					},
+				},
+			},
+			&greenhousev1alpha1.PluginPreset{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: pluginPresetName,
+				},
+				Spec: greenhousev1alpha1.PluginPresetSpec{
+					Plugin: greenhousev1alpha1.PluginSpec{
+						PluginDefinition: pluginPresetDefinitionName,
+						OptionValues: []greenhousev1alpha1.PluginOptionValue{
+							{
+								Name:  "plugin_preset.test_parameter_1",
+								Value: asAPIextensionJSON(1),
+							},
+							{
+								Name:  "plugin_preset.test_parameter_2",
+								Value: asAPIextensionJSON(2),
+							},
+							{
+								Name:  "plugin_preset.test_parameter_4",
+								Value: asAPIextensionJSON(4),
+							},
+						},
+					},
+				},
+			},
+			false,
+		),
 		Entry("should skip when plugin preset has the same values like plugin",
 			&greenhousev1alpha1.Plugin{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controllers/plugin/pluginpreset_controller_test.go
+++ b/pkg/controllers/plugin/pluginpreset_controller_test.go
@@ -269,27 +269,6 @@ var _ = Describe("Plugin Preset skip changes", Ordered, func() {
 						greenhouseapis.LabelKeyPluginPreset: pluginPresetName,
 					},
 				},
-				Spec: greenhousev1alpha1.PluginSpec{PluginDefinition: pluginPresetDefinitionName + "A"},
-			},
-			&greenhousev1alpha1.PluginPreset{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: pluginPresetName,
-				},
-				Spec: greenhousev1alpha1.PluginPresetSpec{
-					Plugin: greenhousev1alpha1.PluginSpec{
-						PluginDefinition: pluginPresetDefinitionName,
-					},
-				},
-			},
-			false,
-		),
-		Entry("should not skip when plugin definition is different between plugin and plugin preset",
-			&greenhousev1alpha1.Plugin{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						greenhouseapis.LabelKeyPluginPreset: pluginPresetName,
-					},
-				},
 				Spec: greenhousev1alpha1.PluginSpec{
 					PluginDefinition: pluginPresetDefinitionName,
 					OptionValues: []greenhousev1alpha1.PluginOptionValue{

--- a/pkg/controllers/plugin/pluginpreset_controller_test.go
+++ b/pkg/controllers/plugin/pluginpreset_controller_test.go
@@ -242,6 +242,260 @@ var _ = Describe("PluginPreset Controller Lifecycle", Ordered, func() {
 	})
 })
 
+var _ = Describe("Plugin Preset skip changes", Ordered, func() {
+	It("should skip when plugin preset name in plugin's labels is different then defined name in plugin preset", func() {
+		testPlugin := &greenhousev1alpha1.Plugin{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					greenhouseapis.LabelKeyPluginPreset: pluginPresetName + "A",
+				},
+			},
+		}
+
+		testPresetCase := &greenhousev1alpha1.PluginPreset{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: pluginPresetName,
+			},
+		}
+
+		Expect(shouldSkipPlugin(testPlugin, testPresetCase)).To(BeTrue())
+	})
+
+	It("should not skip when plugin definition is different between plugin and plugin preset", func() {
+		testPlugin := &greenhousev1alpha1.Plugin{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					greenhouseapis.LabelKeyPluginPreset: pluginPresetName,
+				},
+			},
+			Spec: greenhousev1alpha1.PluginSpec{PluginDefinition: pluginPresetDefinitionName + "A"},
+		}
+
+		testPresetCase := &greenhousev1alpha1.PluginPreset{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: pluginPresetName,
+			},
+			Spec: greenhousev1alpha1.PluginPresetSpec{
+				Plugin: greenhousev1alpha1.PluginSpec{
+					PluginDefinition: pluginPresetDefinitionName,
+				},
+			},
+		}
+
+		Expect(shouldSkipPlugin(testPlugin, testPresetCase)).To(BeFalse())
+	})
+
+	It("should not skip when plugin preset has option which does not exist in plugin", func() {
+		testPlugin := &greenhousev1alpha1.Plugin{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					greenhouseapis.LabelKeyPluginPreset: pluginPresetName,
+				},
+			},
+			Spec: greenhousev1alpha1.PluginSpec{
+				PluginDefinition: pluginPresetDefinitionName,
+				OptionValues: []greenhousev1alpha1.PluginOptionValue{
+					{
+						Name:  greenhouseapis.GroupName + ".test_parameter",
+						Value: asAPIextensionJSON(2),
+					},
+				},
+			},
+		}
+
+		testPresetCase := &greenhousev1alpha1.PluginPreset{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: pluginPresetName,
+			},
+			Spec: greenhousev1alpha1.PluginPresetSpec{
+				Plugin: greenhousev1alpha1.PluginSpec{
+					PluginDefinition: pluginPresetDefinitionName,
+					OptionValues: []greenhousev1alpha1.PluginOptionValue{
+						{
+							Name:  "plugin_preset.test_parameter",
+							Value: asAPIextensionJSON(3),
+						},
+					},
+				},
+			},
+		}
+
+		Expect(shouldSkipPlugin(testPlugin, testPresetCase)).To(BeFalse())
+	})
+
+	It("should not skip when plugin preset has option with different value", func() {
+		testPlugin := &greenhousev1alpha1.Plugin{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					greenhouseapis.LabelKeyPluginPreset: pluginPresetName,
+				},
+			},
+			Spec: greenhousev1alpha1.PluginSpec{
+				PluginDefinition: pluginPresetDefinitionName,
+				OptionValues: []greenhousev1alpha1.PluginOptionValue{
+					{
+						Name:  greenhouseapis.GroupName + ".test_parameter",
+						Value: asAPIextensionJSON(2),
+					},
+					{
+						Name:  "plugin_preset.test_parameter",
+						Value: asAPIextensionJSON(2),
+					},
+				},
+			},
+		}
+
+		testPresetCase := &greenhousev1alpha1.PluginPreset{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: pluginPresetName,
+			},
+			Spec: greenhousev1alpha1.PluginPresetSpec{
+				Plugin: greenhousev1alpha1.PluginSpec{
+					PluginDefinition: pluginPresetDefinitionName,
+					OptionValues: []greenhousev1alpha1.PluginOptionValue{
+						{
+							Name:  "plugin_preset.test_parameter",
+							Value: asAPIextensionJSON(3),
+						},
+					},
+				},
+			},
+		}
+
+		Expect(shouldSkipPlugin(testPlugin, testPresetCase)).To(BeFalse())
+	})
+
+	It("should skip when plugin preset has the same values like plugin", func() {
+		testPlugin := &greenhousev1alpha1.Plugin{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					greenhouseapis.LabelKeyPluginPreset: pluginPresetName,
+				},
+			},
+			Spec: greenhousev1alpha1.PluginSpec{
+				PluginDefinition: pluginPresetDefinitionName,
+				OptionValues: []greenhousev1alpha1.PluginOptionValue{
+					{
+						Name:  "global.greenhouse.test_parameter",
+						Value: asAPIextensionJSON(2),
+					},
+					{
+						Name:  "plugin_preset.test_parameter",
+						Value: asAPIextensionJSON(3),
+					},
+				},
+			},
+		}
+
+		testPresetCase := &greenhousev1alpha1.PluginPreset{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: pluginPresetName,
+			},
+			Spec: greenhousev1alpha1.PluginPresetSpec{
+				Plugin: greenhousev1alpha1.PluginSpec{
+					PluginDefinition: pluginPresetDefinitionName,
+					OptionValues: []greenhousev1alpha1.PluginOptionValue{
+						{
+							Name:  "plugin_preset.test_parameter",
+							Value: asAPIextensionJSON(3),
+						},
+					},
+				},
+			},
+		}
+
+		Expect(shouldSkipPlugin(testPlugin, testPresetCase)).To(BeTrue())
+	})
+
+	It("should not skip when plugin has custom values", func() {
+		testPlugin := &greenhousev1alpha1.Plugin{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					greenhouseapis.LabelKeyPluginPreset: pluginPresetName,
+				},
+			},
+			Spec: greenhousev1alpha1.PluginSpec{
+				PluginDefinition: pluginPresetDefinitionName,
+				OptionValues: []greenhousev1alpha1.PluginOptionValue{
+					{
+						Name:  "greenhouse.global.test_parameter",
+						Value: asAPIextensionJSON(2),
+					},
+					{
+						Name:  "plugin_preset.test_parameter",
+						Value: asAPIextensionJSON(3),
+					},
+					{
+						Name:  "custom_parameter",
+						Value: asAPIextensionJSON(123),
+					},
+				},
+			},
+		}
+
+		testPresetCase := &greenhousev1alpha1.PluginPreset{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: pluginPresetName,
+			},
+			Spec: greenhousev1alpha1.PluginPresetSpec{
+				Plugin: greenhousev1alpha1.PluginSpec{
+					PluginDefinition: pluginPresetDefinitionName,
+					OptionValues: []greenhousev1alpha1.PluginOptionValue{
+						{
+							Name:  "plugin_preset.test_parameter",
+							Value: asAPIextensionJSON(3),
+						},
+					},
+				},
+			},
+		}
+
+		Expect(shouldSkipPlugin(testPlugin, testPresetCase)).To(BeFalse())
+	})
+
+	It("should skip when plugin preset has the same values like plugin", func() {
+		testPlugin := &greenhousev1alpha1.Plugin{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					greenhouseapis.LabelKeyPluginPreset: pluginPresetName,
+				},
+			},
+			Spec: greenhousev1alpha1.PluginSpec{
+				PluginDefinition: pluginPresetDefinitionName,
+				OptionValues: []greenhousev1alpha1.PluginOptionValue{
+					{
+						Name:  "global.greenhouse.test_parameter",
+						Value: asAPIextensionJSON(2),
+					},
+					{
+						Name:  "plugin_preset.test_parameter",
+						Value: asAPIextensionJSON(3),
+					},
+				},
+			},
+		}
+
+		testPresetCase := &greenhousev1alpha1.PluginPreset{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: pluginPresetName,
+			},
+			Spec: greenhousev1alpha1.PluginPresetSpec{
+				Plugin: greenhousev1alpha1.PluginSpec{
+					PluginDefinition: pluginPresetDefinitionName,
+					OptionValues: []greenhousev1alpha1.PluginOptionValue{
+						{
+							Name:  "plugin_preset.test_parameter",
+							Value: asAPIextensionJSON(3),
+						},
+					},
+				},
+			},
+		}
+
+		Expect(shouldSkipPlugin(testPlugin, testPresetCase)).To(BeTrue())
+	})
+})
+
 var _ = Describe("overridesPluginOptionValues", Ordered, func() {
 	DescribeTable("test cases", func(plugin *greenhousev1alpha1.Plugin, preset *greenhousev1alpha1.PluginPreset, expectedPlugin *greenhousev1alpha1.Plugin) {
 		overridesPluginOptionValues(plugin, preset)

--- a/pkg/controllers/plugin/pluginpreset_controller_test.go
+++ b/pkg/controllers/plugin/pluginpreset_controller_test.go
@@ -296,7 +296,7 @@ var _ = Describe("Plugin Preset skip changes", Ordered, func() {
 			&greenhousev1alpha1.PluginDefinition{},
 			true,
 		),
-		Entry("should not skip when plugin definition is different between plugin and plugin preset",
+		Entry("should not skip when plugin preset contains options which is not present in plugin",
 			&greenhousev1alpha1.Plugin{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
@@ -307,7 +307,7 @@ var _ = Describe("Plugin Preset skip changes", Ordered, func() {
 					PluginDefinition: pluginPresetDefinitionName,
 					OptionValues: []greenhousev1alpha1.PluginOptionValue{
 						{
-							Name:  greenhouseapis.GroupName + ".test_parameter",
+							Name:  "global.greenhouse.test_parameter",
 							Value: asAPIextensionJSON(2),
 						},
 					},
@@ -343,7 +343,7 @@ var _ = Describe("Plugin Preset skip changes", Ordered, func() {
 					PluginDefinition: pluginPresetDefinitionName,
 					OptionValues: []greenhousev1alpha1.PluginOptionValue{
 						{
-							Name:  greenhouseapis.GroupName + ".test_parameter",
+							Name:  "global.greenhouse.test_parameter",
 							Value: asAPIextensionJSON(2),
 						},
 						{
@@ -372,7 +372,7 @@ var _ = Describe("Plugin Preset skip changes", Ordered, func() {
 			&greenhousev1alpha1.PluginDefinition{},
 			false,
 		),
-		Entry("should not skip when one of plugin preset option has different value",
+		Entry("should not skip when one of plugin preset option has more then one value and one of them is different then option in plugin",
 			&greenhousev1alpha1.Plugin{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
@@ -479,7 +479,7 @@ var _ = Describe("Plugin Preset skip changes", Ordered, func() {
 					PluginDefinition: pluginPresetDefinitionName,
 					OptionValues: []greenhousev1alpha1.PluginOptionValue{
 						{
-							Name:  "greenhouse.global.test_parameter",
+							Name:  "global.greenhouse.test_parameter",
 							Value: asAPIextensionJSON(2),
 						},
 						{
@@ -511,46 +511,6 @@ var _ = Describe("Plugin Preset skip changes", Ordered, func() {
 			},
 			&greenhousev1alpha1.PluginDefinition{},
 			false,
-		),
-		Entry("should skip when plugin preset has the same values like plugin",
-			&greenhousev1alpha1.Plugin{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						greenhouseapis.LabelKeyPluginPreset: pluginPresetName,
-					},
-				},
-				Spec: greenhousev1alpha1.PluginSpec{
-					PluginDefinition: pluginPresetDefinitionName,
-					OptionValues: []greenhousev1alpha1.PluginOptionValue{
-						{
-							Name:  "global.greenhouse.test_parameter",
-							Value: asAPIextensionJSON(2),
-						},
-						{
-							Name:  "plugin_preset.test_parameter",
-							Value: asAPIextensionJSON(3),
-						},
-					},
-				},
-			},
-			&greenhousev1alpha1.PluginPreset{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: pluginPresetName,
-				},
-				Spec: greenhousev1alpha1.PluginPresetSpec{
-					Plugin: greenhousev1alpha1.PluginSpec{
-						PluginDefinition: pluginPresetDefinitionName,
-						OptionValues: []greenhousev1alpha1.PluginOptionValue{
-							{
-								Name:  "plugin_preset.test_parameter",
-								Value: asAPIextensionJSON(3),
-							},
-						},
-					},
-				},
-			},
-			&greenhousev1alpha1.PluginDefinition{},
-			true,
 		),
 		Entry("should skip when plugin has default values from plugin definition",
 			&greenhousev1alpha1.Plugin{


### PR DESCRIPTION
## Description
Add skipping of updating if plugin preset has not been changed.

## What type of PR is this? (check all applicable)

- [X] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->
- Related Issue # (issue)
- Closes #437
- Fixes # (issue)

> Remove if not applicable

## Added tests?

- [X] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [X] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
