### PR TITLE
fix(dex): add dashboard subdoamin to org redirect URI

### DIFF
--- a/pkg/controllers/organization/dex.go
+++ b/pkg/controllers/organization/dex.go
@@ -243,7 +243,7 @@ func getRedirects(orgName string, redirectURIs []string) []string {
 }
 
 func getRedirectForOrg(orgName string) string {
-	return fmt.Sprintf("https://%s.%s", orgName, common.DNSDomain)
+	return fmt.Sprintf("https://%s.dashboard.%s", orgName, common.DNSDomain)
 }
 
 // appendRedirects - appends newRedirects to the redirects slice if it does not exist

--- a/pkg/controllers/organization/organization_controller_test.go
+++ b/pkg/controllers/organization/organization_controller_test.go
@@ -355,6 +355,7 @@ var _ = Describe("Test Organization reconciliation", Ordered, func() {
 						Expect(orgClient.RedirectURIs).To(ContainElements("https://example.com/app", "http://localhost:33768/auth/callback"), "the oauth client redirect URIs should be equal to organization redirect URIs")
 					case greenhouseOrgName:
 						Expect(orgClient.ID).To(Equal(greenhouseOrgName), "the oauth client ID should be equal to organization name")
+						Expect(orgClient.RedirectURIs).To(ContainElements("https://test-oidc-org.dashboard."), "the greenhouse client should contain the org's dashboard redirect uri")
 						Expect(orgClient.RedirectURIs).To(HaveLen(5), "the oauth client redirect URIs should have 4 elements (default 3 + 1 org + 1 additional)")
 					default:
 						Fail("unexpected oauth client ID")


### PR DESCRIPTION
<!--
Please ensure the PR title follows the conventional commit format:
<type>(<scope>): description

For a list of accepted types and scopes see the workflow documentation: https://github.com/cloudoperators/greenhouse/blob/main/.github/workflows/ci-pr-title.yaml

-->

## Description

The redirect URI for the org was missing the `.dashboard.` subdomain. 

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 

- Related Issue # (issue)
- Closes # (issue)
- Fixes # (issue)

-->

## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [ ] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
