### PR TITLE
fix(charts): remove organization owner reference on auth secrets

### DIFF
--- a/charts/greenhouse/Chart.yaml
+++ b/charts/greenhouse/Chart.yaml
@@ -5,7 +5,7 @@ apiVersion: v2
 name: greenhouse
 description: A Helm chart for deploying greenhouse
 type: application
-version: 0.10.7
+version: 0.10.8
 appVersion: "0.1.0"
 
 dependencies:

--- a/charts/greenhouse/templates/organization-secrets.yaml
+++ b/charts/greenhouse/templates/organization-secrets.yaml
@@ -9,10 +9,6 @@ kind: Secret
 metadata:
   name: {{ .Chart.Name }}-auth
   namespace: {{ .Chart.Name }}
-  ownerReferences:
-    - apiVersion: greenhouse.sap/v1alpha1
-      kind: Organization
-      name: {{ .Chart.Name }}
 type: greenhouse.sap/orgsecret
 data:
 {{- if .Values.global.oidc.enabled }}


### PR DESCRIPTION
## Description

`OwnerReferences` without `UID` are invalid and should be handled either programmatically or with `helm lookup`

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [x] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
