### PR TITLE
fix(service-proxy): revert only enqueue if watched resource changed

### DIFF
--- a/cmd/service-proxy/proxy.go
+++ b/cmd/service-proxy/proxy.go
@@ -36,7 +36,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	greenhouseapis "github.com/cloudoperators/greenhouse/pkg/apis"
 	greenhousev1alpha1 "github.com/cloudoperators/greenhouse/pkg/apis/greenhouse/v1alpha1"
@@ -155,10 +154,9 @@ func (pm *ProxyManager) SetupWithManager(name string, mgr ctrl.Manager) error {
 		Named(name).
 		For(&v1.Secret{}, builder.WithPredicates(
 			clientutil.PredicateFilterBySecretType(greenhouseapis.SecretTypeKubeConfig),
-			predicate.ResourceVersionChangedPredicate{},
 		)).
 		// Watch plugins to be notified about exposed services
-		Watches(&greenhousev1alpha1.Plugin{}, handler.EnqueueRequestsFromMapFunc(enqueuePluginForCluster), builder.WithPredicates(predicate.Or(predicate.GenerationChangedPredicate{}, predicate.LabelChangedPredicate{}))).
+		Watches(&greenhousev1alpha1.Plugin{}, handler.EnqueueRequestsFromMapFunc(enqueuePluginForCluster)).
 		Complete(pm)
 }
 


### PR DESCRIPTION
Reverts cloudoperators/greenhouse#557

The service-proxy needs to be triggered upon changes to the Plugin's status. Since the status contains the information required to proxy the request to the correct service & port. 
With the predicates, changes to the status were not reconciled