### PR TITLE
fix: change outdated plugin release namespace references

### DIFF
--- a/pkg/controllers/plugin/remote_cluster_test.go
+++ b/pkg/controllers/plugin/remote_cluster_test.go
@@ -44,6 +44,7 @@ var (
 		Spec: greenhousev1alpha1.PluginSpec{
 			ClusterName:      "test-cluster",
 			PluginDefinition: "test-plugindefinition",
+			ReleaseNamespace: test.TestNamespace,
 		},
 	}
 
@@ -391,7 +392,7 @@ var _ = Describe("HelmController reconciliation", Ordered, func() {
 		By("creating plugin definition with CRDs")
 		Expect(test.K8sClient.Create(test.Ctx, testPluginWithHelmChartCRDs)).To(Succeed(), "should create plugin definition")
 
-		remoteRestClientGetter := clientutil.NewRestClientGetterFromBytes(remoteKubeConfig, testPluginWithCRDs.GetReleaseNamespace(), clientutil.WithPersistentConfig())
+		remoteRestClientGetter := clientutil.NewRestClientGetterFromBytes(remoteKubeConfig, testPluginWithCRDs.Spec.ReleaseNamespace, clientutil.WithPersistentConfig())
 
 		By("creating test plugin referencing the cluster")
 		testPluginWithCRDs.Spec.ClusterName = "test-cluster"
@@ -410,7 +411,7 @@ var _ = Describe("HelmController reconciliation", Ordered, func() {
 		}).Should(BeTrue(), "the ClusterAccessReadyCondition should be false")
 
 		By("checking the helm releases deployed to the remote cluster")
-		helmConfig, err := helm.ExportNewHelmAction(remoteRestClientGetter, testPluginWithCRDs.GetReleaseNamespace())
+		helmConfig, err := helm.ExportNewHelmAction(remoteRestClientGetter, testPluginWithCRDs.Spec.ReleaseNamespace)
 		Expect(err).ShouldNot(HaveOccurred(), "there should be no error creating helm config")
 		listAction := action.NewList(helmConfig)
 		Eventually(func() []*release.Release {

--- a/pkg/helm/diff_test.go
+++ b/pkg/helm/diff_test.go
@@ -62,6 +62,7 @@ var _ = Describe("ensure helm diff against the release manifest works as expecte
 						Value: test.MustReturnJSONFor("true"),
 					},
 				},
+				ReleaseNamespace: namespace,
 			},
 		}
 

--- a/pkg/helm/suite_test.go
+++ b/pkg/helm/suite_test.go
@@ -146,6 +146,7 @@ var (
 			PluginDefinition: "test-plugindefinition",
 			ClusterName:      "test-cluster",
 			OptionValues:     []greenhousesapv1alpha1.PluginOptionValue{},
+			ReleaseNamespace: "test-release-namespace",
 		},
 	}
 


### PR DESCRIPTION
## Description

Simple fix for plugin's outdated GetReleaseNamespace reference. Now it needs to be plugin.Spec.ReleaseNamespace.
Changed in https://github.com/cloudoperators/greenhouse/pull/576

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [x] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
