### PR TITLE
fix(teamroles): add fieldindex in webhook setup

### DIFF
--- a/internal/clientutil/error.go
+++ b/internal/clientutil/error.go
@@ -3,11 +3,27 @@
 
 package clientutil
 
-import apierrors "k8s.io/apimachinery/pkg/api/errors"
+import (
+	"strings"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+)
 
 // IgnoreAlreadyExists returns nil on IsAlreadyExists errors.
 func IgnoreAlreadyExists(err error) error {
 	if apierrors.IsAlreadyExists(err) {
+		return nil
+	}
+	return err
+}
+
+// IgnoreIndexerConflict returns nil on indexer conflict errors.
+// This is used to ignore errors when the indexer is already set up.
+func IgnoreIndexerConflict(err error) error {
+	if err == nil {
+		return nil
+	}
+	if strings.HasPrefix(err.Error(), "indexer conflict") {
 		return nil
 	}
 	return err

--- a/internal/controller/teamrbac/teamrolebinding_controller.go
+++ b/internal/controller/teamrbac/teamrolebinding_controller.go
@@ -63,7 +63,7 @@ func (r *TeamRoleBindingReconciler) SetupWithManager(name string, mgr ctrl.Manag
 			return nil
 		}
 		return []string{teamRoleBinding.Spec.TeamRoleRef}
-	}); err != nil {
+	}); clientutil.IgnoreIndexerConflict(err) != nil {
 		return err
 	}
 

--- a/internal/webhook/teamrole_webhook_test.go
+++ b/internal/webhook/teamrole_webhook_test.go
@@ -4,17 +4,12 @@
 package admission
 
 import (
-	"context"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	greenhouseapis "github.com/cloudoperators/greenhouse/api"
 	greenhousev1alpha1 "github.com/cloudoperators/greenhouse/api/v1alpha1"
 	"github.com/cloudoperators/greenhouse/internal/clientutil"
 	"github.com/cloudoperators/greenhouse/internal/test"
@@ -105,19 +100,3 @@ var _ = Describe("Validate Role Admission", func() {
 		Expect(err).To(HaveOccurred(), "there should be an error deleting the role with references")
 	})
 })
-
-// setupRoleBindingWebhookForTest adds an indexField for '.spec.roleRef', additionally to setting up the webhook for the RoleBinding resource. It is used in the webhook tests.
-// we can't add this to the webhook setup because it's already indexed by the controller and indexing the field twice is not possible.
-// This is to have the webhook tests run independently of the controller.
-func setupRoleBindingWebhookForTest(mgr manager.Manager) error {
-	err := mgr.GetFieldIndexer().IndexField(context.Background(), &greenhousev1alpha1.TeamRoleBinding{}, greenhouseapis.RolebindingRoleRefField, func(rawObj client.Object) []string {
-		// Extract the Role name from the RoleBinding Spec, if one is provided
-		roleBinding, ok := rawObj.(*greenhousev1alpha1.TeamRoleBinding)
-		if roleBinding.Spec.TeamRoleRef == "" || !ok {
-			return nil
-		}
-		return []string{roleBinding.Spec.TeamRoleRef}
-	})
-	Expect(err).ToNot(HaveOccurred(), "there should be no error indexing the rolebindings by roleRef")
-	return SetupTeamRoleBindingWebhookWithManager(mgr)
-}

--- a/internal/webhook/webhook_suite_test.go
+++ b/internal/webhook/webhook_suite_test.go
@@ -25,7 +25,7 @@ var _ = BeforeSuite(func() {
 	test.RegisterWebhook("secretsWebhook", SetupSecretWebhookWithManager)
 	test.RegisterWebhook("teamsWebhook", SetupTeamWebhookWithManager)
 	test.RegisterWebhook("roleWebhook", SetupTeamRoleWebhookWithManager)
-	test.RegisterWebhook("rolebindingWebhook", setupRoleBindingWebhookForTest)
+	test.RegisterWebhook("rolebindingWebhook", SetupTeamRoleBindingWebhookWithManager)
 	test.TestBeforeSuite()
 })
 


### PR DESCRIPTION


<!--
Please ensure the PR title follows the conventional commit format:
<type>(<scope>): description

For a list of accepted types and scopes see the workflow documentation: https://github.com/cloudoperators/greenhouse/blob/main/.github/workflows/ci-pr-title.yaml

-->

## Description

After the Split of Controller and Webhook deployment the deletion of TeamRoles was failing due to a missing FieldIndex

This add the missing field indexing to the teamrole webhook setup. To avoid conflicts with already existing indices the IgnoreIndexerConflict(..) was added. The code does not expose a typed error, so in this case the check relies on the error's prefix

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 

- Related Issue # (issue)
- Closes # (issue)
- Fixes # (issue)

-->

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [ ] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
