### PR TITLE
feat(ci): e2e OIDC setup between admin and remote clusters

### DIFF
--- a/.github/workflows/ci-e2e-test.yaml
+++ b/.github/workflows/ci-e2e-test.yaml
@@ -43,10 +43,12 @@ jobs:
       # run the e2e tests using composite common/workflows/e2e action
       - name: "E2E"
         id: e2e
-        uses: cloudoperators/common/workflows/e2e@main
+        uses: cloudoperators/common/workflows/e2e@feat/oidc-e2e-setup
         with:
           k8s-version: ${{ matrix.k8s-version }}
           scenario: ${{ matrix.e2es }}
+          admin-config: ${{ github.workspace }}/dev-env/localenv/greenhouse-admin-cluster.yaml
+          remote-config: ${{ github.workspace }}/dev-env/localenv/greenhouse-remote-cluster.yaml
 
       # v4 upload-artifact needs unique names for each artifact (see https://github.com/actions/upload-artifact/tree/main?tab=readme-ov-file#not-uploading-to-the-same-artifact)
       - name: "Upload E2E Logs"

--- a/dev-env/localenv/greenhouse-admin-cluster.yaml
+++ b/dev-env/localenv/greenhouse-admin-cluster.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: control-plane
+    kubeadmConfigPatches:
+      - |
+        kind: ClusterConfiguration
+        apiServer:
+          extraArgs:
+            "anonymous-auth": "true"
+            "service-account-issuer": "https://greenhouse-admin-control-plane:6443"
+            "service-account-jwks-uri": "https://greenhouse-admin-control-plane:6443/openid/v1/jwks"

--- a/dev-env/localenv/greenhouse-remote-cluster.yaml
+++ b/dev-env/localenv/greenhouse-remote-cluster.yaml
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: control-plane
+    kubeadmConfigPatches:
+      - |
+        kind: ClusterConfiguration
+        apiServer:
+          extraArgs:
+            "oidc-issuer-url": "https://greenhouse-admin-control-plane:6443"
+            "oidc-client-id": "greenhouse"
+            "oidc-username-claim": "sub"
+            "oidc-groups-claim": "groups"
+            "oidc-username-prefix": "greenhouse:"
+            "oidc-ca-file": "/etc/kubernetes/pki/oidc-ca.crt"  # Trust the admin cluster CA
+            "anonymous-auth": "true"
+    extraMounts:
+      - hostPath: bin/greenhouse-admin-ca.crt
+        containerPath: /etc/kubernetes/pki/oidc-ca.crt
+        readOnly: true
+  - role: worker
+  - role: worker


### PR DESCRIPTION
## Description

With the upcoming feature of OIDC connectivity from greenhouse management cluster to remote clusters, we need to test end-to-end OIDC cluster onboarding scenario

This PR supplies the necessary config to `KinD` clusters in GitHub Actions

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

- Related Issue #878 

needs https://github.com/cloudoperators/common/pull/26 to be merged first

## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [ ] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
