### PR TITLE
fix(dexcontroller): ensure orgs without oidc are not reconciled

### DIFF
--- a/pkg/controllers/organization/dex_controller.go
+++ b/pkg/controllers/organization/dex_controller.go
@@ -60,7 +60,8 @@ func (r *DexReconciler) SetupWithManager(name string, mgr ctrl.Manager) error {
 	}
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
-		For(&greenhousesapv1alpha1.Organization{}).
+		For(&greenhousesapv1alpha1.Organization{},
+			builder.WithPredicates(clientutil.PredicateHasOICDConfigured())).
 		Owns(&dexapi.Connector{}).
 		Owns(&dexapi.OAuth2Client{}).
 		// Watch secrets referenced by organizations for confidential values.


### PR DESCRIPTION
## Description

With the removal of checking if an Organization has OIDC configured [here](https://github.com/cloudoperators/greenhouse/pull/650/files#diff-9bd930233c1238c12ec8fb701985605cd422789cff96439d72cab2f73903ee1aL70-L73) it is necessary to use the added predicate `clientutil.PredicateHasOICDConfigured()` also in the `For(Organization)`.
Else the controller is running into nil pointer here: https://github.com/cloudoperators/greenhouse/blob/28e29288de22d6747d24ba6352cd2106f1dc6022/pkg/controllers/organization/dex_controller.go#L99-L106


## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->
- Related Issue # (issue)
- Closes # (issue)
- Fixes # (issue)

> Remove if not applicable

## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [ ] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
