### PR TITLE
feat(actions): enforce semantic pr title

### DIFF
--- a/.github/workflows/ci-pr-title.yaml
+++ b/.github/workflows/ci-pr-title.yaml
@@ -45,6 +45,7 @@ jobs:
             heureka
             greenhouse            
             infra
+            actions
             juno
             k8s
             message-provider

--- a/.github/workflows/ci-pr-title.yaml
+++ b/.github/workflows/ci-pr-title.yaml
@@ -1,0 +1,92 @@
+name: CI Check Title
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  title-lint:
+    name: Validate PR title
+    runs-on: [default]
+    steps:
+      - name: CI Check Title
+        uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          wip: true
+          # Configure which types are allowed (newline-delimited).
+          # Default: https://github.com/commitizen/conventional-commit-types
+          types: |
+            build
+            chore
+            fix
+            feat
+            merge
+            publish
+            release
+            refactor
+            research
+            style
+            test
+          # Configure which scopes are allowed (newline-delimited).
+          # These are regex patterns auto-wrapped in `^ $`.
+          scopes: |
+            build
+            communicator
+            config
+            carbon
+            ci
+            core
+            deps
+            docs
+            doop
+            example
+            heureka
+            greenhouse            
+            infra
+            juno
+            k8s
+            message-provider
+            npm
+            oauth
+            supernova
+            template
+            ui
+            utils
+            url-state-provider
+            version
+            ISSUE-\d+
+          # Configure that a scope must always be provided.
+          requireScope: true
+          # Configure which scopes are disallowed in PR titles (newline-delimited).
+          # For instance by setting the value below, `chore(release): ...` (lowercase)
+          # and `ci(e2e,release): ...` (unknown scope) will be rejected.
+          # These are regex patterns auto-wrapped in `^ $`.
+          disallowScopes: |
+            release
+            [A-Z]+
+          # Configure additional validation for the subject based on a regex.
+          # This example ensures the subject doesn't start with an uppercase character.
+          subjectPattern: ^(?![A-Z]).+$
+          # If `subjectPattern` is configured, you can use this property to override
+          # the default error message that is shown when the pattern doesn't match.
+          # The variables `subject` and `title` can be used within the message.
+          subjectPatternError: |
+            The subject "{subject}" found in the pull request title "{title}"
+            didn't match the configured pattern. Please ensure that the subject
+            doesn't start with an uppercase character.
+          # If the PR contains one of these newline-delimited labels, the
+          # validation is skipped. If you want to rerun the validation when
+          # labels change, you might want to use the `labeled` and `unlabeled`
+          # event triggers in your workflow.
+          ignoreLabels: |
+            bot
+            ignore-semantic-pull-request
+          # If you're using a format for the PR title that differs from the traditional Conventional
+          # Commits spec, you can use these options to customize the parsing of the type, scope and
+          # subject. The `headerPattern` should contain a regex where the capturing groups in parentheses
+          # correspond to the parts listed in `headerPatternCorrespondence`.
+          # See: https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-commits-parser#headerpattern
+          headerPattern: '^(\w*)(?:\(([\w$.\-*/ ]*)\))?: (.*)$'
+          headerPatternCorrespondence: type, scope, subject

--- a/.github/workflows/ci-pr-title.yaml
+++ b/.github/workflows/ci-pr-title.yaml
@@ -32,31 +32,28 @@ jobs:
           # Configure which scopes are allowed (newline-delimited).
           # These are regex patterns auto-wrapped in `^ $`.
           scopes: |
+            cluster-controller
+            organization-controller
+            plugin-controller
+            plugindefinition-controller
+            team-controller
+            teammembership-controller
+            teamsrbac-controller
             build
-            communicator
             config
-            carbon
             ci
             core
             deps
             docs
-            doop
-            example
-            heureka
-            greenhouse            
-            infra
+            e2e
+            greenhouse
+            greenhousectl          
             actions
-            juno
-            k8s
-            message-provider
-            npm
-            oauth
-            supernova
             template
             ui
             utils
-            url-state-provider
             version
+            webhook
             ISSUE-\d+
           # Configure that a scope must always be provided.
           requireScope: true

--- a/.github/workflows/ci-pr-title.yaml
+++ b/.github/workflows/ci-pr-title.yaml
@@ -42,6 +42,7 @@ jobs:
             teamrolebindings
             teamroles
             teams
+            service-proxy
             build
             config
             ci

--- a/.github/workflows/ci-pr-title.yaml
+++ b/.github/workflows/ci-pr-title.yaml
@@ -46,6 +46,7 @@ jobs:
             config
             ci
             core
+            controller
             deps
             docs
             e2e

--- a/.github/workflows/ci-pr-title.yaml
+++ b/.github/workflows/ci-pr-title.yaml
@@ -35,6 +35,7 @@ jobs:
             clusterkubeconfigs
             clusters
             organizations
+            dex
             idproxy
             plugindefinitions
             pluginpresets

--- a/.github/workflows/ci-pr-title.yaml
+++ b/.github/workflows/ci-pr-title.yaml
@@ -32,13 +32,16 @@ jobs:
           # Configure which scopes are allowed (newline-delimited).
           # These are regex patterns auto-wrapped in `^ $`.
           scopes: |
-            cluster-controller
-            organization-controller
-            plugin-controller
-            plugindefinition-controller
-            team-controller
-            teammembership-controller
-            teamsrbac-controller
+            clusterkubeconfigs
+            clusters
+            organizations
+            plugindefinitions
+            pluginpresets
+            plugins
+            teammemberships
+            teamrolebindings
+            teamroles
+            teams
             build
             config
             ci

--- a/.github/workflows/ci-pr-title.yaml
+++ b/.github/workflows/ci-pr-title.yaml
@@ -35,6 +35,7 @@ jobs:
             clusterkubeconfigs
             clusters
             organizations
+            idproxy
             plugindefinitions
             pluginpresets
             plugins


### PR DESCRIPTION
## Description
<!--
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

This PR is adding a new action to run on every PR to enforce semantic headers, this is a pre-requisite for CHANGELOG generation. Shared action is not yet available, but In-progress

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->
- Related Issue # (issue)
- Closes # (issue)
- Fixes # (issue)

> Remove if not applicable

## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [ ] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
