### PR TITLE
fix(pluginpreset): handle valueFrom in shouldSkipPlugin

### DIFF
--- a/docs/reference/api/openapi.yaml
+++ b/docs/reference/api/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Greenhouse
-  version: 8cf8689
+  version: c8969a5
   description: PlusOne operations platform
 paths:
   /Team:

--- a/pkg/apis/greenhouse/v1alpha1/plugin_types.go
+++ b/pkg/apis/greenhouse/v1alpha1/plugin_types.go
@@ -43,11 +43,11 @@ type PluginOptionValue struct {
 }
 
 // ValueJSON returns the value as JSON.
-func (v *PluginOptionValue) ValueJSON() (string, error) {
+func (v *PluginOptionValue) ValueJSON() string {
 	if v.Value == nil {
-		return "", nil
+		return ""
 	}
-	return string(v.Value.Raw), nil
+	return string(v.Value.Raw)
 }
 
 const (

--- a/pkg/controllers/plugin/pluginpreset_controller_test.go
+++ b/pkg/controllers/plugin/pluginpreset_controller_test.go
@@ -605,6 +605,117 @@ var _ = Describe("Plugin Preset skip changes", Ordered, func() {
 				},
 			},
 			false,
+		), Entry("should not skip when Plugin has different valueFrom then PluginDefinition",
+			&greenhousev1alpha1.Plugin{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						greenhouseapis.LabelKeyPluginPreset: pluginPresetName,
+					},
+				},
+				Spec: greenhousev1alpha1.PluginSpec{
+					PluginDefinition: pluginPresetDefinitionName,
+					OptionValues: []greenhousev1alpha1.PluginOptionValue{
+						{
+							Name:  "global.greenhouse.test_parameter",
+							Value: asAPIextensionJSON(2),
+						},
+						{
+							Name: "plugin_definition.test_parameter",
+							ValueFrom: &greenhousev1alpha1.ValueFromSource{
+								Secret: &greenhousev1alpha1.SecretKeyReference{
+									Name: "test-secret",
+									Key:  "test-key",
+								},
+							},
+						},
+					},
+				},
+			},
+			&greenhousev1alpha1.PluginPreset{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: pluginPresetName,
+				},
+				Spec: greenhousev1alpha1.PluginPresetSpec{
+					Plugin: greenhousev1alpha1.PluginSpec{
+						PluginDefinition: pluginPresetDefinitionName,
+						OptionValues:     []greenhousev1alpha1.PluginOptionValue{},
+					},
+				},
+			},
+			&greenhousev1alpha1.PluginDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: pluginPresetDefinitionName,
+				},
+				Spec: greenhousev1alpha1.PluginDefinitionSpec{
+					Options: []greenhousev1alpha1.PluginOption{
+						{
+							Name:    "plugin_definition.test_parameter",
+							Default: asAPIextensionJSON(4),
+						},
+					},
+				},
+			},
+			false,
+		), Entry("should skip when Plugin has same valueFrom as PluginDefinition",
+			&greenhousev1alpha1.Plugin{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						greenhouseapis.LabelKeyPluginPreset: pluginPresetName,
+					},
+				},
+				Spec: greenhousev1alpha1.PluginSpec{
+					PluginDefinition: pluginPresetDefinitionName,
+					OptionValues: []greenhousev1alpha1.PluginOptionValue{
+						{
+							Name:  "global.greenhouse.test_parameter",
+							Value: asAPIextensionJSON(2),
+						},
+						{
+							Name: "plugin_definition.test_parameter",
+							ValueFrom: &greenhousev1alpha1.ValueFromSource{
+								Secret: &greenhousev1alpha1.SecretKeyReference{
+									Name: "test-secret",
+									Key:  "test-key",
+								},
+							},
+						},
+					},
+				},
+			},
+			&greenhousev1alpha1.PluginPreset{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: pluginPresetName,
+				},
+				Spec: greenhousev1alpha1.PluginPresetSpec{
+					Plugin: greenhousev1alpha1.PluginSpec{
+						PluginDefinition: pluginPresetDefinitionName,
+						OptionValues: []greenhousev1alpha1.PluginOptionValue{
+							{Name: "plugin_definition.test_parameter",
+								ValueFrom: &greenhousev1alpha1.ValueFromSource{
+									Secret: &greenhousev1alpha1.SecretKeyReference{
+										Name: "test-secret",
+										Key:  "test-key",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			&greenhousev1alpha1.PluginDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: pluginPresetDefinitionName,
+				},
+				Spec: greenhousev1alpha1.PluginDefinitionSpec{
+					Options: []greenhousev1alpha1.PluginOption{
+						{
+							Name:    "plugin_definition.test_parameter",
+							Default: asAPIextensionJSON(4),
+						},
+					},
+				},
+			},
+			true,
 		),
 	)
 })

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -453,11 +453,7 @@ func convertFlatValuesToHelmValues(values []greenhousev1alpha1.PluginOptionValue
 	}
 	helmValues := make(map[string]interface{}, 0)
 	for _, v := range values {
-		jsonVal, err := v.ValueJSON()
-		if err != nil {
-			return nil, err
-		}
-		if err := strvals.ParseJSON(fmt.Sprintf("%s=%s", v.Name, jsonVal), helmValues); err != nil {
+		if err := strvals.ParseJSON(fmt.Sprintf("%s=%s", v.Name, v.ValueJSON()), helmValues); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
## Description

The equality check ran into nil pointer if one of the `optionValue.Value` was nil. This came up when `optionValues.ValueFrom` is used.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->
- Related Issue # (issue)
- Closes # (issue)
- Fixes # (issue)

> Remove if not applicable

## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [ ] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
