### PR TITLE
fix(plugin): webhook errors contained []byte value

### DIFF
--- a/pkg/admission/plugin_webhook.go
+++ b/pkg/admission/plugin_webhook.go
@@ -5,6 +5,7 @@ package admission
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -199,8 +200,12 @@ func validatePluginOptionValues(optionValues []greenhousev1alpha1.PluginOptionVa
 			// validate that the Plugin.OptionValue matches the type of the PluginDefinition.Option
 			if val.Value != nil {
 				if err := pluginOption.IsValidValue(val.Value); err != nil {
+					var v any
+					if err := json.Unmarshal(val.Value.Raw, &v); err != nil {
+						v = err
+					}
 					allErrs = append(allErrs, field.Invalid(
-						fieldPathWithIndex.Child("value"), val.Value.Raw, err.Error(),
+						fieldPathWithIndex.Child("value"), v, err.Error(),
 					))
 				}
 			}


### PR DESCRIPTION
## Description

In case a value is invalid, the error should show the invalid value rendered as a string instead of the []byte.


## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->
- Related Issue # (issue)
- Closes # (issue)
- Fixes # (issue)

> Remove if not applicable

## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [ ] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
