### PR TITLE
fix(service-proxy): Correctly decompose host

### DIFF
--- a/cmd/service-proxy/instrumentation.go
+++ b/cmd/service-proxy/instrumentation.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"net/http"
 
+	"github.com/cloudoperators/greenhouse/pkg/common"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
@@ -67,7 +68,7 @@ func InstrumentHandler(next http.Handler, registry prometheus.Registerer) http.H
 
 	injector := func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-			if name, namespace, cluster, err := SplitHost(req.Host); err == nil {
+			if name, cluster, namespace, err := common.SplitHost(req.Host); err == nil {
 				ctx := req.Context()
 				ctx = context.WithValue(ctx, ctxClusterKey{}, cluster)
 				ctx = context.WithValue(ctx, ctxNamespaceKey{}, namespace)

--- a/cmd/service-proxy/instrumentation.go
+++ b/cmd/service-proxy/instrumentation.go
@@ -7,9 +7,10 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/cloudoperators/greenhouse/pkg/common"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+
+	"github.com/cloudoperators/greenhouse/pkg/common"
 )
 
 type ctxClusterKey struct {

--- a/cmd/service-proxy/proxy.go
+++ b/cmd/service-proxy/proxy.go
@@ -10,7 +10,6 @@ import (
 	"net/http/httputil"
 	"net/url"
 	"regexp"
-	"strings"
 	"sync"
 
 	"github.com/go-logr/logr"
@@ -27,6 +26,7 @@ import (
 	greenhouseapis "github.com/cloudoperators/greenhouse/pkg/apis"
 	greenhousev1alpha1 "github.com/cloudoperators/greenhouse/pkg/apis/greenhouse/v1alpha1"
 	"github.com/cloudoperators/greenhouse/pkg/clientutil"
+	"github.com/cloudoperators/greenhouse/pkg/common"
 )
 
 func NewProxyManager() *ProxyManager {
@@ -170,8 +170,8 @@ func (pm *ProxyManager) rewrite(req *httputil.ProxyRequest) {
 		req.Out = req.Out.WithContext(log.IntoContext(req.Out.Context(), l))
 	}()
 
-	// hostname is expected to have the format $name--$namespace--$cluster.$organisation.$basedomain
-	name, namespace, cluster, err := SplitHost(req.In.Host)
+	// hostname is expected to have the format $name--$cluster--$namespace.$organisation.$basedomain
+	name, cluster, namespace, err := common.SplitHost(req.In.Host)
 	if err != nil {
 		return
 	}
@@ -241,17 +241,4 @@ func enqueuePluginForCluster(_ context.Context, o client.Object) []ctrl.Request 
 		return nil
 	}
 	return []ctrl.Request{{NamespacedName: types.NamespacedName{Namespace: plugin.Namespace, Name: plugin.Spec.ClusterName}}}
-}
-
-// SplitHost splits a host into its name, namespace and cluster parts
-func SplitHost(host string) (name, namespace, cluster string, err error) {
-	parts := strings.SplitN(host, ".", 2)
-	if len(parts) < 2 {
-		return "", "", "", fmt.Errorf("invalid host: %s", host)
-	}
-	parts = strings.SplitN(parts[0], "--", 3)
-	if len(parts) < 3 {
-		return "", "", "", fmt.Errorf("invalid host: %s", host)
-	}
-	return parts[0], parts[1], parts[2], nil
 }

--- a/cmd/service-proxy/proxy_test.go
+++ b/cmd/service-proxy/proxy_test.go
@@ -41,7 +41,7 @@ func TestRewrite(t *testing.T) {
 	}{
 		{
 			name:        "valid host",
-			url:         "https://name--namespace--cluster.organisation.basedomain/abcd",
+			url:         "https://name--cluster--namespace.organisation.basedomain/abcd",
 			expectedURL: "https://apiserver/proxy/url/abcd",
 			contextVal:  "cluster",
 		},

--- a/pkg/common/url.go
+++ b/pkg/common/url.go
@@ -6,6 +6,7 @@ package common
 import (
 	"crypto/sha256"
 	"fmt"
+	"strings"
 
 	greenhousev1alpha1 "github.com/cloudoperators/greenhouse/pkg/apis/greenhouse/v1alpha1"
 )
@@ -26,4 +27,20 @@ func URLForExposedServiceInPlugin(serviceName string, plugin *greenhousev1alpha1
 		"https://%s.%s.%s",
 		subdomain, plugin.GetNamespace(), DNSDomain,
 	)
+}
+
+// SplitHost splits an exposed service host into its name, namespace and cluster parts
+// The pattern shall be $service--$cluster--$namespace
+// TODO, need to fix: We know that information on the namespace and even the cluster might be lost when the host was hashed due to it's length.
+// Currently only cluster is critical, need to fix this.
+func SplitHost(host string) (name, cluster, namespace string, err error) {
+	parts := strings.SplitN(host, ".", 2)
+	if len(parts) < 2 {
+		return "", "", "", fmt.Errorf("invalid host: %s", host)
+	}
+	parts = strings.SplitN(parts[0], "--", 3)
+	if len(parts) < 3 {
+		return "", "", "", fmt.Errorf("invalid host: %s", host)
+	}
+	return parts[0], parts[1], parts[2], nil
 }


### PR DESCRIPTION
## Description
We introduced a regression [with changing the order of parameters](https://github.com/cloudoperators/greenhouse/commit/9a049d83879e41e6e0009f9fa7f910ca33c31308#diff-d3666ab886c1a27806b6d26677a42b167e6816af8c07fcade3bb8328f115f7dc) in the service-proxy host.

This PR hotfixes this regression, but we still need a better permanent solution


- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

