### PR TITLE
feat(greenhousectl): validation of cluster name during onboarding

### DIFF
--- a/pkg/admission/secret_webhook_test.go
+++ b/pkg/admission/secret_webhook_test.go
@@ -4,6 +4,8 @@
 package admission
 
 import (
+	"context"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -14,6 +16,7 @@ import (
 var _ = Describe("Validate Secret Creation based on type", func() {
 	DescribeTable("Validate secret creation with different secret types", func(secretType corev1.SecretType, dataKey string, expErr bool) {
 		var secret *corev1.Secret
+		var ctx context.Context
 		if dataKey != "" {
 			secret = &corev1.Secret{
 				Type: secretType,
@@ -26,7 +29,7 @@ var _ = Describe("Validate Secret Creation based on type", func() {
 				Type: secretType,
 			}
 		}
-		err := validateSecretGreenHouseType(secret)
+		err := validateSecretGreenHouseType(ctx, secret)
 		switch expErr {
 		case true:
 			Expect(err).To(HaveOccurred(), "expected an error, got nil")

--- a/pkg/cmd/cluster_bootstrap.go
+++ b/pkg/cmd/cluster_bootstrap.go
@@ -181,7 +181,7 @@ func (o *newClusterBootstrapOptions) fillDefaults() error {
 		}
 		o.clusterName = customerConfig.CurrentContext
 	}
-	if err := validateClusterName(o.clusterName); err != nil {
+	if err := validateClusterName(o.clusterName, 40); err != nil {
 		return err
 	}
 
@@ -426,11 +426,11 @@ func getKubeconfigOrDie(kubecontext string) *rest.Config {
 	return restConfig
 }
 
-func validateClusterName(clustertName string) error {
+func validateClusterName(clustertName string, length int) error {
 	switch {
 	case clustertName == "":
 		return errors.New("cluster name cannot be empty")
-	case len(clustertName) > 40:
+	case len(clustertName) > length:
 		return errors.New("cluster name cannot be longer than 40 characters")
 	case strings.Contains(clustertName, "--"):
 		return errors.New("cluster name cannot contain '--'")

--- a/pkg/cmd/cluster_bootstrap.go
+++ b/pkg/cmd/cluster_bootstrap.go
@@ -430,11 +430,11 @@ func getKubeconfigOrDie(kubecontext string) *rest.Config {
 // validateClusterName is making sure that the cluster name is not empty, not longer than length parameter characters and does not contain '--'
 func validateClusterName(clusterName string, length int) error {
 	switch {
-	case clustertName == "":
+	case clusterName == "":
 		return errors.New("cluster name cannot be empty")
-	case len(clustertName) > length:
+	case len(clusterName) > length:
 		return errors.New("cluster name cannot be longer than 40 characters")
-	case strings.Contains(clustertName, "--"):
+	case strings.Contains(clusterName, "--"):
 		return errors.New("cluster name cannot contain '--'")
 	}
 	return nil

--- a/pkg/cmd/cluster_bootstrap.go
+++ b/pkg/cmd/cluster_bootstrap.go
@@ -428,7 +428,7 @@ func getKubeconfigOrDie(kubecontext string) *rest.Config {
 }
 
 // validateClusterName is making sure that the cluster name is not empty, not longer than length parameter characters and does not contain '--'
-func validateClusterName(clustertName string, length int) error {
+func validateClusterName(clusterName string, length int) error {
 	switch {
 	case clustertName == "":
 		return errors.New("cluster name cannot be empty")

--- a/pkg/cmd/cluster_bootstrap.go
+++ b/pkg/cmd/cluster_bootstrap.go
@@ -181,6 +181,7 @@ func (o *newClusterBootstrapOptions) fillDefaults() error {
 		}
 		o.clusterName = customerConfig.CurrentContext
 	}
+	// Validate the cluster name here before proceeding
 	if err := validateClusterName(o.clusterName, 40); err != nil {
 		return err
 	}
@@ -426,6 +427,7 @@ func getKubeconfigOrDie(kubecontext string) *rest.Config {
 	return restConfig
 }
 
+// validateClusterName is making sure that the cluster name is not empty, not longer than lenght parameter characters and does not contain '--'
 func validateClusterName(clustertName string, length int) error {
 	switch {
 	case clustertName == "":

--- a/pkg/cmd/cluster_bootstrap.go
+++ b/pkg/cmd/cluster_bootstrap.go
@@ -427,7 +427,7 @@ func getKubeconfigOrDie(kubecontext string) *rest.Config {
 	return restConfig
 }
 
-// validateClusterName is making sure that the cluster name is not empty, not longer than lenght parameter characters and does not contain '--'
+// validateClusterName is making sure that the cluster name is not empty, not longer than length parameter characters and does not contain '--'
 func validateClusterName(clustertName string, length int) error {
 	switch {
 	case clustertName == "":

--- a/pkg/cmd/cluster_bootstrap.go
+++ b/pkg/cmd/cluster_bootstrap.go
@@ -181,6 +181,9 @@ func (o *newClusterBootstrapOptions) fillDefaults() error {
 		}
 		o.clusterName = customerConfig.CurrentContext
 	}
+	if err := validateClusterName(o.clusterName); err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -421,4 +424,16 @@ func getKubeconfigOrDie(kubecontext string) *rest.Config {
 	}
 	setupLog.Info("Loaded kubeconfig", "context", kubecontext, "host", restConfig.Host)
 	return restConfig
+}
+
+func validateClusterName(clustertName string) error {
+	switch {
+	case clustertName == "":
+		return errors.New("cluster name cannot be empty")
+	case len(clustertName) > 40:
+		return errors.New("cluster name cannot be longer than 40 characters")
+	case strings.Contains(clustertName, "--"):
+		return errors.New("cluster name cannot contain '--'")
+	}
+	return nil
 }


### PR DESCRIPTION
<!--
Please ensure the PR title follows the conventional commit format:
<type>(<scope>): description

For a list of accepted types and scopes see the workflow documentation: https://github.com/cloudoperators/greenhouse/blob/main/.github/workflows/ci-pr-title.yaml

-->

## Description

- `greenhousectl cluster boostrap` enforces of the 40 character limit and no `--` in the ClusterName
- the secret webhook is enforcing the name validation for type `greenhouse.sap/kubeconfig`. the func are re-used from cluster webhook: https://github.com/cloudoperators/greenhouse/blob/4ff77ed17b7bd8354415982de26748849044cab1/pkg/admission/cluster_webhook.go#L91-L97

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 

- Related Issue # (issue)
- Closes # (issue)
- Fixes # (issue)

-->

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [x] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
