### PR TITLE
fix(clusters): revert cluster ready condition

### DIFF
--- a/pkg/controllers/cluster/cluster_status.go
+++ b/pkg/controllers/cluster/cluster_status.go
@@ -44,8 +44,7 @@ func (r *RemoteClusterReconciler) setConditions() lifecycle.Conditioner {
 			allNodesReadyCondition, clusterNodeStatus = r.reconcileNodeStatus(ctx, restClientGetter)
 		}
 
-		// set ready condition if kubeconfig is valid and all nodes are ready
-		readyCondition := r.reconcileReadyStatus(kubeConfigValidCondition, allNodesReadyCondition)
+		readyCondition := r.reconcileReadyStatus(kubeConfigValidCondition)
 
 		conditions = append(conditions, readyCondition, allNodesReadyCondition, kubeConfigValidCondition)
 
@@ -117,7 +116,7 @@ func (r *RemoteClusterReconciler) reconcileReadyStatus(conditions ...greenhousev
 	for _, condition := range conditions {
 		if condition.IsFalse() {
 			readyCondition.Status = metav1.ConditionFalse
-			readyCondition.Message = "cannot access cluster"
+			readyCondition.Message = "kubeconfig not valid - cannot access cluster"
 			if condition.Message != "" {
 				readyCondition.Message = condition.Message
 			}


### PR DESCRIPTION
## Description

Onboarding cluster with `kubeconfig` involved RBAC management by `Greenhouse` and hence `Ready` condition was based on only the `kubeconfig` validation.

With OIDC onboarding RBAC management was delegated to the client as the RBAC needed to exist beforehand.
This involved changing the `Ready` condition to ensure `AllNodesReady` condition to be `True`.

However this introduced a regression where `Ready` condition reported `False` when one of the nodes in the client cluster was not `Ready`.

This PR reverts the logic to compute ready condition based on kubeconfig validity only and fine grained status computing will be handled in follow-up issues. #1034 and #1035 

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [x] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
