### PR TITLE
Fix(service-proxy): use release namespace

### DIFF
--- a/docs/reference/api/openapi.yaml
+++ b/docs/reference/api/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Greenhouse
-  version: 889f70d
+  version: 2f3d729
   description: PlusOne operations platform
 paths:
   /PluginPreset:

--- a/pkg/apis/greenhouse/v1alpha1/plugin_types.go
+++ b/pkg/apis/greenhouse/v1alpha1/plugin_types.go
@@ -148,15 +148,6 @@ type Plugin struct {
 	Status PluginStatus `json:"status,omitempty"`
 }
 
-// GetReleaseNamespace returns the release namespace of the Plugin.
-func (p *Plugin) GetReleaseNamespace() string {
-	// TODO: Replace this method with a Defaulter in the webhook once all Plugins have the ReleaseNamespace set.
-	if p.Spec.ReleaseNamespace == "" {
-		return p.GetNamespace()
-	}
-	return p.Spec.ReleaseNamespace
-}
-
 //+kubebuilder:object:root=true
 
 // PluginList contains a list of Plugin

--- a/pkg/common/url.go
+++ b/pkg/common/url.go
@@ -17,7 +17,7 @@ func URLForExposedServiceInPlugin(serviceName string, plugin *greenhousev1alpha1
 	return fmt.Sprintf(
 		// The pattern shall be $https://$service-$namespace-$cluster.$organisation.$basedomain .
 		"https://%s--%s--%s.%s.%s",
-		serviceName, plugin.GetNamespace(), plugin.Spec.ClusterName,
+		serviceName, plugin.Spec.ReleaseNamespace, plugin.Spec.ClusterName,
 		plugin.GetNamespace(), DNSDomain,
 	)
 }

--- a/pkg/common/url_test.go
+++ b/pkg/common/url_test.go
@@ -6,10 +6,11 @@ package common_test
 import (
 	"testing"
 
-	"github.com/cloudoperators/greenhouse/pkg/apis/greenhouse/v1alpha1"
-	"github.com/cloudoperators/greenhouse/pkg/common"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"github.com/cloudoperators/greenhouse/pkg/apis/greenhouse/v1alpha1"
+	"github.com/cloudoperators/greenhouse/pkg/common"
 )
 
 func TestCommonURL(t *testing.T) {

--- a/pkg/common/url_test.go
+++ b/pkg/common/url_test.go
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package common_test
+
+import (
+	"testing"
+
+	"github.com/cloudoperators/greenhouse/pkg/apis/greenhouse/v1alpha1"
+	"github.com/cloudoperators/greenhouse/pkg/common"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestCommonURL(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "CommonURl")
+}
+
+var _ = Describe("validate url methods", Ordered, func() {
+	It("should correctly generate the url for an exposed service", func() {
+		common.DNSDomain = "example.com"
+		plugin := &v1alpha1.Plugin{
+			Spec: v1alpha1.PluginSpec{
+				ReleaseNamespace: "test-namespace",
+				ClusterName:      "test-cluster",
+			},
+		}
+		plugin.SetNamespace("test-organisation")
+
+		url := common.URLForExposedServiceInPlugin("test-service", plugin)
+		Expect(url).To(Equal("https://test-service--test-namespace--test-cluster.test-organisation.example.com"))
+	})
+})

--- a/pkg/controllers/plugin/suite_test.go
+++ b/pkg/controllers/plugin/suite_test.go
@@ -397,7 +397,7 @@ var _ = Describe("HelmControllerTest", Serial, func() {
 				return err != nil
 			}).Should(BeFalse())
 			Eventually(func() bool {
-				_, err := helm.GetReleaseForHelmChartFromPlugin(test.Ctx, clientutil.NewRestClientGetterFromRestConfig(test.Cfg, testPlugin.GetReleaseNamespace(), clientutil.WithPersistentConfig()), testPlugin)
+				_, err := helm.GetReleaseForHelmChartFromPlugin(test.Ctx, clientutil.NewRestClientGetterFromRestConfig(test.Cfg, testPlugin.Spec.ReleaseNamespace, clientutil.WithPersistentConfig()), testPlugin)
 				if err != nil {
 					return errors.Is(err, driver.ErrReleaseNotFound)
 				}

--- a/pkg/controllers/plugin/util.go
+++ b/pkg/controllers/plugin/util.go
@@ -45,7 +45,7 @@ func initClientGetter(
 
 	// early return if spec.clusterName is not set
 	if plugin.Spec.ClusterName == "" {
-		restClientGetter, err = clientutil.NewRestClientGetterForInCluster(plugin.GetReleaseNamespace(), kubeClientOpts...)
+		restClientGetter, err = clientutil.NewRestClientGetterForInCluster(plugin.Spec.ReleaseNamespace, kubeClientOpts...)
 		if err != nil {
 			clusterAccessReadyCondition.Status = metav1.ConditionFalse
 			clusterAccessReadyCondition.Message = "cannot access greenhouse cluster" + ": " + err.Error()
@@ -77,7 +77,7 @@ func initClientGetter(
 		clusterAccessReadyCondition.Message = fmt.Sprintf("Failed to get secret for cluster %s: %s", plugin.Spec.ClusterName, err.Error())
 		return clusterAccessReadyCondition, nil
 	}
-	restClientGetter, err = clientutil.NewRestClientGetterFromSecret(&secret, plugin.GetReleaseNamespace(), kubeClientOpts...)
+	restClientGetter, err = clientutil.NewRestClientGetterFromSecret(&secret, plugin.Spec.ReleaseNamespace, kubeClientOpts...)
 	if err != nil {
 		clusterAccessReadyCondition.Status = metav1.ConditionFalse
 		clusterAccessReadyCondition.Message = fmt.Sprintf("cannot access cluster %s: %s", plugin.Spec.ClusterName, err.Error())

--- a/pkg/helm/helm_test.go
+++ b/pkg/helm/helm_test.go
@@ -89,7 +89,7 @@ var _ = Describe("helm package test", func() {
 			Expect(err).ShouldNot(HaveOccurred(),
 				"there should be no error for plugindefinitions with helm chart")
 
-			cfg, err := helm.ExportNewHelmAction(test.RestClientGetter, plugin.GetReleaseNamespace())
+			cfg, err := helm.ExportNewHelmAction(test.RestClientGetter, plugin.Spec.ReleaseNamespace)
 			Expect(err).ShouldNot(HaveOccurred(), "there should be no error creating helm config")
 			listAction := action.NewList(cfg)
 			releases, err := listAction.Run()
@@ -104,7 +104,7 @@ var _ = Describe("helm package test", func() {
 			// We expect the release from the previous test to be found
 			Expect(releaseNotFound).To(BeFalse(), "the release should have been found before deleting")
 
-			cfg, err := helm.ExportNewHelmAction(test.RestClientGetter, plugin.GetReleaseNamespace())
+			cfg, err := helm.ExportNewHelmAction(test.RestClientGetter, plugin.Spec.ReleaseNamespace)
 			Expect(err).ShouldNot(HaveOccurred(), "there should be no error creating helm config")
 			listAction := action.NewList(cfg)
 			releases, err := listAction.Run()


### PR DESCRIPTION
## Description
This fixes 

- URL creation of exposed services to use the `plugin.Spec.ReleaseNamespace` instead of the `plugin.GetNamespace()`

and removes
- the utility method `GetReleaseNamespace()` to directly use `.Spec.ReleaseNamespace`

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->
- Related Issue # (issue)
- Closes # (issue)
- Fixes # (issue)

> Remove if not applicable

## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [ ] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
