### PR TITLE
fix(dev-env): provide kubeconfig param for namespace apply

### DIFF
--- a/pkg/internal/local/klient/kind.go
+++ b/pkg/internal/local/klient/kind.go
@@ -17,14 +17,10 @@ func CreateCluster(clusterName string) error {
 	exists, err := clusterExists(clusterName)
 	if err != nil {
 		return err
-	} else if exists {
+	}
+	if exists {
 		utils.Logf("kind cluster with name %s already exists", clusterName)
-		return utils.Shell{
-			Cmd: "kubectl config set-context kind-${name}",
-			Vars: map[string]string{
-				"name": clusterName,
-			},
-		}.Exec()
+		return nil
 	}
 	return utils.Shell{
 		Cmd: "kind create cluster --name ${name}",
@@ -95,7 +91,10 @@ func CreateNamespace(namespaceName, kubeconfig string) error {
 				},
 			},
 			{
-				Cmd: "kubectl apply -f -",
+				Cmd: "kubectl apply --kubeconfig=${kubeconfig} -f -",
+				Vars: map[string]string{
+					"kubeconfig": kubeconfig,
+				},
 			},
 		},
 	}.Exec()


### PR DESCRIPTION
## Description

`namespace` apply must use the cluster kubeconfig otherwise `kubectl` relies on current context leading to apply of resource to wrong cluster.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [x] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
