### PR TITLE
fix(controller): prevent lifecycle reconcile to enter creation phase if deletionTimestamp is set

### DIFF
--- a/pkg/lifecycle/reconcile.go
+++ b/pkg/lifecycle/reconcile.go
@@ -84,7 +84,11 @@ func Reconcile(ctx context.Context, kubeClient client.Client, namespacedName typ
 		result ctrl.Result
 		err    error
 	)
-	if shouldBeDeleted && hasFinalizer {
+	if shouldBeDeleted {
+		// in case of unknown finalizer, we need to ensure that the reconcile does not enter into ensureCreated phase
+		if !hasFinalizer {
+			return ctrl.Result{}, nil
+		}
 		// check if the resource is already deleted (a control state to decide whether to remove finalizer)
 		// at this point the remote resource is already cleaned up so garbage collection can be done
 		if isResourceDeleted(runtimeObject) {

--- a/pkg/lifecycle/reconcile.go
+++ b/pkg/lifecycle/reconcile.go
@@ -187,10 +187,10 @@ func patchStatus(ctx context.Context, kubeClient client.Client, newObject Runtim
 
 // ensureFinalizer - ensures a finalizer is present on the object. Returns an error on failure.
 func ensureFinalizer(ctx context.Context, c client.Client, o client.Object, finalizer string) error {
-	if controllerutil.ContainsFinalizer(o, finalizer) {
-		return nil
+	if controllerutil.AddFinalizer(o, finalizer) {
+		return c.Update(ctx, o)
 	}
-	return c.Update(ctx, o)
+	return nil
 }
 
 // removeFinalizer - removes a finalizer from an object. Returns an error on failure.

--- a/pkg/lifecycle/reconcile.go
+++ b/pkg/lifecycle/reconcile.go
@@ -9,8 +9,6 @@ import (
 	"github.com/go-logr/logr"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	"github.com/cloudoperators/greenhouse/pkg/clientutil"
-
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -192,21 +190,13 @@ func ensureFinalizer(ctx context.Context, c client.Client, o client.Object, fina
 	if controllerutil.ContainsFinalizer(o, finalizer) {
 		return nil
 	}
-	_, err := clientutil.Patch(ctx, c, o, func() error {
-		controllerutil.AddFinalizer(o, finalizer)
-		return nil
-	})
-	return err
+	return c.Update(ctx, o)
 }
 
 // removeFinalizer - removes a finalizer from an object. Returns an error on failure.
 func removeFinalizer(ctx context.Context, c client.Client, o client.Object, finalizer string) error {
-	if !controllerutil.ContainsFinalizer(o, finalizer) {
-		return nil
+	if controllerutil.RemoveFinalizer(o, finalizer) {
+		return c.Update(ctx, o)
 	}
-	_, err := clientutil.Patch(ctx, c, o, func() error {
-		controllerutil.RemoveFinalizer(o, finalizer)
-		return nil
-	})
-	return err
+	return nil
 }

--- a/pkg/lifecycle/reconcile_test.go
+++ b/pkg/lifecycle/reconcile_test.go
@@ -53,6 +53,7 @@ var _ = Describe("Reconcile", func() {
 		statusWriter.On("Patch", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		mockClient = &mocks.MockClient{}
 		mockClient.On("Get", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+		mockClient.On("Update", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		mockClient.On("Patch", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		mockClient.On("Status").Return(statusWriter)
 


### PR DESCRIPTION
This PR addresses prevents the deletion scenario where if non-cleanup finalizers were set on the greenhouse custom resource, the reconciler slipped into `ensureCreated` phase.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

- Closes #896 #895 

## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

By having additional finalizers other than the common `CleanUpFinalizer` the reconciler should not enter into `ensureCreated` phase

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [x] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
