### PR TITLE
fix(plugins): fix naming of opentelemetry-operator for logs plugin

### DIFF
--- a/charts/greenhouse/Chart.yaml
+++ b/charts/greenhouse/Chart.yaml
@@ -5,7 +5,7 @@ apiVersion: v2
 name: greenhouse
 description: A Helm chart for deploying greenhouse
 type: application
-version: 0.10.25
+version: 0.10.26
 appVersion: "0.3.0"
 
 dependencies:

--- a/charts/greenhouse/templates/plugin-logs.yaml
+++ b/charts/greenhouse/templates/plugin-logs.yaml
@@ -74,11 +74,11 @@ spec:
     - name: openTelemetry.manager.prometheusRule.enabled
       value: {{ .Values.openTelemetry.manager.prometheusRule.enabled }}
   {{- if .Values.global.ghcrIoMirror }}
-    - name: logs-operator.manager.image.repository
+    - name: opentelemetry-operator.manager.image.repository
       value: {{ .Values.global.ghcrIoMirror }}/open-telemetry/opentelemetry-operator/opentelemetry-operator
-    - name: logs-operator.manager.collectorImage.repository
+    - name: opentelemetry-operator.manager.collectorImage.repository
       value: {{ .Values.global.ghcrIoMirror }}/cloudoperators/opentelemetry-collector-contrib
-    - name: logs-operator.testFramework.image.repository
+    - name: opentelemetry-operator.testFramework.image.repository
       value: {{ .Values.global.dockerHubMirror }}/library/busybox
     - name: testFramework.image.registry
       value: {{ .Values.global.ghcrIoMirror }}


### PR DESCRIPTION
## Description
This PR fixes the recent name change from `logs-operator` to `opentelemetry-operator` that was introduced to the [Logs Plugin](https://github.com/cloudoperators/greenhouse-extensions/tree/main/logs) here: https://github.com/cloudoperators/greenhouse-extensions/pull/992, so the link to the upstream chart becomes more clear. 

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [x] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

- Related Issue https://github.com/cloudoperators/greenhouse-extensions/pull/992 (issue)

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [x] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
