### PR TITLE
refac(org): controller reconciles namespace and team

### DIFF
--- a/cmd/greenhouse/controllers.go
+++ b/cmd/greenhouse/controllers.go
@@ -21,7 +21,7 @@ import (
 // knownControllers contains all controllers to be registered when starting the operator.
 var knownControllers = map[string]func(controllerName string, mgr ctrl.Manager) error{
 	// Organization controllers.
-	"organizationNamespace":      (&organizationcontrollers.NamespaceReconciler{}).SetupWithManager,
+	"organizationController":     (&organizationcontrollers.OrganizationReconciler{}).SetupWithManager,
 	"organizationRBAC":           (&organizationcontrollers.RBACReconciler{}).SetupWithManager,
 	"organizationDEX":            startOrganizationDexReconciler,
 	"organizationServiceProxy":   (&organizationcontrollers.ServiceProxyReconciler{}).SetupWithManager,

--- a/pkg/controllers/organization/organization_controller.go
+++ b/pkg/controllers/organization/organization_controller.go
@@ -29,6 +29,7 @@ type OrganizationReconciler struct {
 //+kubebuilder:rbac:groups=greenhouse.sap,resources=organizations,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=greenhouse.sap,resources=organizations/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=greenhouse.sap,resources=organizations/finalizers,verbs=update
+//+kubebuilder:rbac:groups=greenhouse.sap,resources=teams,verbs=delete
 //+kubebuilder:rbac:groups="",resources=events,verbs=get;list;watch;create;update;patch
 //+kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch;create;update;patch
 
@@ -112,7 +113,7 @@ func (r *OrganizationReconciler) reconcileAdminTeam(ctx context.Context, org *gr
 	result, err := clientutil.CreateOrPatch(ctx, r.Client, team, func() error {
 		team.Spec.Description = "Admin team for the organization"
 		team.Spec.MappedIDPGroup = mappedOrgAdminIDPGroup
-		return controllerutil.SetOwnerReference(org, team, r.Scheme())
+		return controllerutil.SetControllerReference(org, team, r.Scheme())
 	})
 	if err != nil {
 		return err

--- a/pkg/controllers/organization/organization_controller.go
+++ b/pkg/controllers/organization/organization_controller.go
@@ -29,7 +29,7 @@ type OrganizationReconciler struct {
 //+kubebuilder:rbac:groups=greenhouse.sap,resources=organizations,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=greenhouse.sap,resources=organizations/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=greenhouse.sap,resources=organizations/finalizers,verbs=update
-//+kubebuilder:rbac:groups=greenhouse.sap,resources=teams,verbs=delete
+//+kubebuilder:rbac:groups=greenhouse.sap,resources=teams,verbs=update;patch;delete
 //+kubebuilder:rbac:groups="",resources=events,verbs=get;list;watch;create;update;patch
 //+kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch;create;update;patch
 

--- a/pkg/controllers/organization/organization_controller.go
+++ b/pkg/controllers/organization/organization_controller.go
@@ -13,9 +13,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
-
 	greenhousesapv1alpha1 "github.com/cloudoperators/greenhouse/pkg/apis/greenhouse/v1alpha1"
 	"github.com/cloudoperators/greenhouse/pkg/clientutil"
 )
@@ -86,17 +83,10 @@ func (r *OrganizationReconciler) reconcileNamespace(ctx context.Context, org *gr
 }
 
 func (r *OrganizationReconciler) reconcileAdminTeam(ctx context.Context, org *greenhousesapv1alpha1.Organization) error {
-	orgAdminTeamName := org.Name + "-admin"
 	namespace := org.Name
 
-	var orgAdminTeam = new(greenhousesapv1alpha1.Team)
-	err := r.Get(ctx, types.NamespacedName{Name: orgAdminTeamName, Namespace: namespace}, orgAdminTeam)
-	if !apierrors.IsNotFound(err) && err != nil {
-		return err
-	}
-
 	var team = new(greenhousesapv1alpha1.Team)
-	team.Name = orgAdminTeamName
+	team.Name = org.Name + "-admin"
 	team.Namespace = namespace
 
 	result, err := clientutil.CreateOrPatch(ctx, r.Client, team, func() error {

--- a/pkg/controllers/organization/organization_controller_test.go
+++ b/pkg/controllers/organization/organization_controller_test.go
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package organization_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	greenhousev1alpha1 "github.com/cloudoperators/greenhouse/pkg/apis/greenhouse/v1alpha1"
+	"github.com/cloudoperators/greenhouse/pkg/test"
+)
+
+var _ = Describe("Test Organization reconciliation", func() {
+	const (
+		testOrgName  = "test-org-1"
+		idpGroupName = "SOME-IDP-GROUP"
+	)
+	var (
+		setup    *test.TestSetup
+		ownerRef metav1.OwnerReference
+	)
+
+	BeforeEach(func() {
+		setup = test.NewTestSetup(test.Ctx, test.K8sClient, test.TestNamespace)
+	})
+
+	When("reconciling an organization", func() {
+		It("should create a namespace for new organization", func() {
+			testOrg := setup.CreateOrganization(test.Ctx, testOrgName)
+			test.EventuallyCreated(test.Ctx, test.K8sClient, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testOrgName}})
+			ownerRef = metav1.OwnerReference{
+				APIVersion: greenhousev1alpha1.GroupVersion.String(),
+				Kind:       "Organization",
+				UID:        testOrg.UID,
+				Name:       testOrg.Name,
+			}
+		})
+
+		It("should create admin team for organization", func() {
+			var team = &greenhousev1alpha1.Team{}
+			Eventually(func(g Gomega) {
+				err := setup.Get(test.Ctx, types.NamespacedName{Name: testOrgName + "-admin", Namespace: testOrgName}, team)
+				g.Expect(err).ToNot(HaveOccurred(), "Admin Team should be created for organization")
+			}).Should(Succeed(), "Admin team should be created for organization")
+
+			Eventually(team.OwnerReferences).Should(ContainElement(ownerRef), "Admin Team must have the correct owner reference")
+		})
+
+		It("should update admin team when MappedOrgAdminIDPGroup changes", func() {
+			var org = &greenhousev1alpha1.Organization{}
+			err := setup.Get(test.Ctx, types.NamespacedName{Name: testOrgName, Namespace: ""}, org)
+			Expect(err).ToNot(HaveOccurred(), "there must be no error getting the organization")
+
+			By("updating MappedOrgAdminIDPGroup in Organization")
+			org.Spec.MappedOrgAdminIDPGroup = idpGroupName
+			err = setup.Update(test.Ctx, org)
+			Expect(err).ToNot(HaveOccurred(), "there must be no error updating the organization")
+
+			var team = &greenhousev1alpha1.Team{}
+			Eventually(func(g Gomega) {
+				err := setup.Get(test.Ctx, types.NamespacedName{Name: testOrgName + "-admin", Namespace: testOrgName}, team)
+				g.Expect(err).ToNot(HaveOccurred(), "there should be no error getting org admin team")
+				g.Expect(team.Spec.MappedIDPGroup).To(Equal(idpGroupName), "Admin team should be updated with new IDPGroup")
+			}).Should(Succeed(), "Admin team should be updated with new IDPGroup")
+			Eventually(team.OwnerReferences).Should(ContainElement(ownerRef), "Admin Team must have the correct owner reference")
+		})
+	})
+})

--- a/pkg/controllers/organization/organization_controller_test.go
+++ b/pkg/controllers/organization/organization_controller_test.go
@@ -21,34 +21,45 @@ var _ = Describe("Test Organization reconciliation", func() {
 		anotherIdpGroupName = "ANOTHER-IDP-GROUP"
 	)
 	var (
-		setup    *test.TestSetup
-		ownerRef metav1.OwnerReference
+		setup   *test.TestSetup
+		testOrg *greenhousev1alpha1.Organization
 	)
 
 	BeforeEach(func() {
 		setup = test.NewTestSetup(test.Ctx, test.K8sClient, test.TestNamespace)
+		testOrg = setup.CreateOrganization(test.Ctx, testOrgName, func(org *greenhousev1alpha1.Organization) {
+			org.Spec.MappedOrgAdminIDPGroup = someIdpGroupName
+		})
+	})
+
+	AfterEach(func() {
+		test.EventuallyDeleted(test.Ctx, setup.Client, testOrg)
 	})
 
 	When("reconciling an organization", func() {
 		It("should create a namespace for new organization", func() {
-			testOrg := setup.CreateOrganization(test.Ctx, testOrgName)
 			test.EventuallyCreated(test.Ctx, test.K8sClient, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testOrgName}})
-			b := true
-			ownerRef = metav1.OwnerReference{
-				APIVersion:         greenhousev1alpha1.GroupVersion.String(),
-				Kind:               "Organization",
-				UID:                testOrg.UID,
-				Name:               testOrg.Name,
-				Controller:         &b,
-				BlockOwnerDeletion: &b,
-			}
 		})
 
 		It("should create admin team for organization", func() {
+			var org = &greenhousev1alpha1.Organization{}
+			err := setup.Get(test.Ctx, types.NamespacedName{Name: testOrgName, Namespace: ""}, org)
+			Expect(err).ShouldNot(HaveOccurred(), "there must be no error getting the organization")
+			b := true
+			ownerRef := metav1.OwnerReference{
+				APIVersion:         greenhousev1alpha1.GroupVersion.String(),
+				Kind:               "Organization",
+				UID:                org.UID,
+				Name:               org.Name,
+				Controller:         &b,
+				BlockOwnerDeletion: &b,
+			}
+
 			var team = &greenhousev1alpha1.Team{}
 			Eventually(func(g Gomega) {
 				err := setup.Get(test.Ctx, types.NamespacedName{Name: testOrgName + "-admin", Namespace: testOrgName}, team)
 				g.Expect(err).ToNot(HaveOccurred(), "Admin Team should be created for organization")
+				g.Expect(team.Spec.MappedIDPGroup).To(Equal(someIdpGroupName), "Admin Team should have the same idp group name as organization")
 				g.Expect(team.OwnerReferences).Should(ContainElement(ownerRef), "Admin Team must have the correct owner reference")
 			}).Should(Succeed(), "Admin team should be created for organization")
 		})
@@ -60,7 +71,7 @@ var _ = Describe("Test Organization reconciliation", func() {
 			}).ShouldNot(HaveOccurred(), "there must be no error getting the organization")
 
 			By("updating MappedOrgAdminIDPGroup in Organization")
-			org.Spec.MappedOrgAdminIDPGroup = someIdpGroupName
+			org.Spec.MappedOrgAdminIDPGroup = anotherIdpGroupName
 			err := setup.Update(test.Ctx, org)
 			Expect(err).ToNot(HaveOccurred(), "there must be no error updating the organization")
 
@@ -68,8 +79,7 @@ var _ = Describe("Test Organization reconciliation", func() {
 			Eventually(func(g Gomega) {
 				err := setup.Get(test.Ctx, types.NamespacedName{Name: testOrgName + "-admin", Namespace: testOrgName}, team)
 				g.Expect(err).ToNot(HaveOccurred(), "there should be no error getting org admin team")
-				g.Expect(team.Spec.MappedIDPGroup).To(Equal(someIdpGroupName), "Admin team should be updated with new IDPGroup")
-				g.Expect(team.OwnerReferences).Should(ContainElement(ownerRef), "Admin Team must have the correct owner reference")
+				g.Expect(team.Spec.MappedIDPGroup).To(Equal(anotherIdpGroupName), "Admin team should be updated with new IDPGroup")
 			}).Should(Succeed(), "Admin team should be updated with new IDPGroup")
 		})
 
@@ -87,7 +97,6 @@ var _ = Describe("Test Organization reconciliation", func() {
 				err := setup.Get(test.Ctx, types.NamespacedName{Name: testOrgName + "-admin", Namespace: testOrgName}, team)
 				g.Expect(err).ToNot(HaveOccurred(), "there should be no error getting org admin team")
 				g.Expect(team.Spec.MappedIDPGroup).To(Equal(someIdpGroupName), "Admin team should be updated with organization IDPGroup")
-				g.Expect(team.OwnerReferences).Should(ContainElement(ownerRef), "Admin Team must have the correct owner reference")
 			}).Should(Succeed(), "Admin team should be updated with organization IDPGroup")
 		})
 
@@ -103,7 +112,6 @@ var _ = Describe("Test Organization reconciliation", func() {
 			Eventually(func(g Gomega) {
 				err := setup.Get(test.Ctx, types.NamespacedName{Name: testOrgName + "-admin", Namespace: testOrgName}, team)
 				g.Expect(err).ToNot(HaveOccurred(), "there should be no error getting org admin team")
-				g.Expect(team.OwnerReferences).Should(ContainElement(ownerRef), "Admin Team must have the correct owner reference")
 			}).Should(Succeed(), "Org admin team should be recreated")
 		})
 	})

--- a/pkg/controllers/organization/rbac_controller_test.go
+++ b/pkg/controllers/organization/rbac_controller_test.go
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
 // SPDX-License-Identifier: Apache-2.0
 
-package organization
+package organization_test
 
 import (
 	. "github.com/onsi/ginkgo/v2"
@@ -16,17 +16,15 @@ import (
 	"github.com/cloudoperators/greenhouse/pkg/test"
 )
 
-const (
-	orgName = "test-org-rbac"
-)
-
-var (
-	setup *test.TestSetup
-)
-
-var ownerRef metav1.OwnerReference
-
 var _ = Describe("Test RBAC reconciliation", func() {
+	const (
+		orgName = "test-org-rbac"
+	)
+	var (
+		setup    *test.TestSetup
+		ownerRef metav1.OwnerReference
+	)
+
 	BeforeEach(func() {
 		setup = test.NewTestSetup(test.Ctx, test.K8sClient, "org-rbac-test")
 	})

--- a/pkg/controllers/organization/suite_test.go
+++ b/pkg/controllers/organization/suite_test.go
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
 // SPDX-License-Identifier: Apache-2.0
 
-package organization
+package organization_test
 
 import (
 	"testing"
@@ -10,6 +10,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/cloudoperators/greenhouse/pkg/admission"
+	organizationpkg "github.com/cloudoperators/greenhouse/pkg/controllers/organization"
 	"github.com/cloudoperators/greenhouse/pkg/test"
 )
 
@@ -19,9 +20,10 @@ func TestOrganization(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	test.RegisterController("namespaceController", (&NamespaceReconciler{}).SetupWithManager)
-	test.RegisterController("organizationController", (&RBACReconciler{}).SetupWithManager)
+	test.RegisterController("organizationController", (&organizationpkg.OrganizationReconciler{}).SetupWithManager)
+	test.RegisterController("organizationRBAC", (&organizationpkg.RBACReconciler{}).SetupWithManager)
 	test.RegisterWebhook("orgWebhook", admission.SetupOrganizationWebhookWithManager)
+	test.RegisterWebhook("teamWebhook", admission.SetupTeamWebhookWithManager)
 	test.TestBeforeSuite()
 })
 

--- a/pkg/test/resources.go
+++ b/pkg/test/resources.go
@@ -127,7 +127,7 @@ func (t *TestSetup) CreateCluster(ctx context.Context, name string, opts ...func
 }
 
 // CreateOrganization creates a Organization within the TestSetup and returns the created Organization resource.
-func (t *TestSetup) CreateOrganization(ctx context.Context, name string) *greenhousev1alpha1.Organization {
+func (t *TestSetup) CreateOrganization(ctx context.Context, name string, opts ...func(*greenhousev1alpha1.Organization)) *greenhousev1alpha1.Organization {
 	GinkgoHelper()
 	org := &greenhousev1alpha1.Organization{
 		TypeMeta: metav1.TypeMeta{
@@ -137,6 +137,9 @@ func (t *TestSetup) CreateOrganization(ctx context.Context, name string) *greenh
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},
+	}
+	for _, o := range opts {
+		o(org)
 	}
 	Expect(t.Create(ctx, org)).Should(Succeed(), "there should be no error creating the Organization")
 	return org

--- a/test/e2e/controllers.go
+++ b/test/e2e/controllers.go
@@ -26,7 +26,7 @@ const (
 // knownControllers contains all controllers to be registered when starting the e2e test suite
 var knownControllers = map[string]func(controllerName string, mgr ctrl.Manager) error{
 	// Organization controllers.
-	"organizationNamespace":      (&organizationcontrollers.NamespaceReconciler{}).SetupWithManager,
+	"organizationController":     (&organizationcontrollers.OrganizationReconciler{}).SetupWithManager,
 	"organizationRBAC":           (&organizationcontrollers.RBACReconciler{}).SetupWithManager,
 	"organizationDEX":            startOrganizationDexReconciler,
 	"organizationServiceProxy":   (&organizationcontrollers.ServiceProxyReconciler{}).SetupWithManager,


### PR DESCRIPTION
## Description

This PR refactors NamespaceController into OrganizationController. It adds Org Admin Team reconciliation into the OrganizationController. Org admin team's purpose is then to be used by TeamMembershipController to create TeamMemberships.

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

- Closes #478 

## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Added integration tests checking the logic of OrganizationController updater.
Run ginkgo tests in `greenhouse/pkg/controllers/organization` directory.

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [x] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
