### PR TITLE
fix(greenhousectl): reference the updated kind configuraton file for extra mounts

### DIFF
--- a/internal/local/commands/setup.go
+++ b/internal/local/commands/setup.go
@@ -90,6 +90,10 @@ func processDevSetup(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
+		// re-write the config file with the hostPath config
+		if hostPathConfig != "" {
+			cfg.Cluster.ConfigPath = hostPathConfig
+		}
 		env := setup.NewExecutionEnv().
 			WithClusterSetup(cfg.Cluster)
 		for _, dep := range cfg.Dependencies {


### PR DESCRIPTION
## Description

- fixes the missing hostPath extra mounts for admin cluster

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

- Closes #1135 

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [x] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
