### PR TITLE
feat(plugins): first helm release rollback

### DIFF
--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -565,6 +565,10 @@ func isCanReleaseBeUpgraded(r *release.Release) (release.Status, bool) {
 	if r.Info == nil {
 		return release.StatusUnknown, false
 	}
+	// Allow the upgrade to the first release, even if it failed.
+	if r.Version == 1 {
+		return r.Info.Status, !r.Info.Status.IsPending()
+	}
 	// The release must neither be pending nor failed.
 	return r.Info.Status, !r.Info.Status.IsPending() && r.Info.Status != release.StatusFailed
 }

--- a/pkg/helm/helm_test.go
+++ b/pkg/helm/helm_test.go
@@ -198,6 +198,45 @@ var _ = Describe("helm package test", func() {
 			Expect(err).ToNot(HaveOccurred(), "there must be no error uninstalling helm release")
 		})
 	})
+
+	FWhen("helm install fails at initial release", func() {
+		It("should rollback to the same initial version", func() {
+			By("installing a helm chart from a pluginDefinition")
+			err := helm.InstallOrUpgradeHelmChartFromPlugin(test.Ctx, test.K8sClient, test.RestClientGetter, testPluginWithHelmChart, plugin)
+			Expect(err).ShouldNot(HaveOccurred(),
+				"there should be no error for installing helm chart from plugin")
+
+			By("getting the deployed helm release")
+			cfg, err := helm.ExportNewHelmAction(test.RestClientGetter, plugin.Spec.ReleaseNamespace)
+			Expect(err).ShouldNot(HaveOccurred(), "there should be no error creating helm config")
+			getAction := action.NewGet(cfg)
+			helmRelease, err := getAction.Run(plugin.Name)
+			Expect(err).ShouldNot(HaveOccurred(), "there should be no error getting the helm release")
+			Expect(helmRelease.Info.Status).To(Equal(release.StatusDeployed), "helm release should be set to deployed")
+
+			By("fake failing helm install by setting the deployed helm release to failed")
+			helmRelease.SetStatus(release.StatusFailed, "release set to failed manually from a test")
+			err = cfg.Releases.Update(helmRelease)
+			Expect(err).ToNot(HaveOccurred(), "there should be no error updating the helm release")
+
+			By("checking that the helm release status is set to failed")
+			getAction = action.NewGet(cfg)
+			helmRelease, err = getAction.Run(plugin.Name)
+			Expect(err).ShouldNot(HaveOccurred(), "there should be no error getting the helm release")
+			Expect(helmRelease.Info.Status).To(Equal(release.StatusFailed), "helm release should be set to failed")
+
+			By("running install or upgrade again")
+			err = helm.InstallOrUpgradeHelmChartFromPlugin(test.Ctx, test.K8sClient, test.RestClientGetter, testPluginWithHelmChart, plugin)
+			Expect(err).ShouldNot(HaveOccurred(),
+				"there should be no error for upgrading the helm chart")
+
+			By("checking that the helm release has been fixed")
+			getAction = action.NewGet(cfg)
+			helmRelease, err = getAction.Run(plugin.Name)
+			Expect(err).ShouldNot(HaveOccurred(), "there should be no error getting the helm release")
+			Expect(helmRelease.Info.Status).To(Equal(release.StatusDeployed), "helm release should be set to deployed")
+		})
+	})
 })
 
 var _ = DescribeTable("getting helm values from Plugin", func(defaultValue any, exp any) {

--- a/pkg/helm/helm_test.go
+++ b/pkg/helm/helm_test.go
@@ -199,10 +199,10 @@ var _ = Describe("helm package test", func() {
 		})
 	})
 
-	FWhen("helm install fails at initial release", func() {
+	When("helm install fails at initial release", func() {
 		It("should rollback to the same initial version", func() {
 			By("installing a helm chart from a pluginDefinition")
-			err := helm.InstallOrUpgradeHelmChartFromPlugin(test.Ctx, test.K8sClient, test.RestClientGetter, testPluginWithHelmChart, plugin)
+			err := helm.InstallOrUpgradeHelmChartFromPlugin(test.Ctx, test.K8sClient, test.RestClientGetter, testPluginWithHelmChartCRDs, plugin)
 			Expect(err).ShouldNot(HaveOccurred(),
 				"there should be no error for installing helm chart from plugin")
 
@@ -226,7 +226,7 @@ var _ = Describe("helm package test", func() {
 			Expect(helmRelease.Info.Status).To(Equal(release.StatusFailed), "helm release should be set to failed")
 
 			By("running install or upgrade again")
-			err = helm.InstallOrUpgradeHelmChartFromPlugin(test.Ctx, test.K8sClient, test.RestClientGetter, testPluginWithHelmChart, plugin)
+			err = helm.InstallOrUpgradeHelmChartFromPlugin(test.Ctx, test.K8sClient, test.RestClientGetter, testPluginWithHelmChartCRDs, plugin)
 			Expect(err).ShouldNot(HaveOccurred(),
 				"there should be no error for upgrading the helm chart")
 
@@ -235,6 +235,10 @@ var _ = Describe("helm package test", func() {
 			helmRelease, err = getAction.Run(plugin.Name)
 			Expect(err).ShouldNot(HaveOccurred(), "there should be no error getting the helm release")
 			Expect(helmRelease.Info.Status).To(Equal(release.StatusDeployed), "helm release should be set to deployed")
+
+			By("cleaning up test")
+			_, err = helm.UninstallHelmRelease(test.Ctx, test.RestClientGetter, plugin)
+			Expect(err).ToNot(HaveOccurred(), "there must be no error uninstalling helm release")
 		})
 	})
 })


### PR DESCRIPTION
## Description

This PR allows a rollback of the first helm release in version 1. In case of failed release, the rollback to the same version will commence.

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

- Closes #857 

## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

I've added a test that installs helm release, sets it into a failed status, and then retries the chart installation to trigger the rollback.

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [x] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
