### PR TITLE
fix(cluster) Cluster's metrics is updated (#519)

### DIFF
--- a/pkg/controllers/cluster/direct_access_controller.go
+++ b/pkg/controllers/cluster/direct_access_controller.go
@@ -67,6 +67,9 @@ func (r *DirectAccessReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, nil
 	}
 
+	// Update metrics at the end of the reconcile function
+	defer updateMetrics(cluster)
+
 	isScheduled, schedule, err := clientutil.ExtractDeletionSchedule(cluster.GetAnnotations())
 	if err != nil {
 		return ctrl.Result{}, err
@@ -153,7 +156,6 @@ func (r *DirectAccessReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, err
 	}
 
-	updateMetrics(cluster)
 	return ctrl.Result{RequeueAfter: defaultRequeueInterval}, nil
 }
 

--- a/pkg/controllers/cluster/headscale_access_controller.go
+++ b/pkg/controllers/cluster/headscale_access_controller.go
@@ -123,6 +123,9 @@ func (r *HeadscaleAccessReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return ctrl.Result{}, nil
 	}
 
+	// Update metrics at the end of the reconcile function
+	defer updateMetrics(cluster)
+
 	// Cleanup logic
 	if cluster.DeletionTimestamp != nil && controllerutil.ContainsFinalizer(cluster, greenhouseapis.FinalizerCleanupCluster) {
 		// Delete resources (serviceAccount, clusterRoleBinding, namespace, etc.) in remote cluster before the secret.
@@ -211,7 +214,6 @@ func (r *HeadscaleAccessReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return ctrl.Result{}, err
 	}
 
-	updateMetrics(cluster)
 	return ctrl.Result{RequeueAfter: defaultRequeueInterval}, nil
 }
 


### PR DESCRIPTION
## Description
Cluster metrics were not updated when something went wrong during reconciliation. This resulted in the appropriate alert not being sent by Prometheus.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [X] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->
- Related Issue # (issue)
- Closes #519
- Fixes #519

> Remove if not applicable

## Added tests?

- [ ] 👍 yes
- [X] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [X] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (no document changes needed)
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (tests not needed)
- [X] New and existing unit tests pass locally with my changes
