### PR TITLE
(fix): create namespace using kubeconfig

### DIFF
--- a/pkg/internal/local/klient/kind.go
+++ b/pkg/internal/local/klient/kind.go
@@ -81,16 +81,17 @@ func getKindClusters() ([]string, error) {
 }
 
 // CreateNamespace - creates a namespace with the given name
-func CreateNamespace(namespaceName string) error {
+func CreateNamespace(namespaceName, kubeconfig string) error {
 	if strings.TrimSpace(namespaceName) == "" {
 		return errors.New("namespace name cannot be empty")
 	}
 	return utils.ShellPipe{
 		Shells: []utils.Shell{
 			{
-				Cmd: "kubectl create namespace ${namespace} --dry-run=client -o yaml",
+				Cmd: "kubectl create namespace ${namespace} --kubeconfig=${kubeconfig} --dry-run=client -o yaml",
 				Vars: map[string]string{
-					"namespace": namespaceName,
+					"namespace":  namespaceName,
+					"kubeconfig": kubeconfig,
 				},
 			},
 			{

--- a/pkg/internal/local/setup/cluster.go
+++ b/pkg/internal/local/setup/cluster.go
@@ -28,13 +28,11 @@ func clusterSetup(env *ExecutionEnv) error {
 	if err != nil {
 		return err
 	}
-	if env.cluster.Namespace != nil {
-		err = klient.CreateNamespace(*env.cluster.Namespace)
-		if err != nil {
-			return err
-		}
+	err = env.cluster.saveConfig() // save kubeconfig after cluster creation
+	if err != nil {
+		return err
 	}
-	err = env.cluster.saveConfig()
+	err = env.cluster.createNamespace() // create namespace if specified using kubeconfig
 	if err != nil {
 		return err
 	}
@@ -63,4 +61,11 @@ func (c *Cluster) saveConfig() error {
 	}
 	c.kubeConfigPath = filepath.Join(dir, file)
 	return nil
+}
+
+func (c *Cluster) createNamespace() error {
+	if c.Namespace == nil {
+		return nil
+	}
+	return klient.CreateNamespace(*c.Namespace, c.kubeConfigPath)
 }


### PR DESCRIPTION
## Description

During the usage of `greenhousectl dev setup` the namespace `greenhouse` creation for the central / admin cluster was done using `kubectl create namespace ....` command, which uses the current-context. 

`KinD` CLI always sets the current-context and if the cluster exists we make sure to set the current-context of the `KinD` cluster being used.

But the pkg `https://github.com/vladimirvivien/gexe` uses a dedicated session for each shell command that is executed in the dev setup process. The current context of `KinD` will not be made available in the next session as the previous session is destroyed.

To prevent applying to wrong context `--kubeconfig` parameter is passed to the command, retrieved from the previous step during cluster creation.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
