### PR TITLE
fix(teamrolebindings): do not error out on cluster connection errors

### DIFF
--- a/pkg/controllers/teamrbac/suite_test.go
+++ b/pkg/controllers/teamrbac/suite_test.go
@@ -5,7 +5,6 @@ package teamrbac
 
 import (
 	"testing"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -14,7 +13,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 
 	"github.com/cloudoperators/greenhouse/pkg/admission"
-	"github.com/cloudoperators/greenhouse/pkg/controllers/cluster"
 	"github.com/cloudoperators/greenhouse/pkg/test"
 	//+kubebuilder:scaffold:imports
 )
@@ -44,10 +42,6 @@ func TestRBACController(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	test.RegisterController("roleBindingController", (&TeamRoleBindingReconciler{}).SetupWithManager)
-	test.RegisterController("clusterReconciler", (&cluster.RemoteClusterReconciler{
-		RemoteClusterBearerTokenValidity:   30 * time.Minute,
-		RenewRemoteClusterBearerTokenAfter: 25 * time.Minute,
-	}).SetupWithManager)
 	test.RegisterWebhook("clusterWebhook", admission.SetupClusterWebhookWithManager)
 	test.RegisterWebhook("teamsWebhook", admission.SetupTeamWebhookWithManager)
 	test.RegisterWebhook("teamRoleBindingWebhook", admission.SetupTeamRoleBindingWebhookWithManager)

--- a/pkg/test/util.go
+++ b/pkg/test/util.go
@@ -16,6 +16,7 @@ import (
 	gomegaTypes "github.com/onsi/gomega/types"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -56,6 +57,20 @@ func MustDeleteCluster(ctx context.Context, c client.Client, id client.ObjectKey
 		err := c.Get(ctx, client.ObjectKeyFromObject(cluster), cluster)
 		return apierrors.IsNotFound(err)
 	}).Should(BeTrue(), "the object should be deleted eventually")
+}
+
+// SetClusterReadyCondition sets the ready condition of the cluster resource.
+func SetClusterReadyCondition(ctx context.Context, c client.Client, cluster *greenhousev1alpha1.Cluster, readyStatus metav1.ConditionStatus) error {
+	_, err := clientutil.PatchStatus(ctx, c, cluster, func() error {
+		cluster.Status.StatusConditions.SetConditions(greenhousev1alpha1.NewCondition(
+			greenhousev1alpha1.ReadyCondition,
+			readyStatus,
+			"",
+			"",
+		))
+		return nil
+	})
+	return err
 }
 
 // MustReturnJSONFor marshals val to JSON and returns an apiextensionsv1.JSON.


### PR DESCRIPTION
<!--
Please ensure the PR title follows the conventional commit format:
<type>(<scope>): description

For a list of accepted types and scopes see the workflow documentation: https://github.com/cloudoperators/greenhouse/blob/main/.github/workflows/ci-pr-title.yaml

-->

## Description

The TeamRoleBindings were not correctly reconciled once the connection to one cluster was not working. It would early exit with an error because the client could not be created.

This also fixes an error where clusters were listed twice in the error condition.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 

- Related Issue # (issue)
- Closes # (issue)
- Fixes # (issue)

-->

## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [ ] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
