### PR TITLE
Improve helm chart test controller

### DIFF
--- a/charts/manager/alerts/operator.alerts
+++ b/charts/manager/alerts/operator.alerts
@@ -21,7 +21,7 @@ groups:
         severity: warning
     - alert: GreenhouseOperatorWorkqueueNotDrained
       annotations:
-        description:  The workqueue backlog of Greenhuse Operator controller - {{ $labels.name }} is not getting drained.
+        description:  The workqueue backlog of Greenhouse Operator controller - {{ $labels.name }} is not getting drained.
         summary: Greenhouse Operator controller - {{ $labels.name }}'s backlog is not being drained.
       expr: |
         sum by (name) (rate(workqueue_depth{job="greenhouse-controller-manager-metrics-service"}[5m])) > 0

--- a/pkg/controllers/plugin/helm_chart_test_controller.go
+++ b/pkg/controllers/plugin/helm_chart_test_controller.go
@@ -75,7 +75,7 @@ func (r *HelmChartTestReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 	// Helm Chart Test cannot be done as the Helm Chart deployment is not successful
 	if plugin.Status.HelmReleaseStatus.Status != "deployed" {
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{}, nil
 	}
 
 	pluginStatus := initPluginStatus(&plugin)


### PR DESCRIPTION
This PR removes the requeue logic from the helmChartTestcontroller when the helmStatus is "not deployed". As, a new reconciliation will be automatically triggered when the HelmReleaseStatus changes to "deployed". 