### PR TITLE
fix(core): skip non-ready clusters during propagation reconciliation

### DIFF
--- a/pkg/controllers/propagation_reconciler.go
+++ b/pkg/controllers/propagation_reconciler.go
@@ -74,6 +74,11 @@ func (r *PropagationReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 	// TODO parallelize
 	for _, cluster := range clusterList.Items {
+		// skip clusters that are no longer accessible
+		if !cluster.Status.StatusConditions.IsReadyTrue() {
+			continue
+		}
+
 		// get corresponding secret to access the cluster
 		var secret = new(corev1.Secret)
 		if err := r.Get(ctx, types.NamespacedName{Name: cluster.GetSecretName(), Namespace: cluster.GetNamespace()}, secret); err != nil {


### PR DESCRIPTION

<!--
Please ensure the PR title follows the conventional commit format:
<type>(<scope>): description

For a list of accepted types and scopes see the workflow documentation: https://github.com/cloudoperators/greenhouse/blob/main/.github/workflows/ci-pr-title.yaml

-->

## Description

Clusters which are not accessible block the deletion. This skips clusters which cannot be accessed.


## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 

- Related Issue # (issue)
- Closes # (issue)
- Fixes # (issue)

-->

## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [ ] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
