### PR TITLE
fix(plugins): prevent infinite reconciliation in plugins

### DIFF
--- a/pkg/controllers/plugin/plugin_controller.go
+++ b/pkg/controllers/plugin/plugin_controller.go
@@ -221,7 +221,10 @@ func (r *PluginReconciler) getPluginDefinition(
 		return nil, errors.New(errorMessage)
 	}
 
-	plugin.SetCondition(greenhousev1alpha1.FalseCondition(greenhousev1alpha1.HelmReconcileFailedCondition, "", ""))
+	helmReconcileCondition := plugin.Status.GetConditionByType(greenhousev1alpha1.HelmReconcileFailedCondition)
+	if helmReconcileCondition == nil {
+		plugin.SetCondition(greenhousev1alpha1.FalseCondition(greenhousev1alpha1.HelmReconcileFailedCondition, "", ""))
+	}
 	return pluginDefinition, nil
 }
 

--- a/pkg/controllers/plugin/plugin_controller.go
+++ b/pkg/controllers/plugin/plugin_controller.go
@@ -220,11 +220,6 @@ func (r *PluginReconciler) getPluginDefinition(
 
 		return nil, errors.New(errorMessage)
 	}
-
-	helmReconcileCondition := plugin.Status.GetConditionByType(greenhousev1alpha1.HelmReconcileFailedCondition)
-	if helmReconcileCondition == nil {
-		plugin.SetCondition(greenhousev1alpha1.FalseCondition(greenhousev1alpha1.HelmReconcileFailedCondition, "", ""))
-	}
 	return pluginDefinition, nil
 }
 


### PR DESCRIPTION
## Description

The plugin controller flaps between True and False for `HelmReconcileFailed` condition as it is initialized in the beginning to be `False` and then later set to `True` due to reconciliation errors.

We need to avoid this so that the reconcile doesn't go into an endless loop

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [x] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
