### PR TITLE
fix(plugins): set timeout for helm releasetest actions

### DIFF
--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -119,8 +119,9 @@ func ChartTest(restClientGetter genericclioptions.RESTClientGetter, plugin *gree
 	if err != nil {
 		return hasTestHook, err
 	}
-
-	results, err := action.NewReleaseTesting(cfg).Run(plugin.Name)
+	rta := action.NewReleaseTesting(cfg)
+	rta.Timeout = GetHelmTimeout() // set a timeout for the release testing to avoid waiting forever
+	results, err := rta.Run(plugin.Name)
 	if err != nil {
 		return hasTestHook, err
 	}


### PR DESCRIPTION
<!--
Please ensure the PR title follows the conventional commit format:
<type>(<scope>): description

For a list of accepted types and scopes see the workflow documentation: https://github.com/cloudoperators/greenhouse/blob/main/.github/workflows/ci-pr-title.yaml

-->

## Description

The Chart Testing has no timeout set by default. This PR sets at least the default timeout used for the [HELM CLI](https://github.com/helm/helm/blob/9fad3cd907012122465ae46cd340dd637ed429ea/pkg/cmd/release_testing.go#L97) 
This is to avoid that a Chart Test that retries on failure does not block the Plugin controller.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 

- Related Issue # (issue)
- Closes # (issue)
- Fixes # (issue)

-->

## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [ ] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
