### PR TITLE
fix(utils): generate manifests with new controller-gen version

### DIFF
--- a/charts/manager/crds/greenhouse.sap_clusterkubeconfigs.yaml
+++ b/charts/manager/crds/greenhouse.sap_clusterkubeconfigs.yaml
@@ -6,7 +6,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: clusterkubeconfigs.greenhouse.sap
 spec:
   group: greenhouse.sap

--- a/charts/manager/crds/greenhouse.sap_clusters.yaml
+++ b/charts/manager/crds/greenhouse.sap_clusters.yaml
@@ -6,7 +6,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: clusters.greenhouse.sap
 spec:
   group: greenhouse.sap

--- a/charts/manager/crds/greenhouse.sap_organizations.yaml
+++ b/charts/manager/crds/greenhouse.sap_organizations.yaml
@@ -6,7 +6,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: organizations.greenhouse.sap
 spec:
   group: greenhouse.sap

--- a/charts/manager/crds/greenhouse.sap_plugindefinitions.yaml
+++ b/charts/manager/crds/greenhouse.sap_plugindefinitions.yaml
@@ -6,7 +6,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: plugindefinitions.greenhouse.sap
 spec:
   group: greenhouse.sap

--- a/charts/manager/crds/greenhouse.sap_pluginpresets.yaml
+++ b/charts/manager/crds/greenhouse.sap_pluginpresets.yaml
@@ -6,7 +6,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: pluginpresets.greenhouse.sap
 spec:
   group: greenhouse.sap

--- a/charts/manager/crds/greenhouse.sap_plugins.yaml
+++ b/charts/manager/crds/greenhouse.sap_plugins.yaml
@@ -6,7 +6,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: plugins.greenhouse.sap
 spec:
   group: greenhouse.sap

--- a/charts/manager/crds/greenhouse.sap_teammemberships.yaml
+++ b/charts/manager/crds/greenhouse.sap_teammemberships.yaml
@@ -6,7 +6,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: teammemberships.greenhouse.sap
 spec:
   group: greenhouse.sap

--- a/charts/manager/crds/greenhouse.sap_teamrolebindings.yaml
+++ b/charts/manager/crds/greenhouse.sap_teamrolebindings.yaml
@@ -6,7 +6,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: teamrolebindings.greenhouse.sap
 spec:
   group: greenhouse.sap

--- a/charts/manager/crds/greenhouse.sap_teamroles.yaml
+++ b/charts/manager/crds/greenhouse.sap_teamroles.yaml
@@ -6,7 +6,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: teamroles.greenhouse.sap
 spec:
   group: greenhouse.sap

--- a/charts/manager/crds/greenhouse.sap_teams.yaml
+++ b/charts/manager/crds/greenhouse.sap_teams.yaml
@@ -6,7 +6,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: teams.greenhouse.sap
 spec:
   group: greenhouse.sap

--- a/charts/manager/templates/manager-role.yaml
+++ b/charts/manager/templates/manager-role.yaml
@@ -8,17 +8,6 @@ rules:
   - ""
   resources:
   - events
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
   - namespaces
   verbs:
   - create
@@ -32,16 +21,6 @@ rules:
   - ""
   resources:
   - secrets
-  verbs:
-  - create
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
   - serviceaccounts
   verbs:
   - create
@@ -72,6 +51,7 @@ rules:
   - greenhouse.sap
   resources:
   - cluster-kubeconfigs
+  - teamroles
   verbs:
   - create
   - get
@@ -83,6 +63,12 @@ rules:
   - greenhouse.sap
   resources:
   - clusters
+  - organizations
+  - plugindefinitions
+  - plugins
+  - teammemberships
+  - teamrolebindings
+  - teams
   verbs:
   - create
   - delete
@@ -94,74 +80,26 @@ rules:
 - apiGroups:
   - greenhouse.sap
   resources:
-  - clusters
-  - teams
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - greenhouse.sap
-  resources:
   - clusters/finalizers
+  - organizations/finalizers
+  - plugindefinitions/finalizers
+  - pluginpresets/finalizers
+  - plugins/finalizers
+  - teammemberships/finalizers
+  - teamrolebindings/finalizers
+  - teams/finalizers
   verbs:
   - update
 - apiGroups:
   - greenhouse.sap
   resources:
   - clusters/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - greenhouse.sap
-  resources:
-  - organizations
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - greenhouse.sap
-  resources:
-  - organizations/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - greenhouse.sap
-  resources:
   - organizations/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - greenhouse.sap
-  resources:
-  - plugindefinitions
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - greenhouse.sap
-  resources:
-  - plugindefinitions/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - greenhouse.sap
-  resources:
   - plugindefinitions/status
+  - pluginpresets/status
+  - teammemberships/status
+  - teamrolebindings/status
+  - teams/status
   verbs:
   - get
   - patch
@@ -178,38 +116,6 @@ rules:
 - apiGroups:
   - greenhouse.sap
   resources:
-  - pluginpresets/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - greenhouse.sap
-  resources:
-  - pluginpresets/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - greenhouse.sap
-  resources:
-  - plugins
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - greenhouse.sap
-  resources:
-  - plugins/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - greenhouse.sap
-  resources:
   - plugins/status
   verbs:
   - get
@@ -217,95 +123,6 @@ rules:
   - patch
   - update
   - watch
-- apiGroups:
-  - greenhouse.sap
-  resources:
-  - teammemberships
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - greenhouse.sap
-  resources:
-  - teammemberships/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - greenhouse.sap
-  resources:
-  - teammemberships/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - greenhouse.sap
-  resources:
-  - teamrolebindings
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - greenhouse.sap
-  resources:
-  - teamrolebindings/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - greenhouse.sap
-  resources:
-  - teamrolebindings/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - greenhouse.sap
-  resources:
-  - teamroles
-  verbs:
-  - create
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - greenhouse.sap
-  resources:
-  - teams
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - greenhouse.sap
-  resources:
-  - teams/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - greenhouse.sap
-  resources:
-  - teams/status
-  verbs:
-  - get
-  - patch
-  - update
 - apiGroups:
   - rbac
   resources:


### PR DESCRIPTION
## Description

Controller-gen was bumped to v0.16.5.  With v0.16.0 the generated RBAC is now deduplicated by default.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->
- Related Issue # (issue)
- Closes # (issue)
- Fixes # (issue)

> Remove if not applicable

## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [ ] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
