### PR TITLE
fix(teams): reconcile teams if scim api access is ready

### DIFF
--- a/internal/clientutil/predicates.go
+++ b/internal/clientutil/predicates.go
@@ -79,21 +79,6 @@ func PredicateHasFinalizer(finalizer string) predicate.Predicate {
 	})
 }
 
-func PredicateHasOICDConfigured() predicate.Predicate {
-	return predicate.NewPredicateFuncs(func(o client.Object) bool {
-		org, ok := o.(*greenhousev1alpha1.Organization)
-		if !ok {
-			return false
-		}
-
-		if org.Spec.Authentication == nil || org.Spec.Authentication.OIDCConfig == nil {
-			return false
-		}
-
-		return true
-	})
-}
-
 // LabelSelectorPredicate constructs a Predicate from a LabelSelector.
 // Only objects matching the LabelSelector will be admitted.
 // Credit https://github.com/kubernetes-sigs/controller-runtime/blob/v0.10.1/pkg/predicate/predicate.go#L323-L333.
@@ -128,6 +113,30 @@ func PredicatePluginWithStatusReadyChange() predicate.Predicate {
 				return true
 			}
 			return oldReadyCondition.Status != newReadyCondition.Status
+		},
+		DeleteFunc:  func(_ event.DeleteEvent) bool { return false },
+		GenericFunc: func(_ event.GenericEvent) bool { return false },
+	}
+}
+
+func PredicateOrganizationSCIMStatusChange() predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(_ event.CreateEvent) bool { return false },
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			if e.ObjectOld == nil || e.ObjectNew == nil {
+				return false
+			}
+			oldOrg, okOld := e.ObjectOld.(*greenhousev1alpha1.Organization)
+			newOrg, okNew := e.ObjectNew.(*greenhousev1alpha1.Organization)
+			if !okOld || !okNew {
+				return false
+			}
+			oldCondition := oldOrg.Status.GetConditionByType(greenhousev1alpha1.SCIMAPIAvailableCondition)
+			newCondition := newOrg.Status.GetConditionByType(greenhousev1alpha1.SCIMAPIAvailableCondition)
+			if newCondition == nil {
+				return false
+			}
+			return (oldCondition == nil || oldCondition.IsFalse()) && newCondition.IsTrue() // check is the SCIMAPIAvailableCondition condition is flip to true
 		},
 		DeleteFunc:  func(_ event.DeleteEvent) bool { return false },
 		GenericFunc: func(_ event.GenericEvent) bool { return false },

--- a/internal/controller/teammembership/teammembership_updater_controller.go
+++ b/internal/controller/teammembership/teammembership_updater_controller.go
@@ -79,7 +79,8 @@ func (r *TeamMembershipUpdaterController) SetupWithManager(name string, mgr ctrl
 		Owns(&greenhousev1alpha1.TeamMembership{}).
 		// If an Organization's .Spec was changed, reconcile relevant Teams.
 		Watches(&greenhousev1alpha1.Organization{}, handler.EnqueueRequestsFromMapFunc(r.enqueueAllTeamsForOrganization),
-			builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+			builder.WithPredicates(
+				predicate.Or(predicate.GenerationChangedPredicate{}, clientutil.PredicateOrganizationSCIMStatusChange()))).
 		Complete(r)
 }
 


### PR DESCRIPTION

<!--
Please ensure the PR title follows the conventional commit format:
<type>(<scope>): description

For a list of accepted types and scopes see the workflow documentation: https://github.com/cloudoperators/greenhouse/blob/main/.github/workflows/ci-pr-title.yaml

-->

## Description

previously the teams were only reconciled if the orgs generation changed.
this commit makes sure that the teams are reconciled if the org's state for scim api access changes to true.


## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 

- Related Issue # (issue)
- Closes # (issue)
- Fixes # (issue)

-->

## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [ ] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
