### PR TITLE
fix(rbac): adjust access on TeamRole & TeamRoleBindings for org members & cluster admins

### DIFF
--- a/pkg/rbac/role.go
+++ b/pkg/rbac/role.go
@@ -32,12 +32,6 @@ func OrganizationAdminPolicyRules() []rbacv1.PolicyRule {
 			APIGroups: []string{"rbac.authorization.k8s.io"},
 			Resources: []string{"rolebindings"},
 		},
-		// Grant permission for TeamRoles
-		{
-			Verbs:     []string{"get", "list", "watch", "update", "patch", "delete", "create"},
-			APIGroups: []string{greenhouseapisv1alpha1.GroupVersion.Group},
-			Resources: []string{"teamroles"},
-		},
 		// Grant permission to view Alertmanager and AlertmanagerConfig resources
 		{
 			Verbs:     []string{"get", "list", "watch"},
@@ -71,6 +65,12 @@ func OrganizationClusterAdminPolicyRules() []rbacv1.PolicyRule {
 			Verbs:     []string{"create", "update", "patch"},
 			APIGroups: []string{corev1.GroupName},
 			Resources: []string{"secrets"},
+		},
+		// Grant permission for TeamRoles
+		{
+			Verbs:     []string{"get", "list", "watch", "update", "patch", "delete", "create"},
+			APIGroups: []string{greenhouseapisv1alpha1.GroupVersion.Group},
+			Resources: []string{"teamroles"},
 		},
 		// Grant permission for TeamRoleBindings
 		{

--- a/pkg/rbac/role.go
+++ b/pkg/rbac/role.go
@@ -53,11 +53,11 @@ func OrganizationAdminPolicyRules() []rbacv1.PolicyRule {
 // OrganizationClusterAdminPolicyRules returns the namespace-scoped PolicyRules for an organization cluster admin.
 func OrganizationClusterAdminPolicyRules() []rbacv1.PolicyRule {
 	policyRules := []rbacv1.PolicyRule{
-		// Grant read permissions for Clusters to organization cluster admins.
+		// Grant CRUD Permissions for Clusters, TeamRoles and TeamRoleBindings
 		{
 			Verbs:     []string{"get", "list", "watch", "update", "patch", "delete", "create"},
 			APIGroups: []string{greenhouseapisv1alpha1.GroupVersion.Group},
-			Resources: []string{"clusters"},
+			Resources: []string{"clusters", "teamroles", "teamrolebindings"},
 		},
 		// Grant permissions for secrets referenced by other resources, e.g. Plugins for storing sensitive values.
 		// Retrieving these secrets is not permitted to the user.
@@ -65,18 +65,6 @@ func OrganizationClusterAdminPolicyRules() []rbacv1.PolicyRule {
 			Verbs:     []string{"create", "update", "patch"},
 			APIGroups: []string{corev1.GroupName},
 			Resources: []string{"secrets"},
-		},
-		// Grant permission for TeamRoles
-		{
-			Verbs:     []string{"get", "list", "watch", "update", "patch", "delete", "create"},
-			APIGroups: []string{greenhouseapisv1alpha1.GroupVersion.Group},
-			Resources: []string{"teamroles"},
-		},
-		// Grant permission for TeamRoleBindings
-		{
-			Verbs:     []string{"get", "list", "watch", "update", "patch", "delete", "create"},
-			APIGroups: []string{greenhouseapisv1alpha1.GroupVersion.Group},
-			Resources: []string{"teamrolebindings"},
 		},
 	}
 	return append(OrganizationMemberPolicyRules(), policyRules...)

--- a/pkg/rbac/role.go
+++ b/pkg/rbac/role.go
@@ -109,7 +109,7 @@ func OrganizationMemberPolicyRules() []rbacv1.PolicyRule {
 		{
 			Verbs:     []string{"get", "list", "watch"},
 			APIGroups: []string{greenhouseapisv1alpha1.GroupVersion.Group},
-			Resources: []string{"clusters", "plugins", "pluginpresets", "teams", "teammemberships"},
+			Resources: []string{"clusters", "plugins", "pluginpresets", "teams", "teammemberships", "teamroles", "teamrolebindings"},
 		},
 	}
 }


### PR DESCRIPTION
## Description

Organization members should be able to view TeamRoles and TeamRoleBindings. 

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->
- Related Issue # (issue)
- Closes # (issue)
- Fixes # (issue)

> Remove if not applicable

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [ ] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
