### PR TITLE
Add alert for failing Plugin Helm Chart tests

### DIFF
--- a/charts/manager/alerts/operator.alerts
+++ b/charts/manager/alerts/operator.alerts
@@ -28,6 +28,15 @@ groups:
       for: 15m
       labels:
         severity: warning
+    - alert: GreenhousePluginHelmChartTestFailures
+      expr: |
+        sum by(plugin, cluster, namespace)(rate(greenhouse_plugin_chart_test_runs_total{result="Error"}[30m])) > 0
+      for: 15m
+      labels:
+        severity: warning
+      annotations:
+        summary: "Helm Chart test failing for plugin {{ $labels.plugin }}"
+        description: "Helm Chart test for plugin {{ $labels.plugin }} in namespace {{ $labels.namespace }} on cluster {{ $labels.cluster }} has been failing for the last 15 minutes"
   - name: greenhouse-webhooks.rules
     rules:
     - alert: GreenhouseWebhookLatencyHigh

--- a/charts/manager/alerts/operator.alerts
+++ b/charts/manager/alerts/operator.alerts
@@ -30,13 +30,13 @@ groups:
         severity: warning
     - alert: GreenhousePluginHelmChartTestFailures
       expr: |
-        sum by(plugin, cluster, namespace)(rate(greenhouse_plugin_chart_test_runs_total{result="Error"}[30m])) > 0
-      for: 15m
+        sum by(plugin, cluster, namespace)(rate(greenhouse_plugin_chart_test_runs_total{result="Error"}[15m])) > 0
+      for: 30m
       labels:
         severity: warning
       annotations:
         summary: "Helm Chart test failing for plugin {{ $labels.plugin }}"
-        description: "Helm Chart test for plugin {{ $labels.plugin }} in namespace {{ $labels.namespace }} on cluster {{ $labels.cluster }} has been failing for the last 15 minutes"
+        description: "Helm Chart test for plugin {{ $labels.plugin }} in namespace {{ $labels.namespace }} on cluster {{ $labels.cluster }} has been failing for the last 30 minutes"
   - name: greenhouse-webhooks.rules
     rules:
     - alert: GreenhouseWebhookLatencyHigh


### PR DESCRIPTION
This pull request adds an alert for failing Helm Chart tests. The alert is triggered when the Helm Chart test has been failing for the last 15 minutes. The alert includes information about the plugin, namespace, and cluster of the remote cluster.

pre-requisite for https://github.com/cloudoperators/greenhouse-extensions/issues/447