### PR TITLE
feat(teamrbac): show failing namespaces

### DIFF
--- a/pkg/controllers/teamrbac/teamrolebinding_controller_test.go
+++ b/pkg/controllers/teamrbac/teamrolebinding_controller_test.go
@@ -330,6 +330,58 @@ var _ = Describe("Validate ClusterRole & RoleBinding on Remote Cluster", Ordered
 		})
 	})
 
+	Context("When creating a Greenhouse TeamRoleBinding with non-existing namespaces on the central cluster", func() {
+		It("Should fail to create ClusterRole and RoleBinding on the remote cluster", func() {
+			By("creating a TeamRoleBinding on the central cluster")
+			trb := setup.CreateTeamRoleBinding(test.Ctx, "test-rolebinding",
+				test.WithTeamRoleRef(teamRoleUT.Name),
+				test.WithTeamRef(teamUT.Name),
+				test.WithClusterName(clusterA.Name),
+				test.WithNamespaces("non-existing-namespace", setup.Namespace()))
+
+			By("validating the RoleBinding created on the remote cluster")
+			remoteRoleBinding := &rbacv1.RoleBinding{}
+			remoteRoleBindingName := types.NamespacedName{
+				Name:      trb.GetRBACName(),
+				Namespace: trb.Namespace,
+			}
+			Eventually(func(g Gomega) bool {
+				g.Expect(clusterAKubeClient.Get(context.TODO(), remoteRoleBindingName, remoteRoleBinding)).To(Succeed(), "there should be no error getting the RoleBinding from the Remote Cluster")
+				return !remoteRoleBinding.CreationTimestamp.IsZero()
+			}).Should(BeTrue(), "there should be no error getting the RoleBinding")
+			Expect(remoteRoleBinding.RoleRef.Name).To(HavePrefix(greenhouseapis.RBACPrefix))
+			Expect(remoteRoleBinding.RoleRef.Name).To(ContainSubstring(teamRoleUT.Name))
+
+			By("validating the ClusterRole created on the remote cluster")
+			remoteClusterRole := &rbacv1.ClusterRole{}
+			remoteClusterRoleName := types.NamespacedName{
+				Name: teamRoleUT.GetRBACName(),
+			}
+			Eventually(func(g Gomega) bool {
+				g.Expect(clusterAKubeClient.Get(test.Ctx, remoteClusterRoleName, remoteClusterRole)).To(Succeed(), "there should be no error getting the ClusterRole from the Remote Cluster")
+				return !remoteClusterRole.CreationTimestamp.IsZero()
+			}).Should(BeTrue(), "there should be no error getting the ClusterRole")
+			Expect(remoteClusterRole.Name).To(HavePrefix(greenhouseapis.RBACPrefix))
+			Expect(remoteClusterRole.Name).To(ContainSubstring(teamRoleUT.Name))
+			Expect(remoteClusterRole.Rules).To(Equal(teamRoleUT.Spec.Rules))
+
+			By("validating the TeamRoleBinding PropagationStatus for the remote cluster is false")
+			actTRB := &greenhousev1alpha1.TeamRoleBinding{}
+			actTRBKey := types.NamespacedName{Name: trb.Name, Namespace: trb.Namespace}
+			Eventually(func(g Gomega) {
+				g.Expect(test.K8sClient.Get(test.Ctx, actTRBKey, actTRB)).To(Succeed(), "there should be no error getting the TeamRoleBinding from the Central Cluster")
+				g.Expect(actTRB.Status.PropagationStatus).To(HaveLen(1), "the TeamRoleBinding should be propagated to one cluster")
+				g.Expect(actTRB.Status.PropagationStatus[0].Message).To(ContainSubstring("Failed to reconcile RoleBindings"))
+			}).Should(Succeed(), "there should be no error validating the PropagationStatus")
+			Expect(remoteClusterRole.Name).To(HavePrefix(greenhouseapis.RBACPrefix))
+			Expect(remoteClusterRole.Name).To(ContainSubstring(teamRoleUT.Name))
+			Expect(remoteClusterRole.Rules).To(Equal(teamRoleUT.Spec.Rules))
+
+			By("cleaning up the test")
+			test.EventuallyDeleted(test.Ctx, test.K8sClient, trb)
+		})
+	})
+
 	Context("When creating a Greenhouse TeamRoleBinding without namespaces on the central cluster", func() {
 		It("Should create a ClusterRole and ClusterRoleBinding on the remote cluster", func() {
 			By("creating a TeamRoleBinding without Namespaces on the central cluster")


### PR DESCRIPTION
## Description

reconciliation failures for RoleBindings did not mention for which Namespace they failed.
With this change both, events and PropagationStatus, will contain the error message describing
why the reconciliation failed

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

- Related PR #667, needs to be rebased after merging the standardisation

> Remove if not applicable

## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [ ] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
