### PR TITLE
feat(pluginpresets): deletion protection for plugin preset

### DIFF
--- a/docs/user-guides/plugin/plugin-management.md
+++ b/docs/user-guides/plugin/plugin-management.md
@@ -21,6 +21,8 @@ In case the _PluginPreset_ is updated all of the Plugin instances that are manag
 Changes that are done directly on a _Plugin_ which was created from a _PluginPreset_ will be overwritten immediately by the _PluginPreset_ Controller. All changes must be performed on the _PluginPreset_ itself.
 If a _Plugin_ already existed with the same name as the _PluginPreset_ would create, this _Plugin_ will be ignored in following reconciliations.
 
+To prevent accidental deletion of the _Plugin_, the _PluginPreset_ has the annotation `greenhouse.sap/prevent-deletion`. To delete the pluginPreset along with the plugins, you must first remove the annotation.
+
 ## Example _PluginPreset_
 
 ```yaml

--- a/docs/user-guides/plugin/plugin-management.md
+++ b/docs/user-guides/plugin/plugin-management.md
@@ -21,8 +21,7 @@ In case the _PluginPreset_ is updated all of the Plugin instances that are manag
 Changes that are done directly on a _Plugin_ which was created from a _PluginPreset_ will be overwritten immediately by the _PluginPreset_ Controller. All changes must be performed on the _PluginPreset_ itself.
 If a _Plugin_ already existed with the same name as the _PluginPreset_ would create, this _Plugin_ will be ignored in following reconciliations.
 
-To prevent accidental deletion of the _Plugin_, the _PluginPreset_ has the annotation `greenhouse.sap/prevent-deletion`. To delete the pluginPreset along with the plugins, you must first remove the annotation.
-
+A __PluginPreset__ with the annotation `greenhouse.sap/prevent-deletion` may not be deleted. This is to prevent the accidental deletion of a __PluginPreset__ including the managed __Plugins__ and their deployed Helm releases. Only after removing the annotation it is possible to delete a __PluginPreset__.
 ## Example _PluginPreset_
 
 ```yaml

--- a/pkg/admission/pluginpreset_webhook.go
+++ b/pkg/admission/pluginpreset_webhook.go
@@ -35,7 +35,20 @@ func SetupPluginPresetWebhookWithManager(mgr ctrl.Manager) error {
 
 //+kubebuilder:webhook:path=/mutate-greenhouse-sap-v1alpha1-pluginpreset,mutating=true,failurePolicy=fail,sideEffects=None,groups=greenhouse.sap,resources=pluginpresets,verbs=create;update,versions=v1alpha1,name=mpluginpreset.kb.io,admissionReviewVersions=v1
 
-func DefaultPluginPreset(_ context.Context, _ client.Client, _ runtime.Object) error {
+func DefaultPluginPreset(_ context.Context, _ client.Client, o runtime.Object) error {
+	pluginPreset, ok := o.(*greenhousev1alpha1.PluginPreset)
+	if !ok {
+		return nil
+	}
+
+	// prevent deletion on plugin preset creation
+	if pluginPreset.Annotations == nil {
+		pluginPreset.Annotations = map[string]string{}
+	}
+	if pluginPreset.CreationTimestamp.IsZero() {
+		pluginPreset.Annotations[preventDeletionAnnotation] = "true"
+	}
+
 	return nil
 }
 

--- a/pkg/admission/pluginpreset_webhook.go
+++ b/pkg/admission/pluginpreset_webhook.go
@@ -109,6 +109,21 @@ func ValidateUpdatePluginPreset(ctx context.Context, c client.Client, oldObj, cu
 	return nil, nil
 }
 
-func ValidateDeletePluginPreset(_ context.Context, _ client.Client, _ runtime.Object) (admission.Warnings, error) {
+func ValidateDeletePluginPreset(_ context.Context, _ client.Client, obj runtime.Object) (admission.Warnings, error) {
+	pluginPreset, ok := obj.(*greenhousev1alpha1.PluginPreset)
+	if !ok {
+		return nil, nil
+	}
+
+	var allErrs field.ErrorList
+	if _, ok := pluginPreset.Annotations["greenhouse.sap/prevent-deletion"]; ok {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("metadata").Child("annotation").Child("greenhouse.sap/prevent-deletion"), pluginPreset.Annotations,
+			"Plugin preset has prevent deletion annotation"))
+	}
+
+	if len(allErrs) > 0 {
+		return nil, apierrors.NewInvalid(pluginPreset.GroupVersionKind().GroupKind(), pluginPreset.Name, allErrs)
+	}
+
 	return nil, nil
 }

--- a/pkg/admission/pluginpreset_webhook.go
+++ b/pkg/admission/pluginpreset_webhook.go
@@ -19,6 +19,8 @@ import (
 
 // Webhook for the PluginPreset custom resource.
 
+const preventDeletionAnnotation = "greenhouse.sap/prevent-deletion"
+
 func SetupPluginPresetWebhookWithManager(mgr ctrl.Manager) error {
 	return setupWebhook(mgr,
 		&greenhousev1alpha1.PluginPreset{},
@@ -116,9 +118,9 @@ func ValidateDeletePluginPreset(_ context.Context, _ client.Client, obj runtime.
 	}
 
 	var allErrs field.ErrorList
-	if _, ok := pluginPreset.Annotations["greenhouse.sap/prevent-deletion"]; ok {
-		allErrs = append(allErrs, field.Invalid(field.NewPath("metadata").Child("annotation").Child("greenhouse.sap/prevent-deletion"), pluginPreset.Annotations,
-			"Plugin preset has prevent deletion annotation"))
+	if _, ok := pluginPreset.Annotations[preventDeletionAnnotation]; ok {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("metadata").Child("annotation").Child(preventDeletionAnnotation),
+			pluginPreset.Annotations, "Plugin preset has prevent deletion annotation"))
 	}
 
 	if len(allErrs) > 0 {

--- a/pkg/admission/pluginpreset_webhook.go
+++ b/pkg/admission/pluginpreset_webhook.go
@@ -133,7 +133,7 @@ func ValidateDeletePluginPreset(_ context.Context, _ client.Client, obj runtime.
 	var allErrs field.ErrorList
 	if _, ok := pluginPreset.Annotations[preventDeletionAnnotation]; ok {
 		allErrs = append(allErrs, field.Invalid(field.NewPath("metadata").Child("annotation").Child(preventDeletionAnnotation),
-			pluginPreset.Annotations, "Plugin preset has prevent deletion annotation"))
+			pluginPreset.Annotations, fmt.Sprintf("PluginPreset with annotation '%s' set may not be deleted.", preventDeletionAnnotation)))
 	}
 
 	if len(allErrs) > 0 {

--- a/pkg/admission/pluginpreset_webhook_test.go
+++ b/pkg/admission/pluginpreset_webhook_test.go
@@ -170,4 +170,35 @@ var _ = Describe("PluginPreset Admission Tests", Ordered, func() {
 		Expect(test.K8sClient.Delete(test.Ctx, cut)).
 			To(Succeed(), "there must be no error deleting the PluginPreset")
 	})
+
+	It("should reject delete operation when PluginPreset has prevent deletion annotation", func() {
+		pluginPreset := &greenhousev1alpha1.PluginPreset{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      pluginPresetUpdate,
+				Namespace: test.TestNamespace,
+				Annotations: map[string]string{
+					preventDeletionAnnotation: "true",
+				},
+			},
+			Spec: greenhousev1alpha1.PluginPresetSpec{
+				Plugin: greenhousev1alpha1.PluginSpec{
+					PluginDefinition: pluginPresetDefinition,
+				},
+				ClusterSelector: metav1.LabelSelector{MatchLabels: map[string]string{"foo": "bar"}},
+			},
+		}
+
+		err := test.K8sClient.Create(test.Ctx, pluginPreset)
+		Expect(err).ToNot(HaveOccurred())
+
+		err = test.K8sClient.Delete(test.Ctx, pluginPreset)
+		Expect(err).To(HaveOccurred())
+
+		pluginPreset.Annotations = map[string]string{}
+		err = test.K8sClient.Update(test.Ctx, pluginPreset)
+		Expect(err).ToNot(HaveOccurred())
+
+		err = test.K8sClient.Delete(test.Ctx, pluginPreset)
+		Expect(err).ToNot(HaveOccurred())
+	})
 })

--- a/pkg/admission/pluginpreset_webhook_test.go
+++ b/pkg/admission/pluginpreset_webhook_test.go
@@ -167,6 +167,12 @@ var _ = Describe("PluginPreset Admission Tests", Ordered, func() {
 		Expect(err.Error()).
 			To(ContainSubstring("field is immutable"), "the error must reflect the field is immutable")
 
+		_, err = clientutil.CreateOrPatch(test.Ctx, test.K8sClient, cut, func() error {
+			delete(cut.Annotations, preventDeletionAnnotation)
+			return nil
+		})
+		Expect(err).
+			ToNot(HaveOccurred())
 		Expect(test.K8sClient.Delete(test.Ctx, cut)).
 			To(Succeed(), "there must be no error deleting the PluginPreset")
 	})

--- a/pkg/controllers/plugin/pluginpreset_controller_test.go
+++ b/pkg/controllers/plugin/pluginpreset_controller_test.go
@@ -165,6 +165,9 @@ var _ = Describe("PluginPreset Controller Lifecycle", Ordered, func() {
 		Expect(err).NotTo(HaveOccurred(), "failed to update Plugin")
 
 		By("deleting the PluginPreset")
+		testPluginPreset.Annotations = map[string]string{}
+		err = test.K8sClient.Update(test.Ctx, testPluginPreset)
+		Expect(err).ToNot(HaveOccurred())
 		Expect(test.K8sClient.Delete(test.Ctx, testPluginPreset)).Should(Succeed(), "failed to delete test PluginPreset")
 	})
 
@@ -195,6 +198,12 @@ var _ = Describe("PluginPreset Controller Lifecycle", Ordered, func() {
 		}))
 
 		By("removing plugin preset")
+		Eventually(func(g Gomega) {
+			err := test.K8sClient.Get(test.Ctx, client.ObjectKeyFromObject(pluginPreset), pluginPreset)
+			g.Expect(err).ShouldNot(HaveOccurred(), "unexpected error getting PluginPreset")
+			pluginPreset.Annotations = map[string]string{}
+			Expect(test.K8sClient.Update(test.Ctx, pluginPreset)).ToNot(HaveOccurred())
+		}).Should(Succeed(), "failed to update PluginPreset")
 		Expect(test.K8sClient.Delete(test.Ctx, pluginPreset)).ToNot(HaveOccurred())
 		test.EventuallyDeleted(test.Ctx, test.K8sClient, pluginPreset)
 	})


### PR DESCRIPTION
<!--
Please ensure the PR title follows the conventional commit format:
<type>(<scope>): description

For a list of accepted types and scopes see the workflow documentation: https://github.com/cloudoperators/greenhouse/blob/main/.github/workflows/ci-pr-title.yaml

-->

## Description
I implemented validation in the webhook to prevent the deletion of plugin presets when the greenhouse.sap/prevent-deletion annotation is present.

## What type of PR is this? (check all applicable)

- [X] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 

- Related Issue # (issue)
- Closes #804 
- Fixes # (issue)

-->

## Added tests?

- [X] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [X] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes
