### PR TITLE
Revert "feat(organizationwebhook): deny deletion of organization (#610)"

### DIFF
--- a/pkg/admission/organization_webhook.go
+++ b/pkg/admission/organization_webhook.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"strings"
 
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -56,10 +55,6 @@ func ValidateUpdateOrganization(_ context.Context, _ client.Client, _, _ runtime
 	return nil, nil
 }
 
-func ValidateDeleteOrganization(_ context.Context, _ client.Client, o runtime.Object) (admission.Warnings, error) {
-	_, ok := o.(*greenhousev1alpha1.Organization)
-	if !ok {
-		return nil, nil
-	}
-	return nil, apierrors.NewBadRequest("Organization cannot be deleted")
+func ValidateDeleteOrganization(_ context.Context, _ client.Client, _ runtime.Object) (admission.Warnings, error) {
+	return nil, nil
 }

--- a/pkg/admission/organization_webhook_test.go
+++ b/pkg/admission/organization_webhook_test.go
@@ -13,35 +13,20 @@ import (
 	greenhousev1alpha1 "github.com/cloudoperators/greenhouse/pkg/apis/greenhouse/v1alpha1"
 )
 
-var _ = Describe("Organization Webhook", func() {
-	Context("Validate Organization Defaulting Webhook", func() {
-		It("Should default the display name of the organization", func() {
-			orgWithoutDisplayName := &greenhousev1alpha1.Organization{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-organization",
-				},
-				Spec: greenhousev1alpha1.OrganizationSpec{},
-			}
+var _ = Describe("Validate Organization Defaulting Webhook", func() {
+	It("Should default the display name of the organization", func() {
+		orgWithoutDisplayName := &greenhousev1alpha1.Organization{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-organization",
+			},
+			Spec: greenhousev1alpha1.OrganizationSpec{},
+		}
 
-			Expect(DefaultOrganization(context.TODO(), nil, orgWithoutDisplayName)).
-				To(Succeed(), "there should be no error applying defaults to the organization")
-			Expect(orgWithoutDisplayName.Spec.DisplayName).
-				ToNot(BeEmpty(), "the spec.displayName should be defaulted and not be empty")
-			Expect(orgWithoutDisplayName.Spec.DisplayName).
-				To(Equal("test organization"), "the spec.display should be defaulted and match")
-		})
-	})
-
-	Context("Validate Delete Organization", func() {
-		It("should deny deletion of an organization", func() {
-			org := &greenhousev1alpha1.Organization{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-organization",
-				},
-			}
-			_, err := ValidateDeleteOrganization(context.TODO(), nil, org)
-			Expect(err).To(HaveOccurred(), "webhook should deny organization deletion")
-			Expect(err.Error()).To(Equal("Organization cannot be deleted"), "webhook should deny organization deletion with proper error message")
-		})
+		Expect(DefaultOrganization(context.TODO(), nil, orgWithoutDisplayName)).
+			To(Succeed(), "there should be no error applying defaults to the organization")
+		Expect(orgWithoutDisplayName.Spec.DisplayName).
+			ToNot(BeEmpty(), "the spec.displayName should be defaulted and not be empty")
+		Expect(orgWithoutDisplayName.Spec.DisplayName).
+			To(Equal("test organization"), "the spec.display should be defaulted and match")
 	})
 })


### PR DESCRIPTION
## Description

This reverts commit ffeaae094f6541b9407f86a86393c6a36031370a.

Besides Greenhouse Admins, nobody is allowed to delete Organization resources. With the revert it will possible again to test cleanup logic etc.

@abhijith-darshan regarding what we have talked about in the office yesterday.
The RBAC on the Organization is defined here: https://github.com/cloudoperators/greenhouse/blob/main/pkg/rbac/clusterrole.go

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [x] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->
- Related Issue # (issue)
- Closes # (issue)
- Fixes # (issue)

> Remove if not applicable

## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [ ] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
