### PR TITLE
fix(helmChartTestController): Don't run test when plugin is disabled

### DIFF
--- a/pkg/controllers/plugin/helm_chart_test_controller.go
+++ b/pkg/controllers/plugin/helm_chart_test_controller.go
@@ -73,6 +73,10 @@ func (r *HelmChartTestReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, nil
 	}
 
+	if plugin.Spec.Disabled {
+		return ctrl.Result{}, nil
+	}
+
 	// Helm Chart Test cannot be done as the Helm Chart deployment is not successful
 	if plugin.Status.HelmReleaseStatus.Status != "deployed" {
 		return ctrl.Result{}, nil


### PR DESCRIPTION
With this PR, the Helm Chart Tests won't run from the `helmChartTestController` when the plugin is disabled in the spec. 

fixes https://github.com/cloudoperators/greenhouse/issues/550