### PR TITLE
fix(ci): add docs as type

### DIFF
--- a/.github/workflows/ci-pr-title.yaml
+++ b/.github/workflows/ci-pr-title.yaml
@@ -29,6 +29,7 @@ jobs:
             research
             style
             test
+            docs
           # Configure which scopes are allowed (newline-delimited).
           # These are regex patterns auto-wrapped in `^ $`.
           scopes: |


### PR DESCRIPTION
This adds a new valid `type` for PR titles: `docs`