### PR TITLE
feat(rbac): allow OrgAdmins to view secrets, configmaps & workload res

### DIFF
--- a/pkg/rbac/role.go
+++ b/pkg/rbac/role.go
@@ -22,7 +22,7 @@ func OrganizationAdminPolicyRules() []rbacv1.PolicyRule {
 		// Grant permissions for secrets referenced by other resources, e.g. Plugins for storing sensitive values.
 		// Retrieving these secrets is not permitted to the user.
 		{
-			Verbs:     []string{"create", "update", "patch"},
+			Verbs:     []string{"get", "create", "update", "patch"},
 			APIGroups: []string{corev1.GroupName},
 			Resources: []string{"secrets"},
 		},
@@ -43,6 +43,12 @@ func OrganizationAdminPolicyRules() []rbacv1.PolicyRule {
 			Verbs:     []string{"get", "list", "watch"},
 			APIGroups: []string{"monitoring.coreos.com"},
 			Resources: []string{"alertmanagers", "alertmanagerconfigs"},
+		},
+		// Grant permission to view Pods, ReplicaSets, Deployments, StatefulSets, DaemonSets, CronJobs, Jobs, ConfigMaps
+		{
+			Verbs:     []string{"get", "list", "watch"},
+			APIGroups: []string{""},
+			Resources: []string{"pods", "replicasets", "deployments", "statefulsets", "daemonsets", "cronjobs", "jobs", "configmaps"},
 		},
 	}
 	orgAdminPolicyRules = append(orgAdminPolicyRules,


### PR DESCRIPTION
## Description
allow OrgAdmins to view secrets, configmaps & workload ressources in their namespace

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->
- Related Issue # (issue)
- Closes # (issue)
- Fixes # (issue)

> Remove if not applicable

## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [ ] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
