### PR TITLE
docs(clusters): improve cluster onboarding documentation

### DIFF
--- a/docs/user-guides/cluster/onboarding.md
+++ b/docs/user-guides/cluster/onboarding.md
@@ -36,7 +36,7 @@ For accessing the `greenhouse` cluster, the `greenhousectl` will expect your def
 The location of the `kubeconfig` file to the `bootstrap` cluster is passed via the `--kubeconfig` flag or via the `KUBECONFIG` enviorment variable
 
 ```commandline
-greenhousectl cluster bootstrap --kubeconfig=<path/to/greenhouse-kubeconfig-file> --bootstrap-kubeconfig <path/to/bootstrap-kubeconfig-file> --org <greenhouse-organization-name> --cluster-name <name>
+greenhousectl cluster bootstrap --kubeconfig=<path/to/bootstrap-kubeconfig-file> --greenhouse-kubeconfig <path/to/greenhouse-kubeconfig-file> --org <greenhouse-organization-name> --cluster-name <name>
 ```
 
 Since Greenhouse generates URLs which contain the cluster name, we highly recommend to choose a **short** cluster name.

--- a/docs/user-guides/cluster/onboarding.md
+++ b/docs/user-guides/cluster/onboarding.md
@@ -29,12 +29,12 @@ You need to have the `kubeconfig` files for both the `greenhouse` and the `boots
 
 _Organization_ > _Clusters_ > _Access greenhouse cluster_.
 
+### Onboard
+
 For accessing the `greenhouse` cluster, the `greenhousectl` will expect your default kubernetes [`kubeconfig` file](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/) and [`context`](https://kubernetes.io/docs/reference/kubectl/generated/kubectl_config/kubectl_config_use-context/) to be set to `greenhouse`.
 The easiest way for doing so is passing the `--kubeconfig` (and optionally `--kubecontext`) flag to your `greenhousectl` command.
 
 The location of the `kubeconfig` file to the `bootstrap` cluster is passed via the `--bootstrap-kubeconfig` flag.
-
-### Onboard
 
 ```commandline
 greenhousectl cluster bootstrap --kubeconfig=<path/to/greenhouse-kubeconfig-file> --bootstrap-kubeconfig <path/to/bootstrap-kubeconfig-file> --org <greenhouse-organization-name> --cluster-name <name>
@@ -78,7 +78,7 @@ kind: Cluster
 metadata:
   creationTimestamp: "2024-02-07T10:23:23Z"
   finalizers:
-    - greenhouse.sap/cluster
+    greenhouse.sap/cluster
   generation: 1
   name: monitoring
   namespace: ccloud
@@ -89,9 +89,18 @@ spec:
 status:
   bearerTokenExpirationTimestamp: "2024-02-09T06:28:57Z"
   kubernetesVersion: v1.27.8
+  statusConditions:
+    conditions:
+    - lastTransitionTime: "2024-02-09T06:28:57Z"
+      status: "True"
+      type: Ready
+...
 ```
 
 When the `status.kubernetesVersion` field shows the correct version of the Kubernetes cluster, the cluster was successfully bootstrapped in Greenhouse.
+Then `status.conditions` will contain a `Condition` with `type=ready` and `status="true""` 
+
+
 In the remote cluster, a new namespace is created and contains some resources managed by Greenhouse.
 The namespace has the same name as your organization in Greenhouse.
 

--- a/docs/user-guides/cluster/onboarding.md
+++ b/docs/user-guides/cluster/onboarding.md
@@ -5,6 +5,13 @@ description: >
   Onboard an existing Kubernetes cluster to Greenhouse.
 ---
 
+## Content Overview
+
+- [Preparation](#preparation)
+- [Onboard](#onboard)
+- [After onboarding](#after-onboarding)
+- [Trouble shooting](#trouble-shooting)
+
 This guides describes how to onboard an existing Kubernetes cluster to your Greenhouse organization.  
 If you don't have an organization yet please reach out to the Greenhouse administrators.
 
@@ -100,6 +107,8 @@ Then `status.conditions` will contain a `Condition` with `type=Ready` and `statu
 
 In the remote cluster, a new namespace is created and contains some resources managed by Greenhouse.
 The namespace has the same name as your organization in Greenhouse.
+
+## Trouble shooting
 
 If the bootstrapping failed, you can find details about why it failed in the `Cluster.statusConditions`. More precisely there will be a condition of `type=KubeConfigValid` which might have hints in the `message` field. This is also displayed in the UI on the `Cluster` details view.
 Reruning the onboarding command with an updated `kubeConfig` file will fix these issues.

--- a/docs/user-guides/cluster/onboarding.md
+++ b/docs/user-guides/cluster/onboarding.md
@@ -31,9 +31,9 @@ _Organization_ > _Clusters_ > _Access Greenhouse cluster_.
 
 ### Onboard
 
-For accessing the `greenhouse` cluster, the `greenhousectl` will expect your default Kubernetes [`kubeconfig` file](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/) and [`context`](https://kubernetes.io/docs/reference/kubectl/generated/kubectl_config/kubectl_config_use-context/) to be set to `bootstrap`.
+For accessing the `bootstrap` cluster, the `greenhousectl` will expect your default Kubernetes [`kubeconfig` file](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/) and [`context`](https://kubernetes.io/docs/reference/kubectl/generated/kubectl_config/kubectl_config_use-context/) to be set to `bootstrap`. This can be achieved by passing the `--kubeconfig` flag or by setting the `KUBECONFIG` env var.
 
-The location of the `kubeconfig` file to the `bootstrap` cluster is passed via the `--kubeconfig` flag or via the `KUBECONFIG` enviorment variable
+The location of the `kubeconfig` file to the `greenhouse` cluster is passed via the `--greenhouse-kubeconfig` flag.
 
 ```commandline
 greenhousectl cluster bootstrap --kubeconfig=<path/to/bootstrap-kubeconfig-file> --greenhouse-kubeconfig <path/to/greenhouse-kubeconfig-file> --org <greenhouse-organization-name> --cluster-name <name>
@@ -76,8 +76,7 @@ apiVersion: greenhouse.sap/v1alpha1
 kind: Cluster
 metadata:
   creationTimestamp: "2024-02-07T10:23:23Z"
-  finalizers:
-    greenhouse.sap/cluster
+  finalizers: greenhouse.sap/cluster
   generation: 1
   name: monitoring
   namespace: ccloud
@@ -90,15 +89,13 @@ status:
   kubernetesVersion: v1.27.8
   statusConditions:
     conditions:
-    - lastTransitionTime: "2024-02-09T06:28:57Z"
-      status: "True"
-      type: Ready
-...
+      - lastTransitionTime: "2024-02-09T06:28:57Z"
+        status: "True"
+        type: Ready
 ```
 
 When the `status.kubernetesVersion` field shows the correct version of the Kubernetes cluster, the cluster was successfully bootstrapped in Greenhouse.
-Then `status.conditions` will contain a `Condition` with `type=ready` and `status="true""` 
-
+Then `status.conditions` will contain a `Condition` with `type=ready` and `status="true""`
 
 In the remote cluster, a new namespace is created and contains some resources managed by Greenhouse.
 The namespace has the same name as your organization in Greenhouse.

--- a/docs/user-guides/cluster/onboarding.md
+++ b/docs/user-guides/cluster/onboarding.md
@@ -31,7 +31,7 @@ _Organization_ > _Clusters_ > _Access Greenhouse cluster_.
 
 ### Onboard
 
-For accessing the `greenhouse` cluster, the `greenhousectl` will expect your default Kubernetes [`kubeconfig` file](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/) and [`context`](https://kubernetes.io/docs/reference/kubectl/generated/kubectl_config/kubectl_config_use-context/) to be set to `greenhouse`.
+For accessing the `greenhouse` cluster, the `greenhousectl` will expect your default Kubernetes [`kubeconfig` file](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/) and [`context`](https://kubernetes.io/docs/reference/kubectl/generated/kubectl_config/kubectl_config_use-context/) to be set to `bootstrap`.
 
 The location of the `kubeconfig` file to the `bootstrap` cluster is passed via the `--kubeconfig` flag or via the `KUBECONFIG` enviorment variable
 

--- a/docs/user-guides/cluster/onboarding.md
+++ b/docs/user-guides/cluster/onboarding.md
@@ -32,7 +32,6 @@ _Organization_ > _Clusters_ > _Access Greenhouse cluster_.
 ### Onboard
 
 For accessing the `greenhouse` cluster, the `greenhousectl` will expect your default Kubernetes [`kubeconfig` file](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/) and [`context`](https://kubernetes.io/docs/reference/kubectl/generated/kubectl_config/kubectl_config_use-context/) to be set to `greenhouse`.
-The easiest way for doing so is passing the `--kubeconfig` (and optionally `--kubecontext`) flag to your `greenhousectl` command.
 
 The location of the `kubeconfig` file to the `bootstrap` cluster is passed via the `--kubeconfig` flag or via the `KUBECONFIG` enviorment variable
 

--- a/docs/user-guides/cluster/onboarding.md
+++ b/docs/user-guides/cluster/onboarding.md
@@ -18,7 +18,7 @@ NOTE: The UI is currently in development. For now this guide describes the onboa
 
 Download the latest `greenhousectl` binary from [here](https://github.com/cloudoperators/greenhouse/releases).
 
-Onboarding a `Cluster` to Greenhouse will require you to authenticate to two different kubernetes clusters via repsective `kubeconfig` files:
+Onboarding a `Cluster` to Greenhouse will require you to authenticate to two different Kubernetes clusters via respective `kubeconfig` files:
 
 - `greenhouse`: The cluster your Greenhouse installation is running on. You need `organization-admin` or `cluster-admin` priviledges.
 - `bootstrap`: The cluster you want to onboard. You need `system:masters` priviledges.

--- a/docs/user-guides/cluster/onboarding.md
+++ b/docs/user-guides/cluster/onboarding.md
@@ -6,9 +6,9 @@ description: >
 ---
 
 This guides describes how to onboard an existing Kubernetes cluster to your Greenhouse organization.  
-If you don't have an organization yet please reach out to the Greenhouse administrators.  
+If you don't have an organization yet please reach out to the Greenhouse administrators.
 
-While all members of an organization can see existing clusters, their management requires **organization admin privileges**. 
+While all members of an organization can see existing clusters, their management requires [`org-admin` or `cluster-admin` privileges](./../../getting-started/core-concepts/organizations.md).
 
 ```
 NOTE: The UI is currently in development. For now this guide describes the onboarding workflow via command line.
@@ -16,24 +16,32 @@ NOTE: The UI is currently in development. For now this guide describes the onboa
 
 ### Preparation
 
-Download the latest `greenhousectl` binary from [here](https://github.com/cloudoperators/greenhouse/releases). 
+Download the latest `greenhousectl` binary from [here](https://github.com/cloudoperators/greenhouse/releases).
 
-The command line tool requires access to both the Greenhouse **and** your Kubernetes cluster. 
-Hence, have the `kubeconfig` files for both clusters at hand. The `kubeconfig` file for the Greenhouse Kubernetes cluster can be downloaded via the Greenhouse dashboard: _Organization_ > _Clusters_ > _Access greenhouse cluster_. 
+Onboarding a `Cluster` to Greenhouse will require you to authenticate to two different kubernetes clusters via repsective `kubeconfig` files:
 
-For accessing the **Greenhouse Kubernetes cluster**, the `greenhousectl` will check whether your local kubectl is connected to the Greenhouse Kubernetes cluster. If not connected, 
-either the environment variables `KUBECONFIG` and `KUBECONTEXT` or the *greenhousectl* flags `--kubeconfig` and `--kubecontext`  
-must point to the respective Greenhouse kubeconfig. 
+- `greenhouse`: The cluster your Greenhouse installation is running on. You need `organization-admin` or `cluster-admin` priviledges.
+- `bootstrap`: The cluster you want to onboard. You need `system:masters` priviledges.
 
-For accessing your **Kubernetes cluster**, it's mandatory to provide the kubeconfig to the *greenhousectl* using the flag `--bootstrap-kubeconfig` 
+For consistency we will refer to those two clusters by their names from now on.
+
+You need to have the `kubeconfig` files for both the `greenhouse` and the `bootstrap` cluster at hand. The `kubeconfig` file for the `greenhouse` cluster can be downloaded via the Greenhouse dashboard:
+
+_Organization_ > _Clusters_ > _Access greenhouse cluster_.
+
+For accessing the `greenhouse` cluster, the `greenhousectl` will expect your default kubernetes [`kubeconfig` file](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/) and [`context`](https://kubernetes.io/docs/reference/kubectl/generated/kubectl_config/kubectl_config_use-context/) to be set to `greenhouse`.
+The easiest way for doing so is passing the `--kubeconfig` (and optionally `--kubecontext`) flag to your `greenhousectl` command.
+
+The location of the `kubeconfig` file to the `bootstrap` cluster is passed via the `--bootstrap-kubeconfig` flag.
+
 ### Onboard
 
-Since Greenhouse generates URLs which contain the cluster name, we highly recommend to choose a **short** cluster name. 
-In particular for <span style="color:red">Gardener Clusters</span> setting a short name is mandatory, because Gardener has very long cluster names, e.g. `garden-greenhouse--monitoring-external`.
-
 ```commandline
-greenhousectl cluster bootstrap --bootstrap-kubeconfig <path/to/cluster-kubeconfig-file> --org <greenhouse-organization-name> --cluster-name <name>
+greenhousectl cluster bootstrap --kubeconfig=<path/to/greenhouse-kubeconfig-file> --bootstrap-kubeconfig <path/to/bootstrap-kubeconfig-file> --org <greenhouse-organization-name> --cluster-name <name>
 ```
+
+Since Greenhouse generates URLs which contain the cluster name, we highly recommend to choose a **short** cluster name.
+In particular for <span style="color:red">Gardener Clusters</span> setting a short name is mandatory, because Gardener has very long cluster names, e.g. `garden-greenhouse--monitoring-external`.
 
 A typical output when you ran the command looks like
 
@@ -51,22 +59,26 @@ A typical output when you ran the command looks like
 ### After onboarding
 
 1. List all clusters in your Greenhouse organization:
+
 ```
    kubectl --namespace=<greenhouse-organization-name> get clusters
 ```
-2. Show the details of a cluster: 
+
+2. Show the details of a cluster:
+
 ```
    kubectl --namespace=<greenhouse-organization-name> get cluster <name> -o yaml
 ```
 
-Example:   
+Example:
+
 ```yaml
 apiVersion: greenhouse.sap/v1alpha1
 kind: Cluster
 metadata:
   creationTimestamp: "2024-02-07T10:23:23Z"
   finalizers:
-  - greenhouse.sap/cluster
+    - greenhouse.sap/cluster
   generation: 1
   name: monitoring
   namespace: ccloud
@@ -77,10 +89,10 @@ spec:
 status:
   bearerTokenExpirationTimestamp: "2024-02-09T06:28:57Z"
   kubernetesVersion: v1.27.8
-...
 ```
+
 When the `status.kubernetesVersion` field shows the correct version of the Kubernetes cluster, the cluster was successfully bootstrapped in Greenhouse.
-In the remote cluster, a new namespace is created and contains some resources managed by Greenhouse. 
-The namespace has the same name as your organization in Greenhouse. 
+In the remote cluster, a new namespace is created and contains some resources managed by Greenhouse.
+The namespace has the same name as your organization in Greenhouse.
 
 If the bootstrapping failed, you can delete the Kubernetes cluster from Greenhouse with `kubectl --namespace=<greenhouse-organization-name> delete cluster <name>` and run the bootstrap command again.

--- a/docs/user-guides/cluster/onboarding.md
+++ b/docs/user-guides/cluster/onboarding.md
@@ -101,4 +101,5 @@ Then `status.conditions` will contain a `Condition` with `type=Ready` and `statu
 In the remote cluster, a new namespace is created and contains some resources managed by Greenhouse.
 The namespace has the same name as your organization in Greenhouse.
 
-If the bootstrapping failed, you can delete the Kubernetes cluster from Greenhouse with `kubectl --namespace=<greenhouse-organization-name> delete cluster <name>` and run the bootstrap command again.
+If the bootstrapping failed, you can find details about why it failed in the `Cluster.statusConditions`. More precisely there will be a condition of `type=KubeConfigValid` which might have hints in the `message` field. This is also displayed in the UI on the `Cluster` details view.
+Reruning the onboarding command with an updated `kubeConfig` file will fix these issues.

--- a/docs/user-guides/cluster/onboarding.md
+++ b/docs/user-guides/cluster/onboarding.md
@@ -21,7 +21,7 @@ Download the latest `greenhousectl` binary from [here](https://github.com/cloudo
 Onboarding a `Cluster` to Greenhouse will require you to authenticate to two different Kubernetes clusters via respective `kubeconfig` files:
 
 - `greenhouse`: The cluster your Greenhouse installation is running on. You need `organization-admin` or `cluster-admin` priviledges.
-- `bootstrap`: The cluster you want to onboard. You need `system:masters` priviledges.
+- `bootstrap`: The cluster you want to onboard. You need `system:masters` privileges.
 
 For consistency we will refer to those two clusters by their names from now on.
 

--- a/docs/user-guides/cluster/onboarding.md
+++ b/docs/user-guides/cluster/onboarding.md
@@ -31,7 +31,7 @@ _Organization_ > _Clusters_ > _Access Greenhouse cluster_.
 
 ### Onboard
 
-For accessing the `greenhouse` cluster, the `greenhousectl` will expect your default kubernetes [`kubeconfig` file](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/) and [`context`](https://kubernetes.io/docs/reference/kubectl/generated/kubectl_config/kubectl_config_use-context/) to be set to `greenhouse`.
+For accessing the `greenhouse` cluster, the `greenhousectl` will expect your default Kubernetes [`kubeconfig` file](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/) and [`context`](https://kubernetes.io/docs/reference/kubectl/generated/kubectl_config/kubectl_config_use-context/) to be set to `greenhouse`.
 The easiest way for doing so is passing the `--kubeconfig` (and optionally `--kubecontext`) flag to your `greenhousectl` command.
 
 The location of the `kubeconfig` file to the `bootstrap` cluster is passed via the `--bootstrap-kubeconfig` flag.

--- a/docs/user-guides/cluster/onboarding.md
+++ b/docs/user-guides/cluster/onboarding.md
@@ -34,7 +34,7 @@ _Organization_ > _Clusters_ > _Access Greenhouse cluster_.
 For accessing the `greenhouse` cluster, the `greenhousectl` will expect your default Kubernetes [`kubeconfig` file](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/) and [`context`](https://kubernetes.io/docs/reference/kubectl/generated/kubectl_config/kubectl_config_use-context/) to be set to `greenhouse`.
 The easiest way for doing so is passing the `--kubeconfig` (and optionally `--kubecontext`) flag to your `greenhousectl` command.
 
-The location of the `kubeconfig` file to the `bootstrap` cluster is passed via the `--bootstrap-kubeconfig` flag.
+The location of the `kubeconfig` file to the `bootstrap` cluster is passed via the `--kubeconfig` flag or via the `KUBECONFIG` enviorment variable
 
 ```commandline
 greenhousectl cluster bootstrap --kubeconfig=<path/to/greenhouse-kubeconfig-file> --bootstrap-kubeconfig <path/to/bootstrap-kubeconfig-file> --org <greenhouse-organization-name> --cluster-name <name>

--- a/docs/user-guides/cluster/onboarding.md
+++ b/docs/user-guides/cluster/onboarding.md
@@ -76,7 +76,8 @@ apiVersion: greenhouse.sap/v1alpha1
 kind: Cluster
 metadata:
   creationTimestamp: "2024-02-07T10:23:23Z"
-  finalizers: greenhouse.sap/cluster
+  finalizers:
+    - greenhouse.sap/cleanup
   generation: 1
   name: monitoring
   namespace: ccloud
@@ -95,7 +96,7 @@ status:
 ```
 
 When the `status.kubernetesVersion` field shows the correct version of the Kubernetes cluster, the cluster was successfully bootstrapped in Greenhouse.
-Then `status.conditions` will contain a `Condition` with `type=ready` and `status="true""`
+Then `status.conditions` will contain a `Condition` with `type=Ready` and `status="true""`
 
 In the remote cluster, a new namespace is created and contains some resources managed by Greenhouse.
 The namespace has the same name as your organization in Greenhouse.

--- a/docs/user-guides/cluster/onboarding.md
+++ b/docs/user-guides/cluster/onboarding.md
@@ -27,7 +27,7 @@ For consistency we will refer to those two clusters by their names from now on.
 
 You need to have the `kubeconfig` files for both the `greenhouse` and the `bootstrap` cluster at hand. The `kubeconfig` file for the `greenhouse` cluster can be downloaded via the Greenhouse dashboard:
 
-_Organization_ > _Clusters_ > _Access greenhouse cluster_.
+_Organization_ > _Clusters_ > _Access Greenhouse cluster_.
 
 ### Onboard
 


### PR DESCRIPTION
## Description
This aims to better define and outline the permission scopes needed to onboard a `Cluster` to Greenhouse


## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [x] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

- Closes #539 

