### PR TITLE
feat(utils): add namespace selector to greenhouse secret webhooks

### DIFF
--- a/charts/manager/templates/webhooks.yaml
+++ b/charts/manager/templates/webhooks.yaml
@@ -4,380 +4,392 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: greenhouse-mutating-webhook-configuration
 webhooks:
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: greenhouse-webhook-service
-      namespace: greenhouse
-      path: /mutate-greenhouse-sap-v1alpha1-cluster
-  failurePolicy: Fail
-  name: mcluster.kb.io
-  rules:
-  - apiGroups:
-    - greenhouse.sap
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - clusters
-  sideEffects: None
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: greenhouse-webhook-service
-      namespace: greenhouse
-      path: /mutate-greenhouse-sap-v1alpha1-organization
-  failurePolicy: Fail
-  name: morganization.kb.io
-  rules:
-  - apiGroups:
-    - greenhouse.sap
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - organizations
-  sideEffects: None
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: greenhouse-webhook-service
-      namespace: greenhouse
-      path: /mutate-greenhouse-sap-v1alpha1-plugin
-  failurePolicy: Fail
-  name: mplugin.kb.io
-  rules:
-  - apiGroups:
-    - greenhouse.sap
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - plugins
-  sideEffects: None
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: greenhouse-webhook-service
-      namespace: greenhouse
-      path: /mutate-greenhouse-sap-v1alpha1-plugindefinition
-  failurePolicy: Fail
-  name: mplugindefinition.kb.io
-  rules:
-  - apiGroups:
-    - greenhouse.sap
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - plugindefinitions
-  sideEffects: None
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: greenhouse-webhook-service
-      namespace: greenhouse
-      path: /mutate-greenhouse-sap-v1alpha1-pluginpreset
-  failurePolicy: Fail
-  name: mpluginpreset.kb.io
-  rules:
-  - apiGroups:
-    - greenhouse.sap
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - pluginpresets
-  sideEffects: None
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: greenhouse-webhook-service
-      namespace: greenhouse
-      path: /mutate-greenhouse-sap-v1alpha1-teamrole
-  failurePolicy: Fail
-  name: mrole.kb.io
-  rules:
-  - apiGroups:
-    - greenhouse.sap
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - teamroles
-  sideEffects: None
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: greenhouse-webhook-service
-      namespace: greenhouse
-      path: /mutate-greenhouse-sap-v1alpha1-teamrolebinding
-  failurePolicy: Fail
-  name: mrolebinding.kb.io
-  rules:
-  - apiGroups:
-    - greenhouse.sap
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - teamrolebindings
-  sideEffects: None
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: greenhouse-webhook-service
-      namespace: greenhouse
-      path: /mutate--v1-secret
-  failurePolicy: Ignore
-  matchPolicy: Exact
-  name: msecret.kb.io
-  rules:
-  - apiGroups:
-    - ""
-    apiVersions:
-    - v1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - secrets
-  sideEffects: None
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: greenhouse-webhook-service
-      namespace: greenhouse
-      path: /mutate-greenhouse-sap-v1alpha1-team
-  failurePolicy: Fail
-  name: mteam.kb.io
-  rules:
-  - apiGroups:
-    - greenhouse.sap
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - teams
-  sideEffects: None
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: greenhouse-webhook-service
+        namespace: greenhouse
+        path: /mutate-greenhouse-sap-v1alpha1-cluster
+    failurePolicy: Fail
+    name: mcluster.kb.io
+    rules:
+      - apiGroups:
+          - greenhouse.sap
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - clusters
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: greenhouse-webhook-service
+        namespace: greenhouse
+        path: /mutate-greenhouse-sap-v1alpha1-organization
+    failurePolicy: Fail
+    name: morganization.kb.io
+    rules:
+      - apiGroups:
+          - greenhouse.sap
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - organizations
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: greenhouse-webhook-service
+        namespace: greenhouse
+        path: /mutate-greenhouse-sap-v1alpha1-plugin
+    failurePolicy: Fail
+    name: mplugin.kb.io
+    rules:
+      - apiGroups:
+          - greenhouse.sap
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - plugins
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: greenhouse-webhook-service
+        namespace: greenhouse
+        path: /mutate-greenhouse-sap-v1alpha1-plugindefinition
+    failurePolicy: Fail
+    name: mplugindefinition.kb.io
+    rules:
+      - apiGroups:
+          - greenhouse.sap
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - plugindefinitions
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: greenhouse-webhook-service
+        namespace: greenhouse
+        path: /mutate-greenhouse-sap-v1alpha1-pluginpreset
+    failurePolicy: Fail
+    name: mpluginpreset.kb.io
+    rules:
+      - apiGroups:
+          - greenhouse.sap
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - pluginpresets
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: greenhouse-webhook-service
+        namespace: greenhouse
+        path: /mutate-greenhouse-sap-v1alpha1-teamrole
+    failurePolicy: Fail
+    name: mrole.kb.io
+    rules:
+      - apiGroups:
+          - greenhouse.sap
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - teamroles
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: greenhouse-webhook-service
+        namespace: greenhouse
+        path: /mutate-greenhouse-sap-v1alpha1-teamrolebinding
+    failurePolicy: Fail
+    name: mrolebinding.kb.io
+    rules:
+      - apiGroups:
+          - greenhouse.sap
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - teamrolebindings
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: greenhouse-webhook-service
+        namespace: greenhouse
+        path: /mutate--v1-secret
+    failurePolicy: Ignore
+    matchPolicy: Exact
+    name: msecret.kb.io
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - secrets
+    sideEffects: None
+    namespaceSelector:
+      matchExpressions:
+        - key: kubernetes.io
+          operator: NotIn
+          values:
+            - kube-system
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: greenhouse-webhook-service
+        namespace: greenhouse
+        path: /mutate-greenhouse-sap-v1alpha1-team
+    failurePolicy: Fail
+    name: mteam.kb.io
+    rules:
+      - apiGroups:
+          - greenhouse.sap
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - teams
+    sideEffects: None
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: greenhouse-validating-webhook-configuration
 webhooks:
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: greenhouse-webhook-service
-      namespace: greenhouse
-      path: /validate-greenhouse-sap-v1alpha1-cluster
-  failurePolicy: Fail
-  name: vcluster.kb.io
-  rules:
-  - apiGroups:
-    - greenhouse.sap
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    - DELETE
-    resources:
-    - clusters
-  sideEffects: None
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: greenhouse-webhook-service
-      namespace: greenhouse
-      path: /validate-greenhouse-sap-v1alpha1-organization
-  failurePolicy: Fail
-  name: vorganization.kb.io
-  rules:
-  - apiGroups:
-    - greenhouse.sap
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    - DELETE
-    resources:
-    - organizations
-  sideEffects: None
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: greenhouse-webhook-service
-      namespace: greenhouse
-      path: /validate-greenhouse-sap-v1alpha1-plugin
-  failurePolicy: Fail
-  name: vplugin.kb.io
-  rules:
-  - apiGroups:
-    - greenhouse.sap
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    - DELETE
-    resources:
-    - plugins
-  sideEffects: None
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: greenhouse-webhook-service
-      namespace: greenhouse
-      path: /validate-greenhouse-sap-v1alpha1-plugindefinition
-  failurePolicy: Fail
-  name: vplugindefinition.kb.io
-  rules:
-  - apiGroups:
-    - greenhouse.sap
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    - DELETE
-    resources:
-    - plugindefinitions
-  sideEffects: None
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: greenhouse-webhook-service
-      namespace: greenhouse
-      path: /validate-greenhouse-sap-v1alpha1-pluginpreset
-  failurePolicy: Fail
-  name: vpluginpreset.kb.io
-  rules:
-  - apiGroups:
-    - greenhouse.sap
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    - DELETE
-    resources:
-    - pluginpresets
-  sideEffects: None
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: greenhouse-webhook-service
-      namespace: greenhouse
-      path: /validate-greenhouse-sap-v1alpha1-teamrole
-  failurePolicy: Fail
-  name: vrole.kb.io
-  rules:
-  - apiGroups:
-    - greenhouse.sap
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    - DELETE
-    resources:
-    - teamroles
-  sideEffects: None
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: greenhouse-webhook-service
-      namespace: greenhouse
-      path: /validate-greenhouse-sap-v1alpha1-teamrolebinding
-  failurePolicy: Fail
-  name: vrolebinding.kb.io
-  rules:
-  - apiGroups:
-    - greenhouse.sap
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    - DELETE
-    resources:
-    - teamrolebindings
-  sideEffects: None
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: greenhouse-webhook-service
-      namespace: greenhouse
-      path: /validate--v1-secret
-  failurePolicy: Ignore
-  matchPolicy: Exact
-  name: vsecret.kb.io
-  rules:
-  - apiGroups:
-    - ""
-    apiVersions:
-    - v1
-    operations:
-    - CREATE
-    - UPDATE
-    - DELETE
-    resources:
-    - secrets
-  sideEffects: None
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: greenhouse-webhook-service
-      namespace: greenhouse
-      path: /validate-greenhouse-sap-v1alpha1-team
-  failurePolicy: Fail
-  name: vteam.kb.io
-  rules:
-  - apiGroups:
-    - greenhouse.sap
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    - DELETE
-    resources:
-    - teams
-  sideEffects: None
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: greenhouse-webhook-service
+        namespace: greenhouse
+        path: /validate-greenhouse-sap-v1alpha1-cluster
+    failurePolicy: Fail
+    name: vcluster.kb.io
+    rules:
+      - apiGroups:
+          - greenhouse.sap
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+          - DELETE
+        resources:
+          - clusters
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: greenhouse-webhook-service
+        namespace: greenhouse
+        path: /validate-greenhouse-sap-v1alpha1-organization
+    failurePolicy: Fail
+    name: vorganization.kb.io
+    rules:
+      - apiGroups:
+          - greenhouse.sap
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+          - DELETE
+        resources:
+          - organizations
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: greenhouse-webhook-service
+        namespace: greenhouse
+        path: /validate-greenhouse-sap-v1alpha1-plugin
+    failurePolicy: Fail
+    name: vplugin.kb.io
+    rules:
+      - apiGroups:
+          - greenhouse.sap
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+          - DELETE
+        resources:
+          - plugins
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: greenhouse-webhook-service
+        namespace: greenhouse
+        path: /validate-greenhouse-sap-v1alpha1-plugindefinition
+    failurePolicy: Fail
+    name: vplugindefinition.kb.io
+    rules:
+      - apiGroups:
+          - greenhouse.sap
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+          - DELETE
+        resources:
+          - plugindefinitions
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: greenhouse-webhook-service
+        namespace: greenhouse
+        path: /validate-greenhouse-sap-v1alpha1-pluginpreset
+    failurePolicy: Fail
+    name: vpluginpreset.kb.io
+    rules:
+      - apiGroups:
+          - greenhouse.sap
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+          - DELETE
+        resources:
+          - pluginpresets
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: greenhouse-webhook-service
+        namespace: greenhouse
+        path: /validate-greenhouse-sap-v1alpha1-teamrole
+    failurePolicy: Fail
+    name: vrole.kb.io
+    rules:
+      - apiGroups:
+          - greenhouse.sap
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+          - DELETE
+        resources:
+          - teamroles
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: greenhouse-webhook-service
+        namespace: greenhouse
+        path: /validate-greenhouse-sap-v1alpha1-teamrolebinding
+    failurePolicy: Fail
+    name: vrolebinding.kb.io
+    rules:
+      - apiGroups:
+          - greenhouse.sap
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+          - DELETE
+        resources:
+          - teamrolebindings
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: greenhouse-webhook-service
+        namespace: greenhouse
+        path: /validate--v1-secret
+    failurePolicy: Ignore
+    matchPolicy: Exact
+    name: vsecret.kb.io
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+          - DELETE
+        resources:
+          - secrets
+    sideEffects: None
+    namespaceSelector:
+      matchExpressions:
+        - key: kubernetes.io
+          operator: NotIn
+          values:
+            - kube-system
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: greenhouse-webhook-service
+        namespace: greenhouse
+        path: /validate-greenhouse-sap-v1alpha1-team
+    failurePolicy: Fail
+    name: vteam.kb.io
+    rules:
+      - apiGroups:
+          - greenhouse.sap
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+          - DELETE
+        resources:
+          - teams
+    sideEffects: None

--- a/hack/helmify
+++ b/hack/helmify
@@ -37,6 +37,8 @@ PREFIX="greenhouse" rename "mutating-webhook-configuration"
 PREFIX="greenhouse" rename "validating-webhook-configuration"
 PREFIX="greenhouse" rename "webhook-service"
 
+yq -i '(.webhooks[] | select(.name == "*secret.kb.io") | .namespaceSelector) |= {"matchExpressions": [{"key":"kubernetes.io", "operator": "NotIn", "values":["kube-system"]}]}' "$TEMPLATES_DIR/webhooks.yaml"
+
 # Helmify RBAC.
 rename-file-if-exists "$TEMPLATES_DIR/role.yaml" "$TEMPLATES_DIR/manager-role.yaml"
 $SED_CMD 's/namespace: system/namespace: {{ .Release.Namespace}}/g' "$TEMPLATES_DIR/manager-role.yaml"


### PR DESCRIPTION
## Description

This adds a `yq` command to the helmify script to add a namespaceSelector to the secret webhooks.
File is reformatted by `yq`, this is a one-time operation

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->
- Related Issue # (issue)
- Closes # (issue)
- Fixes # (issue)

> Remove if not applicable

## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [ ] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
