### PR TITLE
fix(service-proxy-controller): watch service-proxy plugin definition

### DIFF
--- a/pkg/controllers/organization/service_proxy_controller.go
+++ b/pkg/controllers/organization/service_proxy_controller.go
@@ -143,7 +143,7 @@ func listOrganizationsAsReconcileRequests(ctx context.Context, c client.Client, 
 	}
 	res := make([]ctrl.Request, len(organizationList.Items))
 	for idx, organization := range organizationList.Items {
-		res[idx] = ctrl.Request{NamespacedName: client.ObjectKeyFromObject(organization.DeepCopy())}
+		res[idx] = ctrl.Request{NamespacedName: types.NamespacedName{Name: organization.Name, Namespace: organization.Namespace}}
 	}
 	return res
 }

--- a/pkg/controllers/organization/service_proxy_controller_test.go
+++ b/pkg/controllers/organization/service_proxy_controller_test.go
@@ -15,18 +15,32 @@ import (
 	"github.com/cloudoperators/greenhouse/pkg/test"
 )
 
-var _ = Describe("Organization ServiceProxyReconciler", func() {
-	var setup *test.TestSetup
-
-	BeforeEach(func() {
-		setup = test.NewTestSetup(test.Ctx, test.K8sClient, "org-serviceproxy-test")
-	})
+var _ = Describe("Organization ServiceProxyReconciler", Ordered, func() {
+	var serviceProxyPluginDefinition = &greenhousev1alpha1.PluginDefinition{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "PluginDefinition",
+			APIVersion: greenhousev1alpha1.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "service-proxy",
+			Namespace: corev1.NamespaceDefault,
+		},
+		Spec: greenhousev1alpha1.PluginDefinitionSpec{
+			Description: "Testplugin",
+			Version:     "1.0.0",
+			HelmChart: &greenhousev1alpha1.HelmChartReference{
+				Name:       "./../../test/fixtures/myChart",
+				Repository: "dummy",
+				Version:    "1.0.0",
+			},
+		},
+	}
 
 	When("plugin definition for service proxy is missing", func() {
-		It("should log about missing plugin definition", func() {
+		It("should log about missing plugin definition and create plugin when it's added", func() {
 			By("ensuring service-proxy plugin definition does not exist")
-			var serviceProxyPluginDefinition = new(greenhousev1alpha1.PluginDefinition)
-			err := setup.Get(test.Ctx, types.NamespacedName{Name: "service-proxy", Namespace: ""}, serviceProxyPluginDefinition)
+			var pluginDefinition = new(greenhousev1alpha1.PluginDefinition)
+			err := test.K8sClient.Get(test.Ctx, types.NamespacedName{Name: "service-proxy", Namespace: ""}, pluginDefinition)
 			Expect(err).To(HaveOccurred(), "there should be an error getting the service-proxy plugin definition")
 
 			By("teeing logger to a custom writer")
@@ -35,48 +49,61 @@ var _ = Describe("Organization ServiceProxyReconciler", func() {
 			defer GinkgoWriter.ClearTeeWriters()
 
 			By("creating an organization")
-			setup.CreateOrganization(test.Ctx, "test-serviceproxy-org1")
+			org := &greenhousev1alpha1.Organization{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Organization",
+					APIVersion: greenhousev1alpha1.GroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-serviceproxy-org1",
+				},
+			}
+			err = test.K8sClient.Create(test.Ctx, org)
+			Expect(err).ToNot(HaveOccurred(), "there should be no error creating the organization")
 
 			By("ensuring ServiceProxyController logged about missing plugin definition")
 			Eventually(func() []byte {
 				return tee.Contents()
 			}).Should(ContainSubstring("plugin definition for service-proxy not found"),
 				"ServiceProxyController should log about missing plugin definition")
+
+			By("creating service-proxy plugin definition")
+			err = test.K8sClient.Create(test.Ctx, serviceProxyPluginDefinition)
+			Expect(err).ToNot(HaveOccurred(), "there should be no error creating the service-proxy plugin definition")
+
+			By("ensuring a service-proxy plugin has been created for organization")
+			var plugin = new(greenhousev1alpha1.Plugin)
+			Eventually(func(g Gomega) {
+				err = test.K8sClient.Get(test.Ctx, types.NamespacedName{Name: "service-proxy", Namespace: org.Name}, plugin)
+				g.Expect(err).ToNot(HaveOccurred(), "service-proxy plugin should have been created by controller")
+			}).Should(Succeed(), "service-proxy plugin should have been created for organization")
 		})
 	})
 
 	When("plugin definition for service proxy is present", func() {
 		It("should create service-proxy plugin for organization", func() {
-			By("creating service-proxy plugin definition")
-			var serviceProxyPluginDefinition = &greenhousev1alpha1.PluginDefinition{
+			By("getting service-proxy plugin definition")
+			var pluginDefinition = new(greenhousev1alpha1.PluginDefinition)
+			err := test.K8sClient.Get(test.Ctx, types.NamespacedName{Name: "service-proxy", Namespace: ""}, pluginDefinition)
+			Expect(err).ToNot(HaveOccurred(), "there should be no error getting the service-proxy plugin definition")
+
+			By("creating an organization")
+			org := &greenhousev1alpha1.Organization{
 				TypeMeta: metav1.TypeMeta{
-					Kind:       "PluginDefinition",
+					Kind:       "Organization",
 					APIVersion: greenhousev1alpha1.GroupVersion.String(),
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "service-proxy",
-					Namespace: corev1.NamespaceDefault,
-				},
-				Spec: greenhousev1alpha1.PluginDefinitionSpec{
-					Description: "Testplugin",
-					Version:     "1.0.0",
-					HelmChart: &greenhousev1alpha1.HelmChartReference{
-						Name:       "./../../test/fixtures/myChart",
-						Repository: "dummy",
-						Version:    "1.0.0",
-					},
+					Name: "test-serviceproxy-org2",
 				},
 			}
-			err := setup.Create(test.Ctx, serviceProxyPluginDefinition)
-			Expect(err).ToNot(HaveOccurred(), "there should be no error creating the service-proxy plugin definition")
-
-			By("creating an organization")
-			org := setup.CreateOrganization(test.Ctx, "test-serviceproxy-org2")
+			err = test.K8sClient.Create(test.Ctx, org)
+			Expect(err).ToNot(HaveOccurred(), "there should be no error creating the organization")
 
 			By("ensuring a service-proxy plugin has been created for organization")
 			Eventually(func(g Gomega) {
 				var plugin = new(greenhousev1alpha1.Plugin)
-				err = setup.Get(test.Ctx, types.NamespacedName{Name: "service-proxy", Namespace: org.Name}, plugin)
+				err = test.K8sClient.Get(test.Ctx, types.NamespacedName{Name: "service-proxy", Namespace: org.Name}, plugin)
 				g.Expect(err).ToNot(HaveOccurred(), "service-proxy plugin should have been created by controller")
 			}).Should(Succeed(), "service-proxy plugin should have been created for organization")
 		})

--- a/pkg/controllers/organization/service_proxy_controller_test.go
+++ b/pkg/controllers/organization/service_proxy_controller_test.go
@@ -1,0 +1,84 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package organization_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gbytes"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	greenhousev1alpha1 "github.com/cloudoperators/greenhouse/pkg/apis/greenhouse/v1alpha1"
+	"github.com/cloudoperators/greenhouse/pkg/test"
+)
+
+var _ = Describe("Organization ServiceProxyReconciler", func() {
+	var setup *test.TestSetup
+
+	BeforeEach(func() {
+		setup = test.NewTestSetup(test.Ctx, test.K8sClient, "org-serviceproxy-test")
+	})
+
+	When("plugin definition for service proxy is missing", func() {
+		It("should log about missing plugin definition", func() {
+			By("ensuring service-proxy plugin definition does not exist")
+			var serviceProxyPluginDefinition = new(greenhousev1alpha1.PluginDefinition)
+			err := setup.Get(test.Ctx, types.NamespacedName{Name: "service-proxy", Namespace: ""}, serviceProxyPluginDefinition)
+			Expect(err).To(HaveOccurred(), "there should be an error getting the service-proxy plugin definition")
+
+			By("teeing logger to a custom writer")
+			tee := gbytes.NewBuffer()
+			GinkgoWriter.TeeTo(tee)
+			defer GinkgoWriter.ClearTeeWriters()
+
+			By("creating an organization")
+			setup.CreateOrganization(test.Ctx, "test-serviceproxy-org1")
+
+			By("ensuring ServiceProxyController logged about missing plugin definition")
+			Eventually(func() []byte {
+				return tee.Contents()
+			}).Should(ContainSubstring("plugin definition for service-proxy not found"),
+				"ServiceProxyController should log about missing plugin definition")
+		})
+	})
+
+	When("plugin definition for service proxy is present", func() {
+		It("should create service-proxy plugin for organization", func() {
+			By("creating service-proxy plugin definition")
+			var serviceProxyPluginDefinition = &greenhousev1alpha1.PluginDefinition{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "PluginDefinition",
+					APIVersion: greenhousev1alpha1.GroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "service-proxy",
+					Namespace: corev1.NamespaceDefault,
+				},
+				Spec: greenhousev1alpha1.PluginDefinitionSpec{
+					Description: "Testplugin",
+					Version:     "1.0.0",
+					HelmChart: &greenhousev1alpha1.HelmChartReference{
+						Name:       "./../../test/fixtures/myChart",
+						Repository: "dummy",
+						Version:    "1.0.0",
+					},
+				},
+			}
+			err := setup.Create(test.Ctx, serviceProxyPluginDefinition)
+			Expect(err).ToNot(HaveOccurred(), "there should be no error creating the service-proxy plugin definition")
+
+			By("creating an organization")
+			org := setup.CreateOrganization(test.Ctx, "test-serviceproxy-org2")
+
+			By("ensuring a service-proxy plugin has been created for organization")
+			Eventually(func(g Gomega) {
+				var plugin = new(greenhousev1alpha1.Plugin)
+				err = setup.Get(test.Ctx, types.NamespacedName{Name: "service-proxy", Namespace: org.Name}, plugin)
+				g.Expect(err).ToNot(HaveOccurred(), "service-proxy plugin should have been created by controller")
+			}).Should(Succeed(), "service-proxy plugin should have been created for organization")
+		})
+	})
+})

--- a/pkg/controllers/organization/suite_test.go
+++ b/pkg/controllers/organization/suite_test.go
@@ -22,8 +22,11 @@ func TestOrganization(t *testing.T) {
 var _ = BeforeSuite(func() {
 	test.RegisterController("organizationController", (&organizationpkg.OrganizationReconciler{}).SetupWithManager)
 	test.RegisterController("organizationRBAC", (&organizationpkg.RBACReconciler{}).SetupWithManager)
+	test.RegisterController("organizationServiceProxy", (&organizationpkg.ServiceProxyReconciler{}).SetupWithManager)
 	test.RegisterWebhook("orgWebhook", admission.SetupOrganizationWebhookWithManager)
 	test.RegisterWebhook("teamWebhook", admission.SetupTeamWebhookWithManager)
+	test.RegisterWebhook("pluginDefinitionWebhook", admission.SetupPluginDefinitionWebhookWithManager)
+	test.RegisterWebhook("pluginWebhook", admission.SetupPluginWebhookWithManager)
 	test.TestBeforeSuite()
 })
 


### PR DESCRIPTION
## Description

In this PR the controller returns without error when the service-proxy plugin definition is missing and watches for changes in service-proxy plugin definition to create or update service-proxy plugin for organizations.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

- Closes #542 

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
1. Spin up the local environment without any resources
2. Add an organization
3. See that ServiceProxyController logs missing service-proxy plugin definition and returns without error
4. Add the service-proxy PluginDefinition
5. See that ServiceProxyController is triggered and adds service-proxy plugin for organization

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [x] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
