### PR TITLE
feat(plugin): Provide base domain as Plugin value

### DIFF
--- a/pkg/helm/helm_test.go
+++ b/pkg/helm/helm_test.go
@@ -16,6 +16,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	greenhousesapv1alpha1 "github.com/cloudoperators/greenhouse/pkg/apis/greenhouse/v1alpha1"
+	"github.com/cloudoperators/greenhouse/pkg/common"
 	"github.com/cloudoperators/greenhouse/pkg/helm"
 	"github.com/cloudoperators/greenhouse/pkg/test"
 )
@@ -70,7 +71,9 @@ var _ = Describe("helm package test", func() {
 			Expect(pluginOptionValues).To(
 				ContainElement(greenhousesapv1alpha1.PluginOptionValue{Name: "global.greenhouse.clusterName", Value: test.MustReturnJSONFor(plugin.Spec.ClusterName), ValueFrom: nil}), "the pluginDefinition option values should contain the clusterName from the plugin")
 			Expect(pluginOptionValues).To(
-				ContainElement(greenhousesapv1alpha1.PluginOptionValue{Name: "global.greenhouse.organizationName", Value: test.MustReturnJSONFor(plugin.GetNamespace()), ValueFrom: nil}), "the pluginDefinition option values should contain the orgName from the plugin namspace")
+				ContainElement(greenhousesapv1alpha1.PluginOptionValue{Name: "global.greenhouse.organizationName", Value: test.MustReturnJSONFor(plugin.GetNamespace()), ValueFrom: nil}), "the pluginDefinition option values should contain the orgName from the plugin namespace")
+			Expect(pluginOptionValues).To(
+				ContainElement(greenhousesapv1alpha1.PluginOptionValue{Name: "global.greenhouse.baseDomain", Value: test.MustReturnJSONFor(common.DNSDomain), ValueFrom: nil}), "the pluginDefinition option values should contain the baseDomain")
 		})
 	})
 

--- a/pkg/helm/values.go
+++ b/pkg/helm/values.go
@@ -13,6 +13,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	greenhousev1alpha1 "github.com/cloudoperators/greenhouse/pkg/apis/greenhouse/v1alpha1"
+	"github.com/cloudoperators/greenhouse/pkg/common"
 )
 
 func GetPluginOptionValuesForPlugin(ctx context.Context, c client.Client, plugin *greenhousev1alpha1.Plugin) ([]greenhousev1alpha1.PluginOptionValue, error) {
@@ -137,6 +138,17 @@ func getGreenhouseValues(ctx context.Context, c client.Client, p greenhousev1alp
 		greenhouseValues = append(greenhouseValues, greenhousev1alpha1.PluginOptionValue{
 			Name:      "global.greenhouse.clusterName",
 			Value:     &apiextensionsv1.JSON{Raw: clusterNameVal},
+			ValueFrom: nil,
+		})
+
+		// append DNSDomain
+		baseDomainVal, err := json.Marshal(common.DNSDomain)
+		if err != nil {
+			return nil, err
+		}
+		greenhouseValues = append(greenhouseValues, greenhousev1alpha1.PluginOptionValue{
+			Name:      "global.greenhouse.baseDomain",
+			Value:     &apiextensionsv1.JSON{Raw: baseDomainVal},
 			ValueFrom: nil,
 		})
 	}

--- a/test/e2e/plugin_lifecycle_test.go
+++ b/test/e2e/plugin_lifecycle_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/cloudoperators/greenhouse/test/e2e/fixtures"
 )
 
-var _ = FDescribe("PluginLifecycle", Ordered, func() {
+var _ = Describe("PluginLifecycle", Ordered, func() {
 	It("should deploy the plugin", func() {
 
 		const clusterName = "test-cluster-a"

--- a/test/e2e/plugin_lifecycle_test.go
+++ b/test/e2e/plugin_lifecycle_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/cloudoperators/greenhouse/test/e2e/fixtures"
 )
 
-var _ = Describe("PluginLifecycle", Ordered, func() {
+var _ = FDescribe("PluginLifecycle", Ordered, func() {
 	It("should deploy the plugin", func() {
 
 		const clusterName = "test-cluster-a"
@@ -115,7 +115,9 @@ var _ = Describe("PluginLifecycle", Ordered, func() {
 		err = test.K8sClient.Get(ctx, namespacedName, testPlugin)
 		Expect(err).NotTo(HaveOccurred())
 		testPlugin = &pluginList.Items[0]
-		testPlugin.Spec.OptionValues[9].Value.Raw = []byte("2")
+		// TODO: This test must not rely on index value, but on OptionValue.Name
+		// A helper method to get and set an OptionValue by name should be introduced.
+		testPlugin.Spec.OptionValues[10].Value.Raw = []byte("2")
 		err = test.K8sClient.Update(ctx, testPlugin)
 		Expect(err).NotTo(HaveOccurred())
 		Eventually(func(g Gomega) bool {


### PR DESCRIPTION
## Description
This provides `common.DNSDomain` as `global.greenhouse.baseDomain` in the PluginValues injected to each Plugin


## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->
- [Related Issue](https://github.com/cloudoperators/greenhouse/issues/407)
- Closes # (issue)
- Fixes # (issue)

> Remove if not applicable

## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [ ] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
