### PR TITLE
fix(clusterkubeconfigs): use greenhouse-manged kubeconfig

### DIFF
--- a/pkg/controllers/cluster/kubeconfig_controller.go
+++ b/pkg/controllers/cluster/kubeconfig_controller.go
@@ -126,7 +126,7 @@ func (r *KubeconfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	}
 
 	// collect cluster connection data and update kubeconfig
-	rootKubeCfg := secret.Data["kubeconfig"]
+	rootKubeCfg := secret.Data[greenhouseapis.GreenHouseKubeConfigKey]
 	kubeCfg, err := clientcmd.Load(rootKubeCfg)
 	if err != nil {
 		kubeconfig.Status.Conditions.SetConditions(v1alpha1.TrueCondition(v1alpha1.KubeconfigReconcileFailedCondition, "KubeconfigLoadError", err.Error()))

--- a/pkg/controllers/cluster/kubeconfig_controller_test.go
+++ b/pkg/controllers/cluster/kubeconfig_controller_test.go
@@ -67,7 +67,10 @@ var _ = Describe("ClusterKubeconfig controller", Ordered, func() {
 		secret := setup.CreateSecret(test.Ctx, clusterName,
 			test.WithSecretType(greenhouseapis.SecretTypeKubeConfig),
 			test.WithSecretNamespace(organization.Name),
-			test.WithSecretData(map[string][]byte{greenhouseapis.KubeConfigKey: test.KubeConfig}))
+			test.WithSecretData(map[string][]byte{
+				greenhouseapis.KubeConfigKey:           test.KubeConfig,
+				greenhouseapis.GreenHouseKubeConfigKey: test.KubeConfig,
+			}))
 
 		By("Checking the cluster resource has been created")
 		Eventually(func() error {
@@ -149,7 +152,7 @@ users:
 		secret := corev1.Secret{}
 		Expect(test.K8sClient.Get(test.Ctx, types.NamespacedName{Name: cluster.Name, Namespace: setup.Namespace()}, &secret)).To(Succeed())
 
-		secret.Data[greenhouseapis.KubeConfigKey] = nextKubeconfig
+		secret.Data[greenhouseapis.GreenHouseKubeConfigKey] = nextKubeconfig
 		Expect(test.K8sClient.Update(test.Ctx, &secret)).To(Succeed())
 
 		clusterKubeconfig := v1alpha1.ClusterKubeconfig{}


### PR DESCRIPTION
<!--
Please ensure the PR title follows the conventional commit format:
<type>(<scope>): description

For a list of accepted types and scopes see the workflow documentation: https://github.com/cloudoperators/greenhouse/blob/main/.github/workflows/ci-pr-title.yaml

-->

## Description

The `kubeConfig` key is only used when onboarding Cluster with kubeconfig. When using OIDC this is not present.
Using the `greenhouseKubeConfig` will work for both cases, since this is the kubeconfig that is managed by Greenhouse

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 

- Related Issue # (issue)
- Closes # (issue)
- Fixes # (issue)

-->

## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [ ] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
