### PR TITLE
Fix: prevent incomplete urls for exposed services in plugin

### DIFF
--- a/docs/user-guides/plugin/plugin-deployment.md
+++ b/docs/user-guides/plugin/plugin-deployment.md
@@ -27,6 +27,14 @@ spec:
     - ...
 ```
 
+### Exposed services
+
+Plugins deploying Helm Charts into remote clusters support exposed services.
+
+By adding the following label to a service in helm chart it will become accessible from the central greenhouse system via a service proxy:
+
+```greenhouse.sap/expose: "true"```
+
 ## Deploying a Plugin
 
 Create the Plugin resource via the command:
@@ -40,3 +48,10 @@ kubectl --namespace=<organization name> create -f plugin.yaml
 1. Check with `kubectl --namespace=<organization name> get plugin` has been properly created. When all components of the plugin are successfully created, the plugin should show the state **configured**.
 
 2. Check in the remote cluster that all plugin resources are created in the organization namespace.
+
+### URLs for exposed services
+
+After deploying the plugin to a remote cluster, ExposedServices section in Plugin's status provides an overview of the Plugins services that are centrally exposed. It maps the exposed URL to the service found in the manifest.
+
+- The URLs for exposed services are created in the following pattern: `https://$service-$namespace-$cluster.$organisation.$basedomain`.
+- When deploying a plugin to the central cluster, the exposed services won't have their URLs defined, which will be reflected in the Plugin's Status.

--- a/pkg/controllers/plugin/helm_controller.go
+++ b/pkg/controllers/plugin/helm_controller.go
@@ -5,6 +5,7 @@ package plugin
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -404,6 +405,12 @@ func getExposedServicesForPluginFromHelmRelease(restClientGetter genericclioptio
 		return nil, err
 	}
 	var exposedServices = make(map[string]greenhousev1alpha1.Service, 0)
+	if len(exposedServiceList) == 0 {
+		return exposedServices, nil
+	}
+	if plugin.Spec.ClusterName == "" {
+		return nil, errors.New("plugin does not have ClusterName")
+	}
 	for _, svc := range exposedServiceList {
 		svcPort, err := getPortForExposedService(svc.Object)
 		if err != nil {

--- a/pkg/test/fixtures/chartWithExposedService/Chart.yaml
+++ b/pkg/test/fixtures/chartWithExposedService/Chart.yaml
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v2
+name: myChart
+version: 1.3.0
+description: A basic chart for testing exposed services

--- a/pkg/test/fixtures/chartWithExposedService/templates/services.yaml
+++ b/pkg/test/fixtures/chartWithExposedService/templates/services.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: exposed-service
+  namespace: test-org
+  labels:
+    greenhouse.sap/expose: "true"
+spec:
+  selector:
+    app: some-app
+  type: ClusterIP
+  ports:
+  - name: http
+    port: 80

--- a/pkg/test/fixtures/chartWithExposedService/values.yaml
+++ b/pkg/test/fixtures/chartWithExposedService/values.yaml
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+


### PR DESCRIPTION
## Description

This PR fixes the bug with incomplete URLs generated for exposed services, when a plugin is deployed to the central cluster. It also adds docs describing exposed services in plugin deployment.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [x] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

- Fixes #324 

## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

I added a test checking that HelmController correctly lists URLs for exposed services in plugin status, and a test that confirms the error is reflected on plugin status condition when URLs cannot be generated due to missing cluster name.

## Added to documentation?

- [ ] 📜 README.md
- [x] 🤝 Documentation pages updated
- [ ] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
