### PR TITLE
feat(ci): adds new charts for ui with different resource naming until the decoupling from backend is done

### DIFF
--- a/charts/dashboard/Chart.yaml
+++ b/charts/dashboard/Chart.yaml
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+description: A Helm chart for hosting the dashboard
+name: ui
+version: 0.1.0

--- a/charts/dashboard/ci/test-values.yaml
+++ b/charts/dashboard/ci/test-values.yaml
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+host: dashboard.greenhouse.tld
+oidcIssuerUrl: https://auth.greenhouse.tld
+oidcClientId: topSecret!
+k8sApiEndpoint: https://api.greenhouse.tld

--- a/charts/dashboard/templates/dashboard-props-cm.yaml
+++ b/charts/dashboard/templates/dashboard-props-cm.yaml
@@ -1,0 +1,21 @@
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-dashboard-app-props
+
+data:
+  appProps.json: |
+    {
+      "authIssuerUrl": {{ required ".Values.oidcIssuerUrl" .Values.oidcIssuerUrl | quote }},
+      "authClientId": {{ required ".Values.oidcClientId" .Values.oidcClientId | quote }},
+      "currentHost": {{ required ".Values.juno.assetServerURL missing" .Values.juno.assetServerURL | quote}},
+      "apiEndpoint": {{ required ".Values.k8sApiEndpoint" .Values.k8sApiEndpoint | quote }},
+      "environment": {{ required ".Values.environment" .Values.environment | quote }},
+      "demoUserToken": {{ required ".Values.demoUser.token" .Values.demoUser.token | quote }}
+    }
+

--- a/charts/dashboard/templates/deployment.yaml
+++ b/charts/dashboard/templates/deployment.yaml
@@ -1,0 +1,73 @@
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
+
+kind: Deployment
+apiVersion: apps/v1
+
+metadata:
+  name: {{ .Release.Name }}-dashboard
+
+spec:
+  selector:
+    matchLabels:
+      app: dashboard
+  revisionHistoryLimit: 3
+  replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 2
+  template:
+    metadata:
+      labels:
+        app: dashboard
+      annotations:
+        checksum/props-cm: {{ include (print $.Template.BasePath "/dashboard-props-cm.yaml") . | sha256sum }}
+    spec:
+      # The preStop hook below sleeps 30 seconds, extend the gracePeriod accordingly
+      terminationGracePeriodSeconds: 60
+      containers:
+        - name: dashboard
+          image: "{{ required ".Values.image.repository missing" .Values.image.repository }}:{{ required ".Values.image.tag missing" .Values.image.tag }}"
+          imagePullPolicy: {{ required ".Values.image.pullPolicy missing" .Values.image.pullPolicy }}
+          ports:
+            - name: dashboard
+              containerPort: 80
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "256M"
+            limits:
+              cpu: "100m"
+              memory: "256M"
+              
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+            timeoutSeconds: 10
+            periodSeconds: 60
+            initialDelaySeconds: 60
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            timeoutSeconds: 5
+            periodSeconds: 5
+          lifecycle:
+            preStop:
+              exec:
+                #Give the ingress some time to reload its config
+                command: ["/bin/sh", "-c", "sleep 30"]
+          volumeMounts:
+            - name: props
+              mountPath: /appProps.json
+              subPath: appProps.json
+      volumes:    
+        - name: props
+          configMap:
+            defaultMode: 420
+            name: {{ .Release.Name }}-dashboard-app-props

--- a/charts/dashboard/templates/ingress.yaml
+++ b/charts/dashboard/templates/ingress.yaml
@@ -1,0 +1,40 @@
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
+
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ .Release.Name }}-dashboard
+  annotations:
+    kubernetes.io/tls-acme: "true"
+spec:
+  ingressClassName: {{ required ".Values.ingress.className missing" .Values.ingress.className }}
+  rules:
+    - host: "{{ required ".Values.host missing" .Values.host }}"
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ .Release.Name }}-dashboard
+                port:
+                  number: 80
+    - host: "*.{{ required ".Values.host missing" .Values.host }}"
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ .Release.Name }}-dashboard
+                port:
+                  number: 80
+
+  tls:
+    - hosts:
+        - "{{ required ".Values.host missing" .Values.host }}"
+        - "*.{{ required ".Values.host missing" .Values.host }}"
+      secretName: "tls-{{ .Release.Name }}-ui"

--- a/charts/dashboard/templates/service.yaml
+++ b/charts/dashboard/templates/service.yaml
@@ -1,0 +1,19 @@
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
+
+kind: Service
+apiVersion: v1
+
+metadata:
+  name: {{ .Release.Name }}-dashboard
+
+spec:
+  selector:
+    app: dashboard
+  ports:
+    - name: dashboard
+      port: 80
+      protocol: TCP
+      targetPort: dashboard

--- a/charts/dashboard/values.yaml
+++ b/charts/dashboard/values.yaml
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+image:
+  repository: ghcr.io/cloudoperators/juno-app-greenhouse
+  tag: 0.2.0
+  pullPolicy: IfNotPresent
+
+# TODO: Migrate to ingress.host
+host:
+
+ingress:
+  className: nginx
+
+juno:
+  assetServerURL: origin
+  # version of the juno greenhouse app
+  greenhouse:
+    version: latest
+
+# The user for demonstration purposes.
+demoUser:
+  token: demo
+
+environment: "prod"


### PR DESCRIPTION
## Description

Adds new charts for ui with different resource naming until the decoupling from backend is done. The UI part is going to be deployed in an other release and this avoids resource naming collision for now.

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->
- Related Issue # (issue)
- Closes # (issue)
- Fixes # (issue)

> Remove if not applicable

## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [ ] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
