### PR TITLE
feat(gh-action): Build UI helm chart separately

### DIFF
--- a/.github/workflows/helm-push.yaml
+++ b/.github/workflows/helm-push.yaml
@@ -23,6 +23,8 @@ jobs:
         include:
           - chartDir: charts/greenhouse
             chartName: greenhouse
+          - chartDir: charts/ui
+            chartName: greenhouse-ui
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Description
This builds the greenhouse-ui helm chart separately from the greenhouse umbrella chart.


