### PR TITLE
fix(core): disable leader election in webhook-only mode

### DIFF
--- a/cmd/greenhouse/main.go
+++ b/cmd/greenhouse/main.go
@@ -119,9 +119,18 @@ func main() {
 		handleError(errors.New("--dns-domain must not be empty"), "unable to start controller")
 	}
 
+	mode, err := calculateManagerMode()
+	if err != nil {
+		handleError(err, "unable to calculate manager mode")
+	}
+
 	// Disable leader election if not run within a cluster.
 	isEnableLeaderElection := true
 	if _, ok := os.LookupEnv(podNamespaceEnv); !ok {
+		isEnableLeaderElection = false
+	}
+	// Disable leader election if run in webhook only mode.
+	if mode == webhookOnlyMode {
 		isEnableLeaderElection = false
 	}
 
@@ -149,11 +158,6 @@ func main() {
 	)
 	if err != nil {
 		handleError(err, "unable to get features")
-	}
-
-	mode, err := calculateManagerMode()
-	if err != nil {
-		handleError(err, "unable to calculate manager mode")
 	}
 
 	// Register controllers.


### PR DESCRIPTION
<!--
Please ensure the PR title follows the conventional commit format:
<type>(<scope>): description

For a list of accepted types and scopes see the workflow documentation: https://github.com/cloudoperators/greenhouse/blob/main/.github/workflows/ci-pr-title.yaml

-->

## Description

In case we are running in webhook only mode the leader election is not required, also it will clash with the leader election of the controller deployment.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 

- Related Issue # (issue)
- Closes # (issue)
- Fixes # (issue)

-->

## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [ ] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
