### PR TITLE
fix(charts): helm lookup to populate ownerRef uid from organization

### DIFF
--- a/charts/greenhouse/Chart.yaml
+++ b/charts/greenhouse/Chart.yaml
@@ -5,7 +5,7 @@ apiVersion: v2
 name: greenhouse
 description: A Helm chart for deploying greenhouse
 type: application
-version: 0.10.7
+version: 0.10.9
 appVersion: "0.1.0"
 
 dependencies:

--- a/charts/greenhouse/templates/organization-secrets.yaml
+++ b/charts/greenhouse/templates/organization-secrets.yaml
@@ -4,7 +4,7 @@ kind: Secret
 metadata:
   name: {{ .Chart.Name }}-auth
   namespace: {{ .Chart.Name }}
-  {{- $org := lookup "greenhouse.sap/v1alpha1" "Organization" .Chart.Name }}
+  {{- $org := lookup "greenhouse.sap/v1alpha1" "Organization" .Release.Namespace .Chart.Name }}
   {{- if $org }}
   ownerReferences:
     - apiVersion: greenhouse.sap/v1alpha1

--- a/charts/greenhouse/templates/organization-secrets.yaml
+++ b/charts/greenhouse/templates/organization-secrets.yaml
@@ -1,18 +1,17 @@
-{{/* 
-SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-SPDX-License-Identifier: Apache-2.0
-*/}}
-
 {{- if or .Values.global.oidc.enabled .Values.scim.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Chart.Name }}-auth
   namespace: {{ .Chart.Name }}
+  {{- $org := lookup "greenhouse.sap/v1alpha1" "Organization" .Chart.Name }}
+  {{- if $org }}
   ownerReferences:
     - apiVersion: greenhouse.sap/v1alpha1
       kind: Organization
       name: {{ .Chart.Name }}
+      uid: {{ $org.metadata.uid }}
+  {{- end }}
 type: greenhouse.sap/orgsecret
 data:
 {{- if .Values.global.oidc.enabled }}


### PR DESCRIPTION
## Description

Uses helm lookup to get Organization UID to add as owner reference to the managed secrets

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [x] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
