### PR TITLE
fix(plugindefinitions): skip helm repository creation for UI PluginDefinitions

### DIFF
--- a/internal/controller/flux/plugin_controller.go
+++ b/internal/controller/flux/plugin_controller.go
@@ -139,7 +139,6 @@ func (r *FluxReconciler) EnsureCreated(ctx context.Context, resource lifecycle.R
 	if !ok {
 		return ctrl.Result{}, lifecycle.Failed, errors.New("resource is not a Plugin")
 	}
-	namespace := flux.HelmRepositoryDefaultNamespace
 
 	pluginController.InitPluginStatus(plugin)
 
@@ -148,6 +147,7 @@ func (r *FluxReconciler) EnsureCreated(ctx context.Context, resource lifecycle.R
 		return ctrl.Result{}, lifecycle.Failed, errors.New("plugin definition not found")
 	}
 
+	namespace := flux.HelmRepositoryDefaultNamespace
 	if pluginDef.Namespace != "" {
 		namespace = pluginDef.Namespace
 	}

--- a/internal/controller/plugindefinition/plugindefinition_controller_test.go
+++ b/internal/controller/plugindefinition/plugindefinition_controller_test.go
@@ -68,7 +68,8 @@ func mockPluginDefinition() *greenhousev1alpha1.PluginDefinition {
 }
 
 func mockUIPluginDefinition() *greenhousev1alpha1.PluginDefinition {
-	return test.NewPluginDefinition(test.Ctx, UIPluginDefinitionName, test.AppendPluginOption(
+	GinkgoHelper()
+	pluginDefinition := test.NewPluginDefinition(test.Ctx, UIPluginDefinitionName, test.AppendPluginOption(
 		greenhousev1alpha1.PluginOption{
 			Name:    "test-plugin-definition-option-1",
 			Type:    "int",
@@ -79,6 +80,8 @@ func mockUIPluginDefinition() *greenhousev1alpha1.PluginDefinition {
 			Version: "0.0.1",
 		}),
 	)
+	pluginDefinition.Spec.HelmChart = nil
+	return pluginDefinition
 }
 
 func listEvents(involvedObjectName string) *corev1.EventList {
@@ -89,7 +92,7 @@ func listEvents(involvedObjectName string) *corev1.EventList {
 	return events
 }
 
-var _ = Describe("PluginDefinition controller", func() {
+var _ = FDescribe("PluginDefinition controller", func() {
 	var (
 		remoteEnvTest *envtest.Environment
 	)

--- a/internal/controller/plugindefinition/plugindefinition_controller_test.go
+++ b/internal/controller/plugindefinition/plugindefinition_controller_test.go
@@ -92,7 +92,7 @@ func listEvents(involvedObjectName string) *corev1.EventList {
 	return events
 }
 
-var _ = FDescribe("PluginDefinition controller", func() {
+var _ = Describe("PluginDefinition controller", func() {
 	var (
 		remoteEnvTest *envtest.Environment
 	)


### PR DESCRIPTION
## Description

- Skip flux `HelmRepository` creation for UI `PluginDefinition` (Since there is no helm chart)
- Skip processing `Plugin` that reference UI `PluginDefinition` in plugin_to_flux controller

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [x] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
