### PR TITLE
feat(plugin): Add owning team to global option values

### DIFF
--- a/api/well_known.go
+++ b/api/well_known.go
@@ -44,6 +44,9 @@ const (
 
 	// LabelKeyExposeNamedPort is specifying the port to be exposed by name. LabelKeyExposeService needs to be set. Defaults to the first port if the named port is not found.
 	LabelKeyExposeNamedPort = "greenhouse.sap/exposeNamedPort"
+
+	// LabelKeyOwningTeam is used to identify the owning team of a resource.
+	LabelKeyOwningTeam = "greenhouse.sap/owningTeam"
 )
 
 // TeamRole and TeamRoleBinding constants

--- a/docs/contribute/plugins.md
+++ b/docs/contribute/plugins.md
@@ -42,9 +42,17 @@ Here's a high-level overview of how to develop a plugin for Greenhouse:
    - Clearly define the purpose and functionality of your plugin.
    - What problem does it solve, and what features will it provide?
 
-2. **Plugin Configuration (plugin.yml)**:
+2. **Plugin Definition (plugindefinition.yaml)**:
 
-   - Create a `greenhouse.yml` file in the root of your repository to specify the plugin's metadata and configuration options. This YAML file should include details like the plugin's description, version, and any configuration values required.
+   - Create a `plugindefinition.yaml` ([API Reference](https://cloudoperators.github.io/greenhouse/docs/reference/api/#greenhouse.sap/v1alpha1.PluginDefinition)) file in the root of your repository to specify the plugin's metadata and configuration options. This YAML file should include details like the plugin's description, version, and any configuration values required.
+   - Provide a list of `PluginOptions` which are values that are consumed to configure the actual `Plugin` instance of your `PluginDefinition`.
+     Greenhouse always provides some global values that are injected into your `Plugin` upon deployment:
+     - `global.greenhouse.organizationName`: The `name` of your `Organization`
+     - `global.greenhouse.teamNames`: All available `Teams` in your `Organization`
+     - `global.greenhouse.clusterNames`: All available `Clusters` in your `Organization`
+     - `global.greenhouse.clusterName`: The `name` of the `Cluster` this `Plugin` instance is deployed to.
+     - `global.greenhouse.baseDomain`: The base domain of your Greenhouse installation
+     - `global.greenhouse.owningTeam`: The owning `Team` of this `Plugin` instance
 
 3. **Plugin Components**:
 

--- a/internal/helm/helm_test.go
+++ b/internal/helm/helm_test.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	greenhouseapis "github.com/cloudoperators/greenhouse/api"
 	greenhousev1alpha1 "github.com/cloudoperators/greenhouse/api/v1alpha1"
 	"github.com/cloudoperators/greenhouse/internal/common"
 	"github.com/cloudoperators/greenhouse/internal/helm"
@@ -68,15 +69,17 @@ var _ = Describe("helm package test", func() {
 			pluginOptionValues, err := helm.GetPluginOptionValuesForPlugin(test.Ctx, test.K8sClient, plugin)
 			Expect(err).ShouldNot(HaveOccurred(), "there should be no error getting the pluginDefinition option values")
 			Expect(pluginOptionValues).To(
-				ContainElement(greenhousev1alpha1.PluginOptionValue{Name: "key1", Value: test.MustReturnJSONFor("pluginValue1"), ValueFrom: nil}), "the pluginDefinition option values should contain default from pluginDefinition spec")
+				ContainElement(greenhousev1alpha1.PluginOptionValue{Name: "key1", Value: test.MustReturnJSONFor("pluginValue1"), ValueFrom: nil}), "the plugin option values should contain default from pluginDefinition spec")
 			Expect(pluginOptionValues).To(
-				ContainElement(greenhousev1alpha1.PluginOptionValue{Name: "global.greenhouse.teamNames", Value: test.MustReturnJSONFor([]string{"test-team-1"}), ValueFrom: nil}), "the pluginDefinition option values should contain greenhouse values")
+				ContainElement(greenhousev1alpha1.PluginOptionValue{Name: "global.greenhouse.teamNames", Value: test.MustReturnJSONFor([]string{"test-team-1"}), ValueFrom: nil}), "the plugin option values should contain greenhouse values")
 			Expect(pluginOptionValues).To(
-				ContainElement(greenhousev1alpha1.PluginOptionValue{Name: "global.greenhouse.clusterName", Value: test.MustReturnJSONFor(plugin.Spec.ClusterName), ValueFrom: nil}), "the pluginDefinition option values should contain the clusterName from the plugin")
+				ContainElement(greenhousev1alpha1.PluginOptionValue{Name: "global.greenhouse.clusterName", Value: test.MustReturnJSONFor(plugin.Spec.ClusterName), ValueFrom: nil}), "the plugin option values should contain the clusterName from the plugin")
 			Expect(pluginOptionValues).To(
-				ContainElement(greenhousev1alpha1.PluginOptionValue{Name: "global.greenhouse.organizationName", Value: test.MustReturnJSONFor(plugin.GetNamespace()), ValueFrom: nil}), "the pluginDefinition option values should contain the orgName from the plugin namespace")
+				ContainElement(greenhousev1alpha1.PluginOptionValue{Name: "global.greenhouse.organizationName", Value: test.MustReturnJSONFor(plugin.GetNamespace()), ValueFrom: nil}), "the plugin option values should contain the orgName from the plugin namespace")
 			Expect(pluginOptionValues).To(
-				ContainElement(greenhousev1alpha1.PluginOptionValue{Name: "global.greenhouse.baseDomain", Value: test.MustReturnJSONFor(common.DNSDomain), ValueFrom: nil}), "the pluginDefinition option values should contain the baseDomain")
+				ContainElement(greenhousev1alpha1.PluginOptionValue{Name: "global.greenhouse.baseDomain", Value: test.MustReturnJSONFor(common.DNSDomain), ValueFrom: nil}), "the plugin option values should contain the baseDomain")
+			Expect(pluginOptionValues).To(
+				ContainElement(greenhousev1alpha1.PluginOptionValue{Name: "global.greenhouse.owningTeam", Value: test.MustReturnJSONFor(plugin.Labels[string(greenhouseapis.LabelKeyOwningTeam)]), ValueFrom: nil}), "the plugin option values should contain the owning team")
 		})
 	})
 

--- a/internal/helm/suite_test.go
+++ b/internal/helm/suite_test.go
@@ -10,6 +10,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	greenhouseapis "github.com/cloudoperators/greenhouse/api"
 	greenhousev1alpha1 "github.com/cloudoperators/greenhouse/api/v1alpha1"
 	"github.com/cloudoperators/greenhouse/internal/test"
 	admission "github.com/cloudoperators/greenhouse/internal/webhook"
@@ -141,6 +142,10 @@ var (
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "test-org",
 			Name:      "test-plugin",
+			// add owning team label
+			Labels: map[string]string{
+				greenhouseapis.LabelKeyOwningTeam: "test-team-1",
+			},
 		},
 		Spec: greenhousev1alpha1.PluginSpec{
 			PluginDefinition: "test-plugindefinition",

--- a/internal/helm/values.go
+++ b/internal/helm/values.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	greenhouseapis "github.com/cloudoperators/greenhouse/api"
 	greenhousev1alpha1 "github.com/cloudoperators/greenhouse/api/v1alpha1"
 	"github.com/cloudoperators/greenhouse/internal/common"
 )
@@ -140,15 +141,28 @@ func getGreenhouseValues(ctx context.Context, c client.Client, p greenhousev1alp
 			Value:     &apiextensionsv1.JSON{Raw: clusterNameVal},
 			ValueFrom: nil,
 		})
+	}
 
-		// append DNSDomain
-		baseDomainVal, err := json.Marshal(common.DNSDomain)
+	// append DNSDomain
+	baseDomainVal, err := json.Marshal(common.DNSDomain)
+	if err != nil {
+		return nil, err
+	}
+	greenhouseValues = append(greenhouseValues, greenhousev1alpha1.PluginOptionValue{
+		Name:      "global.greenhouse.baseDomain",
+		Value:     &apiextensionsv1.JSON{Raw: baseDomainVal},
+		ValueFrom: nil,
+	})
+
+	//append owning team if set
+	if p.Labels[string(greenhouseapis.LabelKeyOwningTeam)] != "" {
+		owningTeamVal, err := json.Marshal(p.Labels[greenhouseapis.LabelKeyOwningTeam])
 		if err != nil {
 			return nil, err
 		}
 		greenhouseValues = append(greenhouseValues, greenhousev1alpha1.PluginOptionValue{
-			Name:      "global.greenhouse.baseDomain",
-			Value:     &apiextensionsv1.JSON{Raw: baseDomainVal},
+			Name:      "global.greenhouse.owningTeam",
+			Value:     &apiextensionsv1.JSON{Raw: owningTeamVal},
 			ValueFrom: nil,
 		})
 	}


### PR DESCRIPTION
<!--
Please ensure the PR title follows the conventional commit format:
<type>(<scope>): description

For a list of accepted types and scopes see the workflow documentation: https://github.com/cloudoperators/greenhouse/blob/main/.github/workflows/ci-pr-title.yaml

-->

## Description
With this PR we introduce a new well-known label `greenhouse.sap/owningTeam` to identify owning `Teams` of `Plugins`. The `label` value is propagated as `global.greenhouse.owningTeam` to the helm values via the `Plugin` controller.

It also fixes a Bug where the `global.greenhouse.baseDomain` was only set if  `Plugin.Spec.ClusterName` was set.

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [x] 🐛 Bug Fix
- [x] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents
Part of #976 
This provides an interim solution to #979 

## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Added to documentation?

- [ ] 📜 README.md
- [x] 🤝 Documentation pages updated
- [ ] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
