### PR TITLE
fix(e2e): removes deprecated fields from the appProps.json creation

### DIFF
--- a/charts/dashboard/templates/dashboard-props-cm.yaml
+++ b/charts/dashboard/templates/dashboard-props-cm.yaml
@@ -15,7 +15,6 @@ data:
       "authClientId": {{ default .Values.global.oidc.dashboardClientID "greenhouse" | quote }},
       "currentHost": {{ required ".Values.dashboard.assetServerURL missing" .Values.dashboard.assetServerURL | quote }},
       "apiEndpoint": {{ include "dashboard.api.hostname" $  | quote }},
-      "environment": {{ required ".Values.dashboard.environment" .Values.dashboard.environment | quote }},
       "demoUserToken": {{ required ".Values.dashboard.demoUser.token" .Values.dashboard.demoUser.token | quote }}
     }
 

--- a/charts/dashboard/values.yaml
+++ b/charts/dashboard/values.yaml
@@ -7,7 +7,7 @@ global:
 
 image:
   repository: ghcr.io/cloudoperators/juno-app-greenhouse
-  digest: sha256:2c6c4c169a297239279cc159b07b504a581ece55df1295f87a0d5e12e6ed8a0f
+  digest: sha256:a0db5f8667b8ca9cd025c71ceee218060f6bf8b581d4620e8ce0a4317b74be04
   pullPolicy: IfNotPresent
 
 replicas: 2

--- a/charts/dashboard/values.yaml
+++ b/charts/dashboard/values.yaml
@@ -17,7 +17,6 @@ ingress:
 
 dashboard:
   assetServerURL: origin
-  environment: prod
 
   # The user for demonstration purposes.
   demoUser:

--- a/dev-env/ui.values.yaml
+++ b/dev-env/ui.values.yaml
@@ -17,6 +17,5 @@ image:
 
 dashboard:
   assetServerURL: origin
-  environment: development
   demoUser:
     token: demo

--- a/internal/local/setup/dashboard.go
+++ b/internal/local/setup/dashboard.go
@@ -34,7 +34,6 @@ const (
 	dashboardDeploymentSuffix = "-dashboard"
 	dashboardConfigMapSuffix  = "-dashboard-app-props"
 	apiEndpointKey            = "apiEndpoint"
-	mockAuthKey               = "mockAuth"
 	demoUserTokenKey          = "demoUserToken"
 	demoOrgKey                = "demoOrg"
 	apiProxyURL               = "http://127.0.0.1:9090"
@@ -200,7 +199,6 @@ func (m *Manifest) modifyDashboardProps(ctx context.Context, cl client.Client, c
 		return nil, errors.New("empty token found in service account secret")
 	}
 	props[apiEndpointKey] = apiProxyURL
-	props[mockAuthKey] = "true"
 	props[demoUserTokenKey] = token
 	props[demoOrgKey] = "demo"
 


### PR DESCRIPTION
<!--
Please ensure the PR title follows the conventional commit format:
<type>(<scope>): description

For a list of accepted types and scopes see the workflow documentation: https://github.com/cloudoperators/greenhouse/blob/main/.github/workflows/ci-pr-title.yaml

-->

## Description

- Removes 'mockAuth' from the default appProps.json (deprecated in juno)
- Removes 'environment' from charts/dashboards (deprecated in juno, [commit](https://github.com/cloudoperators/juno/pull/706/commits/15de11203007c3c9e46002b9b81cf2f222ed6f8b))


## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 

- Related Issue # (issue)
- Closes # (issue)
- Fixes # (issue)

-->
Fixes #1048


## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [x] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [x] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
