### PR TITLE
fix(plugins): ensure flux deployment label

### DIFF
--- a/api/well_known.go
+++ b/api/well_known.go
@@ -86,8 +86,8 @@ const (
 	ClusterConnectivityAnnotation     = "greenhouse.sap/cluster-connectivity"
 	ClusterConnectivityKubeconfig     = "kubeconfig"
 	ClusterConnectivityOIDC           = "oidc"
-	GreenhouseHelmDeliveryToolLabel   = "greenhouse.sap/deployment-tool"
-	GreenhouseHelmDeliveryToolFlux    = "flux"
+	HelmDeliveryToolLabel             = "greenhouse.sap/deployment-tool"
+	HelmDeliveryToolFlux              = "flux"
 )
 
 const (

--- a/internal/controller/flux/plugin_controller.go
+++ b/internal/controller/flux/plugin_controller.go
@@ -74,13 +74,13 @@ func (r *FluxReconciler) SetupWithManager(name string, mgr ctrl.Manager) error {
 	labelSelector := metav1.LabelSelector{
 		MatchExpressions: []metav1.LabelSelectorRequirement{
 			{
-				Key:      greenhouseapis.GreenhouseHelmDeliveryToolLabel,
+				Key:      greenhouseapis.HelmDeliveryToolLabel,
 				Operator: metav1.LabelSelectorOpExists,
 			},
 			{
-				Key:      greenhouseapis.GreenhouseHelmDeliveryToolLabel,
+				Key:      greenhouseapis.HelmDeliveryToolLabel,
 				Operator: metav1.LabelSelectorOpIn,
-				Values:   []string{greenhouseapis.GreenhouseHelmDeliveryToolFlux},
+				Values:   []string{greenhouseapis.HelmDeliveryToolFlux},
 			},
 		},
 	}


### PR DESCRIPTION
<!--
Please ensure the PR title follows the conventional commit format:
<type>(<scope>): description

For a list of accepted types and scopes see the workflow documentation: https://github.com/cloudoperators/greenhouse/blob/main/.github/workflows/ci-pr-title.yaml

-->

## Descriptio

Once the deployment tool was changed to flux it should not be changed Flux HelmReleases are not automatically cleared if the label changes To ensure not both HelmController & Flux reconcile the same helm release this defaulting ensures the label cannot be removed


## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 

- Related Issue # (issue)
- Closes # (issue)
- Fixes # (issue)

-->

## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [ ] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
