### PR TITLE
ehancement(e2e): Run E2e with build tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,19 +107,19 @@ test: generate-manifests generate envtest ## Run tests.
 
 .PHONY: e2e
 e2e: 
-	go test ./test/e2e/... -coverprofile cover.out -v
+	go test -tags="e2e" -mod=mod ./test/e2e/... -coverprofile cover.out -test.v
 
 .PHONY: e2e-local
 e2e-local: generate-manifests generate envtest ## Run e2e tests against mock api.
-	unset USE_EXISTING_CLUSTER && KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./test/e2e/... -coverprofile cover.out -v
+	unset USE_EXISTING_CLUSTER && KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test -tags="e2e" -mod=mod ./test/e2e/... -coverprofile cover.out -ginkgo.v -test.v
 
 .PHONY: e2e-remote
 e2e-remote: ## Run e2e tests against a remote Greenhouse cluster. TEST_KUBECONFIG must be set.
-	USE_EXISTING_CLUSTER=true go test ./test/e2e/... -coverprofile cover.out -v
+	USE_EXISTING_CLUSTER=true go test -tags="e2e" -mod=mod ./test/e2e/... -coverprofile cover.out -ginkgo.v -test.v
 
 .PHONY: e2e-local-cluster
 e2e-local-cluster: e2e-local-cluster-create  ## Run e2e tests on a local KIND cluster.
-	USE_EXISTING_CLUSTER=true TEST_KUBECONFIG=$(shell pwd)/test/e2e/local-cluster/e2e.kubeconfig INTERNAL_KUBECONFIG=$(shell pwd)/test/e2e/local-cluster/e2e.internal.kubeconfig go test ./test/e2e/... -coverprofile cover.out -v
+	USE_EXISTING_CLUSTER=true TEST_KUBECONFIG=$(shell pwd)/test/e2e/local-cluster/e2e.kubeconfig INTERNAL_KUBECONFIG=$(shell pwd)/test/e2e/local-cluster/e2e.internal.kubeconfig go test -tags="e2e" -mod=mod ./test/e2e/... -coverprofile cover.out -ginkgo.v -test.v
 
 .PHONY: e2e-local-cluster-create
 e2e-local-cluster-create:

--- a/Makefile
+++ b/Makefile
@@ -107,19 +107,19 @@ test: generate-manifests generate envtest ## Run tests.
 
 .PHONY: e2e
 e2e: 
-	go test -tags="e2e" -mod=mod ./test/e2e/... -coverprofile cover.out -test.v
+	go test -tags="e2e" ./test/e2e/... -coverprofile cover.out -test.v
 
 .PHONY: e2e-local
 e2e-local: generate-manifests generate envtest ## Run e2e tests against mock api.
-	unset USE_EXISTING_CLUSTER && KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test -tags="e2e" -mod=mod ./test/e2e/... -coverprofile cover.out -ginkgo.v -test.v
+	unset USE_EXISTING_CLUSTER && KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test -tags="e2e" ./test/e2e/... -coverprofile cover.out -ginkgo.v -test.v
 
 .PHONY: e2e-remote
 e2e-remote: ## Run e2e tests against a remote Greenhouse cluster. TEST_KUBECONFIG must be set.
-	USE_EXISTING_CLUSTER=true go test -tags="e2e" -mod=mod ./test/e2e/... -coverprofile cover.out -ginkgo.v -test.v
+	USE_EXISTING_CLUSTER=true go test -tags="e2e" ./test/e2e/... -coverprofile cover.out -ginkgo.v -test.v
 
 .PHONY: e2e-local-cluster
 e2e-local-cluster: e2e-local-cluster-create  ## Run e2e tests on a local KIND cluster.
-	USE_EXISTING_CLUSTER=true TEST_KUBECONFIG=$(shell pwd)/test/e2e/local-cluster/e2e.kubeconfig INTERNAL_KUBECONFIG=$(shell pwd)/test/e2e/local-cluster/e2e.internal.kubeconfig go test -tags="e2e" -mod=mod ./test/e2e/... -coverprofile cover.out -ginkgo.v -test.v
+	USE_EXISTING_CLUSTER=true TEST_KUBECONFIG=$(shell pwd)/test/e2e/local-cluster/e2e.kubeconfig INTERNAL_KUBECONFIG=$(shell pwd)/test/e2e/local-cluster/e2e.internal.kubeconfig go test -tags="e2e" ./test/e2e/... -coverprofile cover.out -ginkgo.v -test.v
 
 .PHONY: e2e-local-cluster-create
 e2e-local-cluster-create:

--- a/pkg/test/env.go
+++ b/pkg/test/env.go
@@ -160,13 +160,13 @@ var (
 			Expect(K8sManager).
 				NotTo(BeNil(), "the manager must not be nil")
 
-			// Register webhooks.
+			// Register webhooks
 			for webhookName, registerFunc := range allRegisterWebhookFuncs {
 				logf.FromContext(Ctx, "message", "registering webhook", "name", webhookName)
 				Expect(registerFunc(K8sManager)).To(Succeed(), "there must be no error registering the webhook", "name", webhookName)
 			}
 
-			// Register controllers.
+			// Register controllers
 			for controllerName, registerFunc := range allRegisterControllerFuncs {
 				Expect(registerFunc(controllerName, K8sManager)).
 					To(Succeed(), "there must be no error registering the controller", "name", controllerName)

--- a/pkg/test/env.go
+++ b/pkg/test/env.go
@@ -50,7 +50,7 @@ var (
 )
 
 // RegisterController registers a controller for the testbed.
-// current running testbed is not affected.
+// A currently running testbed is not affected.
 func RegisterController(controllerName string, f registerControllerFunc) {
 	if _, ok := allRegisterControllerFuncs[controllerName]; !ok {
 		allRegisterControllerFuncs[controllerName] = f
@@ -58,13 +58,13 @@ func RegisterController(controllerName string, f registerControllerFunc) {
 }
 
 // UnregisterController removes a controller from the testbed.
-// currently running testbed is not affected.
+// A currently running testbed is not affected.
 func UnregisterController(controllerName string) {
 	delete(allRegisterControllerFuncs, controllerName)
 }
 
 // RegisterWebhook registers a webhook for the testbed.
-// currently running testbed is not affected.
+// A currently running testbed is not affected.
 func RegisterWebhook(webhookName string, f registerWebhookFunc) {
 	if _, ok := allRegisterWebhookFuncs[webhookName]; !ok {
 		allRegisterWebhookFuncs[webhookName] = f
@@ -160,13 +160,13 @@ var (
 			Expect(K8sManager).
 				NotTo(BeNil(), "the manager must not be nil")
 
-			// Register webhooks
+			// Register webhooks.
 			for webhookName, registerFunc := range allRegisterWebhookFuncs {
 				logf.FromContext(Ctx, "message", "registering webhook", "name", webhookName)
 				Expect(registerFunc(K8sManager)).To(Succeed(), "there must be no error registering the webhook", "name", webhookName)
 			}
 
-			// Register controllers
+			// Register controllers.
 			for controllerName, registerFunc := range allRegisterControllerFuncs {
 				Expect(registerFunc(controllerName, K8sManager)).
 					To(Succeed(), "there must be no error registering the controller", "name", controllerName)

--- a/pkg/test/env.go
+++ b/pkg/test/env.go
@@ -58,13 +58,13 @@ func RegisterController(controllerName string, f registerControllerFunc) {
 }
 
 // UnregisterController removes a controller from the testbed.
-// A currently running testbed is not affected.
+// currently running testbed is not affected.
 func UnregisterController(controllerName string) {
 	delete(allRegisterControllerFuncs, controllerName)
 }
 
 // RegisterWebhook registers a webhook for the testbed.
-// A currently running testbed is not affected.
+// currently running testbed is not affected.
 func RegisterWebhook(webhookName string, f registerWebhookFunc) {
 	if _, ok := allRegisterWebhookFuncs[webhookName]; !ok {
 		allRegisterWebhookFuncs[webhookName] = f

--- a/pkg/test/env.go
+++ b/pkg/test/env.go
@@ -50,7 +50,7 @@ var (
 )
 
 // RegisterController registers a controller for the testbed.
-// A currently running testbed is not affected.
+// current running testbed is not affected.
 func RegisterController(controllerName string, f registerControllerFunc) {
 	if _, ok := allRegisterControllerFuncs[controllerName]; !ok {
 		allRegisterControllerFuncs[controllerName] = f

--- a/test/e2e/controllers.go
+++ b/test/e2e/controllers.go
@@ -1,7 +1,8 @@
 // SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
 // SPDX-License-Identifier: Apache-2.0
 
-//nolint:unused
+//go:build e2e
+
 package e2e
 
 import (

--- a/test/e2e/controllers.go
+++ b/test/e2e/controllers.go
@@ -1,8 +1,6 @@
 // SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:build e2e
-
 package e2e
 
 import (

--- a/test/e2e/controllers.go
+++ b/test/e2e/controllers.go
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build e2e
+
 package e2e
 
 import (

--- a/test/e2e/controllers.go
+++ b/test/e2e/controllers.go
@@ -24,6 +24,8 @@ const (
 )
 
 // knownControllers contains all controllers to be registered when starting the e2e test suite
+
+//nolint:unused
 var knownControllers = map[string]func(controllerName string, mgr ctrl.Manager) error{
 	// Organization controllers.
 	"organizationController":     (&organizationcontrollers.OrganizationReconciler{}).SetupWithManager,
@@ -58,6 +60,7 @@ var knownControllers = map[string]func(controllerName string, mgr ctrl.Manager) 
 	"clusterStatus": (&clustercontrollers.ClusterStatusReconciler{}).SetupWithManager,
 }
 
+//nolint:unused
 func startOrganizationDexReconciler(name string, mgr ctrl.Manager) error {
 	namespace := "greenhouse"
 	if v, ok := os.LookupEnv("POD_NAMESPACE"); ok {
@@ -68,6 +71,7 @@ func startOrganizationDexReconciler(name string, mgr ctrl.Manager) error {
 	}).SetupWithManager(name, mgr)
 }
 
+//nolint:unused
 func startClusterDirectAccessReconciler(name string, mgr ctrl.Manager) error {
 	return (&clustercontrollers.DirectAccessReconciler{
 		RemoteClusterBearerTokenValidity:   defaultRemoteClusterBearerTokenValidity,

--- a/test/e2e/controllers.go
+++ b/test/e2e/controllers.go
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
 // SPDX-License-Identifier: Apache-2.0
 
+//nolint:unused
 package e2e
 
 import (
@@ -25,7 +26,6 @@ const (
 
 // knownControllers contains all controllers to be registered when starting the e2e test suite
 
-//nolint:unused
 var knownControllers = map[string]func(controllerName string, mgr ctrl.Manager) error{
 	// Organization controllers.
 	"organizationController":     (&organizationcontrollers.OrganizationReconciler{}).SetupWithManager,
@@ -60,7 +60,6 @@ var knownControllers = map[string]func(controllerName string, mgr ctrl.Manager) 
 	"clusterStatus": (&clustercontrollers.ClusterStatusReconciler{}).SetupWithManager,
 }
 
-//nolint:unused
 func startOrganizationDexReconciler(name string, mgr ctrl.Manager) error {
 	namespace := "greenhouse"
 	if v, ok := os.LookupEnv("POD_NAMESPACE"); ok {
@@ -71,7 +70,6 @@ func startOrganizationDexReconciler(name string, mgr ctrl.Manager) error {
 	}).SetupWithManager(name, mgr)
 }
 
-//nolint:unused
 func startClusterDirectAccessReconciler(name string, mgr ctrl.Manager) error {
 	return (&clustercontrollers.DirectAccessReconciler{
 		RemoteClusterBearerTokenValidity:   defaultRemoteClusterBearerTokenValidity,

--- a/test/e2e/onboard_self_test.go
+++ b/test/e2e/onboard_self_test.go
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build e2e
+
 package e2e
 
 import (

--- a/test/e2e/plugin_lifecycle_test.go
+++ b/test/e2e/plugin_lifecycle_test.go
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build e2e
+
 package e2e
 
 import (

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build e2e
+
 package e2e
 
 import (

--- a/test/e2e/webhooks.go
+++ b/test/e2e/webhooks.go
@@ -1,7 +1,8 @@
 // SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
 // SPDX-License-Identifier: Apache-2.0
 
-//nolint:unused
+//go:build e2e
+
 package e2e
 
 import (

--- a/test/e2e/webhooks.go
+++ b/test/e2e/webhooks.go
@@ -1,8 +1,6 @@
 // SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:build e2e
-
 package e2e
 
 import (

--- a/test/e2e/webhooks.go
+++ b/test/e2e/webhooks.go
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build e2e
+
 package e2e
 
 import (

--- a/test/e2e/webhooks.go
+++ b/test/e2e/webhooks.go
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
 // SPDX-License-Identifier: Apache-2.0
 
+//nolint:unused
 package e2e
 
 import (
@@ -9,7 +10,6 @@ import (
 	"github.com/cloudoperators/greenhouse/pkg/admission"
 )
 
-//nolint:unused
 var knownWebhooks = map[string]func(mgr ctrl.Manager) error{
 	"cluster":          admission.SetupClusterWebhookWithManager,
 	"secrets":          admission.SetupSecretWebhookWithManager,

--- a/test/e2e/webhooks.go
+++ b/test/e2e/webhooks.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cloudoperators/greenhouse/pkg/admission"
 )
 
+//nolint:unused
 var knownWebhooks = map[string]func(mgr ctrl.Manager) error{
 	"cluster":          admission.SetupClusterWebhookWithManager,
 	"secrets":          admission.SetupSecretWebhookWithManager,


### PR DESCRIPTION
## Description

This PR ensures that e2e(s) are run with build tags and no longer runs with unit tests

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
