### PR TITLE
feat(service-proxy): Cap URL subdomain at 63 chars

### DIFF
--- a/docs/user-guides/plugin/plugin-deployment.md
+++ b/docs/user-guides/plugin/plugin-deployment.md
@@ -33,7 +33,7 @@ Plugins deploying Helm Charts into remote clusters support exposed services.
 
 By adding the following label to a service in helm chart it will become accessible from the central greenhouse system via a service proxy:
 
-```greenhouse.sap/expose: "true"```
+`greenhouse.sap/expose: "true"`
 
 ## Deploying a Plugin
 
@@ -53,5 +53,5 @@ kubectl --namespace=<organization name> create -f plugin.yaml
 
 After deploying the plugin to a remote cluster, ExposedServices section in Plugin's status provides an overview of the Plugins services that are centrally exposed. It maps the exposed URL to the service found in the manifest.
 
-- The URLs for exposed services are created in the following pattern: `https://$service-$namespace-$cluster.$organisation.$basedomain`.
+- The URLs for exposed services are created in the following pattern: `$https://$service--$cluster--$namespace.$organisation.$basedomain`. If `$service--$cluster--$namespace` exceeds 63 characters it is capped at 54 characters and a hash is appended.s
 - When deploying a plugin to the central cluster, the exposed services won't have their URLs defined, which will be reflected in the Plugin's Status.

--- a/pkg/common/url_test.go
+++ b/pkg/common/url_test.go
@@ -30,6 +30,20 @@ var _ = Describe("validate url methods", Ordered, func() {
 		plugin.SetNamespace("test-organisation")
 
 		url := common.URLForExposedServiceInPlugin("test-service", plugin)
-		Expect(url).To(Equal("https://test-service--test-namespace--test-cluster.test-organisation.example.com"))
+		Expect(url).To(Equal("https://test-service--test-cluster--test-namespace.test-organisation.example.com"))
+	})
+
+	It("should correctly cap the url with a hash on urls with subdomains exceeding 63 characters", func() {
+		common.DNSDomain = "example.com"
+		plugin := &v1alpha1.Plugin{
+			Spec: v1alpha1.PluginSpec{
+				ReleaseNamespace: "test-long-namespace",
+				ClusterName:      "test-cluster",
+			},
+		}
+		plugin.SetNamespace("test-organisation")
+
+		url := common.URLForExposedServiceInPlugin("this-is-a-very-long-service-name", plugin)
+		Expect(url).To(Equal("https://this-is-a-very-long-service-name--test-cluster--test-l-7982a2e3.test-organisation.example.com"))
 	})
 })

--- a/pkg/controllers/plugin/remote_cluster_test.go
+++ b/pkg/controllers/plugin/remote_cluster_test.go
@@ -529,8 +529,8 @@ var _ = Describe("HelmController reconciliation", Ordered, func() {
 				for exposedServiceURL = range testPluginWithExposedService1.Status.ExposedServices {
 					break
 				}
-				// URL pattern: $https://$service-$namespace-$cluster.$organisation.$basedomain
-				g.Expect(exposedServiceURL).To(Equal("https://exposed-service--test-org--test-cluster.test-org.example.com"), "exposed service URL should be generated correctly")
+				// URL pattern: $https://$service--$cluster--$namespace.$organisation.$basedomain
+				g.Expect(exposedServiceURL).To(Equal("https://exposed-service--test-cluster--test-org.test-org.example.com"), "exposed service URL should be generated correctly")
 			}).Should(Succeed(), "plugin should have correct status")
 
 			By("cleaning up test")


### PR DESCRIPTION
## Description
We currently generate URLs for exposed services without boundary to the first subdomain. The following patter is used:
```
$https://$service-$namespace-$cluster.$organisation.$basedomain
```
As per https://github.com/cloudoperators/greenhouse/issues/78 this fails when the first subdomain exceeds 63 characters.

This PR 
- caps the first subdomain to 63 chars by appending a hash value if exceeding
- changes the order of the first subdomain to `$service--$cluster--$namespace`, since the hashing might eat up the namespace and it is considered the least important information on the URL.


## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

[<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->
- Related Issue # (issue)
- Closes # (issue)
- Fixes # (issue)](https://github.com/cloudoperators/greenhouse/issues/78)

> Remove if not applicable

## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Added to documentation?

- [ ] 📜 README.md
- [x] 🤝 Documentation pages updated
- [ ] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

