### PR TITLE
feat(organizationwebhook): deny deletion of organization

### DIFF
--- a/pkg/admission/organization_webhook.go
+++ b/pkg/admission/organization_webhook.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"strings"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -55,6 +56,10 @@ func ValidateUpdateOrganization(_ context.Context, _ client.Client, _, _ runtime
 	return nil, nil
 }
 
-func ValidateDeleteOrganization(_ context.Context, _ client.Client, _ runtime.Object) (admission.Warnings, error) {
-	return nil, nil
+func ValidateDeleteOrganization(_ context.Context, _ client.Client, o runtime.Object) (admission.Warnings, error) {
+	_, ok := o.(*greenhousev1alpha1.Organization)
+	if !ok {
+		return nil, nil
+	}
+	return nil, apierrors.NewBadRequest("Organization cannot be deleted")
 }

--- a/pkg/admission/organization_webhook_test.go
+++ b/pkg/admission/organization_webhook_test.go
@@ -13,20 +13,35 @@ import (
 	greenhousev1alpha1 "github.com/cloudoperators/greenhouse/pkg/apis/greenhouse/v1alpha1"
 )
 
-var _ = Describe("Validate Organization Defaulting Webhook", func() {
-	It("Should default the display name of the organization", func() {
-		orgWithoutDisplayName := &greenhousev1alpha1.Organization{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "test-organization",
-			},
-			Spec: greenhousev1alpha1.OrganizationSpec{},
-		}
+var _ = Describe("Organization Webhook", func() {
+	Context("Validate Organization Defaulting Webhook", func() {
+		It("Should default the display name of the organization", func() {
+			orgWithoutDisplayName := &greenhousev1alpha1.Organization{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-organization",
+				},
+				Spec: greenhousev1alpha1.OrganizationSpec{},
+			}
 
-		Expect(DefaultOrganization(context.TODO(), nil, orgWithoutDisplayName)).
-			To(Succeed(), "there should be no error applying defaults to the organization")
-		Expect(orgWithoutDisplayName.Spec.DisplayName).
-			ToNot(BeEmpty(), "the spec.displayName should be defaulted and not be empty")
-		Expect(orgWithoutDisplayName.Spec.DisplayName).
-			To(Equal("test organization"), "the spec.display should be defaulted and match")
+			Expect(DefaultOrganization(context.TODO(), nil, orgWithoutDisplayName)).
+				To(Succeed(), "there should be no error applying defaults to the organization")
+			Expect(orgWithoutDisplayName.Spec.DisplayName).
+				ToNot(BeEmpty(), "the spec.displayName should be defaulted and not be empty")
+			Expect(orgWithoutDisplayName.Spec.DisplayName).
+				To(Equal("test organization"), "the spec.display should be defaulted and match")
+		})
+	})
+
+	Context("Validate Delete Organization", func() {
+		It("should deny deletion of an organization", func() {
+			org := &greenhousev1alpha1.Organization{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-organization",
+				},
+			}
+			_, err := ValidateDeleteOrganization(context.TODO(), nil, org)
+			Expect(err).To(HaveOccurred(), "webhook should deny organization deletion")
+			Expect(err.Error()).To(Equal("Organization cannot be deleted"), "webhook should deny organization deletion with proper error message")
+		})
 	})
 })


### PR DESCRIPTION
## Description

This PR denies the deletion of Organization CRs in the Organization Webhook, regardless of dependencies.

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

- Closes #541 

## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

I've added a unit test to check if webhook denies the deletion. I've tested the deletion on a cluster, but decided not to commit the integration test.

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [ ] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
