### PR TITLE
feat(idproxy): make keepUpstreamGroups configurable

### DIFF
--- a/charts/greenhouse/Chart.lock
+++ b/charts/greenhouse/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: idproxy
   repository: file://../idproxy
-  version: 0.3.0
+  version: 0.3.1
 - name: cors-proxy
   repository: file://../cors-proxy
   version: 0.2.0
@@ -17,5 +17,5 @@ dependencies:
 - name: postgresql-ng
   repository: oci://ghcr.io/sapcc/helm-charts
   version: 1.3.0
-digest: sha256:1f0ae04c3f81eccdb8161454ff18715d0b953f2d4b5214c4cc36e390b667ac63
-generated: "2025-03-27T16:31:44.998141+01:00"
+digest: sha256:b07aa5668c340a38565d16f50b06f322814a57c8383d85306bfb40e50e954244
+generated: "2025-04-24T14:35:29.081453+02:00"

--- a/charts/greenhouse/Chart.yaml
+++ b/charts/greenhouse/Chart.yaml
@@ -5,14 +5,14 @@ apiVersion: v2
 name: greenhouse
 description: A Helm chart for deploying greenhouse
 type: application
-version: 0.10.8
+version: 0.10.9
 appVersion: "0.1.0"
 
 dependencies:
   - condition: idproxy.enabled
     name: idproxy
     repository: "file://../idproxy"
-    version: 0.3.0
+    version: 0.3.1
   - condition: cors-proxy.enabled
     name: cors-proxy
     repository: "file://../cors-proxy"

--- a/charts/idproxy/Chart.yaml
+++ b/charts/idproxy/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.3.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/idproxy/templates/deployment.yaml
+++ b/charts/idproxy/templates/deployment.yaml
@@ -54,6 +54,7 @@ spec:
             {{- range $origin := .Values.corsAllowedOrigins | default (list "*") }}
             - --allowed-origins={{ $origin }}
             {{- end }}
+            - --keep-upstream-groups={{ .Values.keepUpstreamGroups }}
           env:
           {{- if eq .Values.global.dex.backend "postgres" }}
           - name: PG_DATABASE

--- a/charts/idproxy/values.yaml
+++ b/charts/idproxy/values.yaml
@@ -6,6 +6,9 @@
 # Declare variables to be passed into your templates.
 
 replicaCount: 2
+# If set the token returned by the IDProxy will contain the Greenhouse groups
+# and all groups returned by the upstream idp
+keepUpstreamGroups: false
 
 image:
   repository: ghcr.io/cloudoperators/greenhouse

--- a/cmd/idproxy/main.go
+++ b/cmd/idproxy/main.go
@@ -34,10 +34,10 @@ import (
 )
 
 func main() {
-	var issuer string
+	var issuer, listenAddr, metricsAddr string
 	var idTokenValidity time.Duration
-	var listenAddr, metricsAddr string
 	var allowedOrigins []string
+	var keepUpstreamGroups bool
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
 	// set default logger to be used by log
 	slog.SetDefault(logger)
@@ -49,6 +49,7 @@ func main() {
 	flag.StringVar(&metricsAddr, "metrics-addr", ":6543", "bind address for metrics")
 	flag.StringSliceVar(&allowedOrigins, "allowed-origins", []string{"*"}, "list of allowed origins for CORS requests on discovery, token and keys endpoint")
 	flag.DurationVar(&idTokenValidity, "id-token-validity", 1*time.Hour, "Maximum validity of issued id tokens")
+	flag.BoolVar(&keepUpstreamGroups, "keep-upstream-groups", false, "Keep upstream groups in the token")
 	flag.Parse()
 
 	if issuer == "" {
@@ -106,7 +107,7 @@ func main() {
 		oidcConfig := new(dex.OIDCConfig)
 		oidcConfig.AddClient(k8sClient)
 		oidcConfig.AddRedirectURI(issuer + "/callback")
-
+		oidcConfig.KeepUpstreamGroups = keepUpstreamGroups
 		return oidcConfig
 	}
 


### PR DESCRIPTION


## Description

Making the `keepUpstreamGroups` configurable on the idproxy. This can then be used for applications hidden behind the idproxy after #701 is fully implemented to use idproxy for auth instead of upstream idp.

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 

- Related Issue # (issue)
- Closes # (issue)
- Fixes # (issue)

-->

## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [ ] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
