### PR TITLE
feat(clusters): add additional status conditions

### DIFF
--- a/api/v1alpha1/cluster_types.go
+++ b/api/v1alpha1/cluster_types.go
@@ -41,8 +41,8 @@ const (
 	// KubeConfigValid reflects the validity of the kubeconfig of a cluster.
 	KubeConfigValid greenhousemetav1alpha1.ConditionType = "KubeConfigValid"
 
-	// Accessible reflects the accessability of a cluster.
-	Accessible greenhousemetav1alpha1.ConditionType = "Accessible"
+	// PermissionsVerified reflects the validity of required permissions.
+	PermissionsVerified greenhousemetav1alpha1.ConditionType = "PermissionsVerified"
 
 	// ManagedResourcesDeployed reflects whether the resources were created on the cluster.
 	ManagedResourcesDeployed greenhousemetav1alpha1.ConditionType = "ManagedResourcesDeployed"

--- a/api/v1alpha1/cluster_types.go
+++ b/api/v1alpha1/cluster_types.go
@@ -41,6 +41,12 @@ const (
 	// KubeConfigValid reflects the validity of the kubeconfig of a cluster.
 	KubeConfigValid greenhousemetav1alpha1.ConditionType = "KubeConfigValid"
 
+	// Accessible reflects the accessability of a cluster.
+	Accessible greenhousemetav1alpha1.ConditionType = "Accessible"
+
+	// ManagedResourcesDeployed reflects whether the resources were created on the cluster.
+	ManagedResourcesDeployed greenhousemetav1alpha1.ConditionType = "ManagedResourcesDeployed"
+
 	// MaxTokenValidity contains maximum bearer token validity duration. It is also default value.
 	MaxTokenValidity = 72
 

--- a/docs/user-guides/cluster/oidc_connectivity.md
+++ b/docs/user-guides/cluster/oidc_connectivity.md
@@ -185,7 +185,7 @@ $ kubectl apply -f <oidc-secret-file>.yaml
 ### Troubleshooting
 
 If the bootstrapping failed, you can find details about why it failed in the `Cluster.status.statusConditions`. 
-More precisely, there will be conditions of `type=KubeConfigValid`, `type=Accessible`, `type=ManagedResourcesDeployed`, and `type=Ready`, each of which may provide helpful context in the message field. 
+More precisely, there will be conditions of `type=KubeConfigValid`, `type=PermissionsVerified`, `type=ManagedResourcesDeployed`, and `type=Ready`, each of which may provide helpful context in the message field. 
 These conditions are also displayed in the UI on the Cluster details view.
 
 If there is any error message regarding RBAC then check the `ClusterRoleBinding` and ensure the subject name is correct

--- a/docs/user-guides/cluster/oidc_connectivity.md
+++ b/docs/user-guides/cluster/oidc_connectivity.md
@@ -184,9 +184,9 @@ $ kubectl apply -f <oidc-secret-file>.yaml
 
 ### Troubleshooting
 
-If the bootstrapping failed, you can find details about why it failed in the `Cluster.status.statusConditions`. More precisely
-there will be a condition of `type=KubeConfigValid` and `type=Ready` which contain more information in the `message` field.
-This is also displayed in the UI on the `Cluster` details view.
+If the bootstrapping failed, you can find details about why it failed in the `Cluster.status.statusConditions`. 
+More precisely, there will be conditions of `type=KubeConfigValid`, `type=Accessible`, `type=ManagedResourcesDeployed`, and `type=Ready`, each of which may provide helpful context in the message field. 
+These conditions are also displayed in the UI on the Cluster details view.
 
 If there is any error message regarding RBAC then check the `ClusterRoleBinding` and ensure the subject name is correct
 

--- a/docs/user-guides/cluster/onboarding.md
+++ b/docs/user-guides/cluster/onboarding.md
@@ -112,5 +112,5 @@ The namespace has the same name as your organization in Greenhouse.
 
 ## Troubleshooting
 
-If bootstrapping fails, you can inspect the `Cluster.statusConditions` for more details. The `type=KubeConfigValid` condition may contain hints in the `message` field. Additional insights can be found in the `type=Accessible` and `type=ManagedResourcesDeployed` conditions, which indicate whether the cluster is reachable and whether required resources were successfully deployed. These conditions are also visible in the UI on the `Cluster` details view.
+If bootstrapping fails, you can inspect the `Cluster.statusConditions` for more details. The `type=KubeConfigValid` condition may contain hints in the `message` field. Additional insights can be found in the `type=PermissionsVerified` and `type=ManagedResourcesDeployed` conditions, which indicate whether `ServiceAccount` has valid permissions and whether required resources were successfully deployed. These conditions are also visible in the UI on the `Cluster` details view.
 Reruning the onboarding command with an updated `kubeConfig` file will fix these issues.

--- a/docs/user-guides/cluster/onboarding.md
+++ b/docs/user-guides/cluster/onboarding.md
@@ -112,5 +112,5 @@ The namespace has the same name as your organization in Greenhouse.
 
 ## Troubleshooting
 
-If the bootstrapping failed, you can find details about why it failed in the `Cluster.statusConditions`. More precisely there will be a condition of `type=KubeConfigValid` which might have hints in the `message` field. This is also displayed in the UI on the `Cluster` details view.
+If bootstrapping fails, you can inspect the `Cluster.statusConditions` for more details. The `type=KubeConfigValid` condition may contain hints in the `message` field. Additional insights can be found in the `type=Accessible` and `type=ManagedResourcesDeployed` conditions, which indicate whether the cluster is reachable and whether required resources were successfully deployed. These conditions are also visible in the UI on the `Cluster` details view.
 Reruning the onboarding command with an updated `kubeConfig` file will fix these issues.

--- a/internal/common/permissions.go
+++ b/internal/common/permissions.go
@@ -1,0 +1,91 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package common
+
+import (
+	"context"
+	"fmt"
+
+	authorizationv1 "k8s.io/api/authorization/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Permission defines a Kubernetes action on a resource.
+type Permission struct {
+	Name     string
+	Verb     string
+	APIGroup string
+	Resource string
+}
+
+func (p Permission) String() string {
+	return fmt.Sprintf("%s %s/%s", p.Verb, p.APIGroup, p.Resource)
+}
+
+var (
+	// greenhousePermissions lists perms for the greenhouse cluster.
+	greenhousePermissions = []Permission{
+		{Name: "createCluster", Verb: "create", APIGroup: "greenhouse.sap", Resource: "clusters"},
+		{Name: "deleteCluster", Verb: "delete", APIGroup: "greenhouse.sap", Resource: "clusters"},
+		{Name: "updateCluster", Verb: "update", APIGroup: "greenhouse.sap", Resource: "clusters"},
+		{Name: "patchCluster", Verb: "patch", APIGroup: "greenhouse.sap", Resource: "clusters"},
+		{Name: "createSecret", Verb: "create", APIGroup: "", Resource: "secrets"},
+		{Name: "updateSecret", Verb: "update", APIGroup: "", Resource: "secrets"},
+		{Name: "patchSecret", Verb: "patch", APIGroup: "", Resource: "secrets"},
+	}
+	// clientClusterPermissions lists perms for the customer cluster.
+	clientClusterPermissions = []Permission{
+		{Name: "clusterAdmin", Verb: "*", APIGroup: "*", Resource: "*"},
+	}
+)
+
+// CheckGreenhousePermission returns names of missing greenhouse permissions for the user.
+func CheckGreenhousePermission(ctx context.Context, kubeClient client.Client, user, nameSpace string) (missingPermission []Permission) {
+	return checkPermissionMap(ctx, kubeClient, greenhousePermissions, user, nameSpace)
+}
+
+// CheckClientClusterPermission returns names of missing client-cluster permissions.
+func CheckClientClusterPermission(ctx context.Context, kubeClient client.Client, user, nameSpace string) (missingPermission []Permission) {
+	return checkPermissionMap(ctx, kubeClient, clientClusterPermissions, user, nameSpace)
+}
+
+func checkPermissionMap(ctx context.Context, kubeClient client.Client, permissionMap []Permission, user, nameSpace string) (missingPermission []Permission) {
+	for _, permission := range permissionMap {
+		if !canI(ctx, kubeClient, nameSpace, user, permission) {
+			missingPermission = append(missingPermission, permission)
+		}
+	}
+	return missingPermission
+}
+
+func canI(ctx context.Context, kubeClient client.Client, user, namespace string, permission Permission) bool {
+	if user == "" {
+		accessReview := &authorizationv1.SelfSubjectAccessReview{
+			Spec: authorizationv1.SelfSubjectAccessReviewSpec{
+				ResourceAttributes: &authorizationv1.ResourceAttributes{
+					Namespace: namespace,
+					Verb:      permission.Verb,
+					Group:     permission.APIGroup,
+					Resource:  permission.Resource,
+				},
+			},
+		}
+
+		return kubeClient.Create(ctx, accessReview) == nil && accessReview.Status.Allowed
+	}
+
+	accessReview := &authorizationv1.SubjectAccessReview{
+		Spec: authorizationv1.SubjectAccessReviewSpec{
+			ResourceAttributes: &authorizationv1.ResourceAttributes{
+				Namespace: namespace,
+				Verb:      permission.Verb,
+				Group:     permission.APIGroup,
+				Resource:  permission.Resource,
+			},
+			User: user,
+		},
+	}
+
+	return kubeClient.Create(ctx, accessReview) == nil && accessReview.Status.Allowed
+}

--- a/internal/common/permissions.go
+++ b/internal/common/permissions.go
@@ -41,18 +41,18 @@ var (
 )
 
 // CheckGreenhousePermission returns names of missing greenhouse permissions for the user.
-func CheckGreenhousePermission(ctx context.Context, kubeClient client.Client, user, nameSpace string) (missingPermission []Permission) {
-	return checkPermissionMap(ctx, kubeClient, greenhousePermissions, user, nameSpace)
+func CheckGreenhousePermission(ctx context.Context, kubeClient client.Client, user, namespace string) (missingPermission []Permission) {
+	return checkPermissionMap(ctx, kubeClient, greenhousePermissions, user, namespace)
 }
 
 // CheckClientClusterPermission returns names of missing client-cluster permissions.
-func CheckClientClusterPermission(ctx context.Context, kubeClient client.Client, user, nameSpace string) (missingPermission []Permission) {
-	return checkPermissionMap(ctx, kubeClient, clientClusterPermissions, user, nameSpace)
+func CheckClientClusterPermission(ctx context.Context, kubeClient client.Client, user, namespace string) (missingPermission []Permission) {
+	return checkPermissionMap(ctx, kubeClient, clientClusterPermissions, user, namespace)
 }
 
-func checkPermissionMap(ctx context.Context, kubeClient client.Client, permissionMap []Permission, user, nameSpace string) (missingPermission []Permission) {
+func checkPermissionMap(ctx context.Context, kubeClient client.Client, permissionMap []Permission, user, namespace string) (missingPermission []Permission) {
 	for _, permission := range permissionMap {
-		if !canI(ctx, kubeClient, nameSpace, user, permission) {
+		if !canI(ctx, kubeClient, namespace, user, permission) {
 			missingPermission = append(missingPermission, permission)
 		}
 	}

--- a/internal/controller/cluster/cluster_status.go
+++ b/internal/controller/cluster/cluster_status.go
@@ -11,14 +11,20 @@ import (
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	greenhouseapis "github.com/cloudoperators/greenhouse/api"
 	greenhousemetav1alpha1 "github.com/cloudoperators/greenhouse/api/meta/v1alpha1"
 	greenhousev1alpha1 "github.com/cloudoperators/greenhouse/api/v1alpha1"
 	"github.com/cloudoperators/greenhouse/internal/clientutil"
+	"github.com/cloudoperators/greenhouse/internal/common"
+	"github.com/cloudoperators/greenhouse/internal/controller/cluster/utils"
 	"github.com/cloudoperators/greenhouse/internal/lifecycle"
 	"github.com/cloudoperators/greenhouse/internal/util"
 )
@@ -33,9 +39,10 @@ func (r *RemoteClusterReconciler) setConditions() lifecycle.Conditioner {
 			logger.Error(errors.New("resource is not a cluster"), "status setup failed")
 			return
 		}
-		var conditions []greenhousemetav1alpha1.Condition
 
-		kubeConfigValidCondition, restClientGetter, k8sVersion := r.reconcileClusterSecret(ctx, cluster)
+		kubeConfigValidCondition, restClientGetter, k8sVersion, clusterSecret := r.reconcileClusterSecret(ctx, cluster)
+		clusterAccessibleCondition := r.reconcileAccessibility(ctx, restClientGetter)
+		resourcesDeployedCondition := r.reconcileBootstrapResources(ctx, cluster, restClientGetter, clusterSecret)
 
 		allNodesReadyCondition := greenhousemetav1alpha1.UnknownCondition(greenhousev1alpha1.AllNodesReady, "", "")
 		clusterNodeStatus := make(map[string]greenhousev1alpha1.NodeStatus)
@@ -46,12 +53,18 @@ func (r *RemoteClusterReconciler) setConditions() lifecycle.Conditioner {
 			allNodesReadyCondition, clusterNodeStatus = r.reconcileNodeStatus(ctx, restClientGetter)
 		}
 
-		readyCondition := r.reconcileReadyStatus(kubeConfigValidCondition)
+		readyCondition := r.reconcileReadyStatus(kubeConfigValidCondition, clusterAccessibleCondition, resourcesDeployedCondition)
 
 		ownerLabelCondition := util.ComputeOwnerLabelCondition(ctx, r.Client, cluster)
 
-		conditions = append(conditions, readyCondition, allNodesReadyCondition, kubeConfigValidCondition, ownerLabelCondition)
-
+		conditions := []greenhousemetav1alpha1.Condition{
+			readyCondition,
+			allNodesReadyCondition,
+			kubeConfigValidCondition,
+			ownerLabelCondition,
+			clusterAccessibleCondition,
+			resourcesDeployedCondition,
+		}
 		deletionCondition := r.checkDeletionSchedule(logger, cluster)
 		if !deletionCondition.IsUnknown() {
 			conditions = append(conditions, deletionCondition)
@@ -79,6 +92,72 @@ func (r *RemoteClusterReconciler) checkDeletionSchedule(logger logr.Logger, clus
 	return deletionCondition
 }
 
+func (r *RemoteClusterReconciler) reconcileBootstrapResources(ctx context.Context, cluster *greenhousev1alpha1.Cluster, clientGetter genericclioptions.RESTClientGetter, secret *corev1.Secret) greenhousemetav1alpha1.Condition {
+	if clientGetter == nil || secret == nil {
+		return greenhousemetav1alpha1.UnknownCondition(greenhousev1alpha1.ManagedResourcesDeployed, "", "managed resources could not be validated")
+	}
+
+	remoteClient, err := clientutil.NewK8sClientFromRestClientGetter(clientGetter)
+	if err != nil {
+		return greenhousemetav1alpha1.FalseCondition(greenhousev1alpha1.ManagedResourcesDeployed, "", err.Error())
+	}
+
+	if err := remoteClient.Get(ctx, client.ObjectKey{Name: cluster.GetNamespace()}, &corev1.Namespace{}); err != nil {
+		condition := greenhousemetav1alpha1.FalseCondition(greenhousev1alpha1.ManagedResourcesDeployed, "", "")
+		if apierrors.IsNotFound(err) {
+			condition.Message = "Namespace not found in remote cluster"
+		} else {
+			condition.Message = err.Error()
+		}
+
+		return condition
+	}
+
+	if secret.Type != greenhouseapis.SecretTypeOIDCConfig {
+		if err := remoteClient.Get(ctx, client.ObjectKey{Namespace: cluster.Namespace, Name: utils.ServiceAccountName}, &corev1.ServiceAccount{}); err != nil {
+			condition := greenhousemetav1alpha1.FalseCondition(greenhousev1alpha1.ManagedResourcesDeployed, "", "")
+			if apierrors.IsNotFound(err) {
+				condition.Message = "ServiceAccount not found in remote cluster"
+			} else {
+				condition.Message = err.Error()
+			}
+
+			return condition
+		}
+
+		if err := remoteClient.Get(ctx, client.ObjectKey{Name: utils.ServiceAccountName}, &rbacv1.ClusterRoleBinding{}); err != nil {
+			condition := greenhousemetav1alpha1.FalseCondition(greenhousev1alpha1.ManagedResourcesDeployed, "", "")
+			if apierrors.IsNotFound(err) {
+				condition.Message = "ClusterRoleBinding not found in remote cluster"
+			} else {
+				condition.Message = err.Error()
+			}
+
+			return condition
+		}
+	}
+
+	return greenhousemetav1alpha1.TrueCondition(greenhousev1alpha1.ManagedResourcesDeployed, "", "")
+}
+
+func (r *RemoteClusterReconciler) reconcileAccessibility(ctx context.Context, clientGetter genericclioptions.RESTClientGetter) greenhousemetav1alpha1.Condition {
+	if clientGetter == nil {
+		return greenhousemetav1alpha1.UnknownCondition(greenhousev1alpha1.Accessible, "", "accessibility could not be validated")
+	}
+
+	remoteClient, err := clientutil.NewK8sClientFromRestClientGetter(clientGetter)
+	if err != nil {
+		return greenhousemetav1alpha1.FalseCondition(greenhousev1alpha1.Accessible, "", err.Error())
+	}
+
+	missing := common.CheckClientClusterPermission(ctx, remoteClient, "", corev1.NamespaceAll)
+	if len(missing) > 0 {
+		return greenhousemetav1alpha1.FalseCondition(greenhousev1alpha1.Accessible, "", "missing cluster admin permission")
+	}
+
+	return greenhousemetav1alpha1.TrueCondition(greenhousev1alpha1.Accessible, "", "")
+}
+
 func (r *RemoteClusterReconciler) reconcileClusterSecret(
 	ctx context.Context,
 	cluster *greenhousev1alpha1.Cluster,
@@ -86,14 +165,15 @@ func (r *RemoteClusterReconciler) reconcileClusterSecret(
 	kubeConfigValidCondition greenhousemetav1alpha1.Condition,
 	restClientGetter genericclioptions.RESTClientGetter,
 	k8sVersion string,
+	clusterSecret *corev1.Secret,
 ) {
 
+	clusterSecret = new(corev1.Secret)
 	kubeConfigValidCondition = greenhousemetav1alpha1.UnknownCondition(greenhousev1alpha1.KubeConfigValid, "", "")
-	var clusterSecret = new(corev1.Secret)
 	if err := r.Get(ctx, types.NamespacedName{Name: cluster.GetSecretName(), Namespace: cluster.GetNamespace()}, clusterSecret); err != nil {
 		kubeConfigValidCondition.Status = metav1.ConditionFalse
 		kubeConfigValidCondition.Message = err.Error()
-		return
+		return kubeConfigValidCondition, restClientGetter, k8sVersion, nil
 	}
 
 	restClientGetter, err := clientutil.NewRestClientGetterFromSecret(clusterSecret, clusterSecret.Namespace, clientutil.WithPersistentConfig())
@@ -103,15 +183,16 @@ func (r *RemoteClusterReconciler) reconcileClusterSecret(
 		return
 	}
 
-	if kubernetesVersion, err := clientutil.GetKubernetesVersion(restClientGetter); err == nil {
-		k8sVersion = kubernetesVersion.String()
-		kubeConfigValidCondition.Status = metav1.ConditionTrue
-	} else {
+	kubernetesVersion, err := clientutil.GetKubernetesVersion(restClientGetter)
+	if err != nil {
 		k8sVersion = clusterK8sVersionUnknown
 		kubeConfigValidCondition.Status = metav1.ConditionFalse
 		kubeConfigValidCondition.Message = err.Error()
+		return
 	}
 
+	k8sVersion = kubernetesVersion.String()
+	kubeConfigValidCondition.Status = metav1.ConditionTrue
 	return
 }
 
@@ -120,7 +201,7 @@ func (r *RemoteClusterReconciler) reconcileReadyStatus(conditions ...greenhousem
 	for _, condition := range conditions {
 		if condition.IsFalse() {
 			readyCondition.Status = metav1.ConditionFalse
-			readyCondition.Message = "kubeconfig not valid - cannot access cluster"
+			readyCondition.Message = "cannot access cluster"
 			if condition.Message != "" {
 				readyCondition.Message = condition.Message
 			}

--- a/internal/controller/cluster/status_test.go
+++ b/internal/controller/cluster/status_test.go
@@ -141,10 +141,10 @@ var _ = Describe("Cluster status", Ordered, func() {
 		Eventually(func(g Gomega) {
 			g.Expect(test.K8sClient.Get(test.Ctx, types.NamespacedName{Name: validCluster.Name, Namespace: setup.Namespace()}, &validCluster)).ShouldNot(HaveOccurred(), "There should be no error getting the cluster resource")
 			// Accessible condition validation.
-			accessibleCondition := validCluster.Status.GetConditionByType(greenhousev1alpha1.Accessible)
+			accessibleCondition := validCluster.Status.GetConditionByType(greenhousev1alpha1.PermissionsVerified)
 			g.Expect(accessibleCondition).ToNot(BeNil(), "The Accessible condition should be present")
 			g.Expect(accessibleCondition.Status).To(Equal(metav1.ConditionTrue), "The Accessible condition should be true")
-			g.Expect(accessibleCondition.Message).To(BeEmpty())
+			g.Expect(accessibleCondition.Message).To(Equal("ServiceAccount has cluster admin permissions"))
 			// ManagedResourcesDeployed condition validation.
 			managedResourcesDeployes := validCluster.Status.GetConditionByType(greenhousev1alpha1.ManagedResourcesDeployed)
 			g.Expect(managedResourcesDeployes).ToNot(BeNil(), "The ManagedResourcesDeployed condition should be present")
@@ -201,10 +201,10 @@ var _ = Describe("Cluster status", Ordered, func() {
 		Eventually(func(g Gomega) {
 			g.Expect(test.K8sClient.Get(test.Ctx, types.NamespacedName{Name: validCluster.Name, Namespace: setup.Namespace()}, &validCluster)).ShouldNot(HaveOccurred(), "There should be no error getting the cluster resource")
 			// Accessible condition validation.
-			accessibleCondition := validCluster.Status.GetConditionByType(greenhousev1alpha1.Accessible)
+			accessibleCondition := validCluster.Status.GetConditionByType(greenhousev1alpha1.PermissionsVerified)
 			g.Expect(accessibleCondition).ToNot(BeNil(), "The Accessible condition should be present")
 			g.Expect(accessibleCondition.Status).To(Equal(metav1.ConditionTrue), "The Accessible condition should be true")
-			g.Expect(accessibleCondition.Message).To(BeEmpty())
+			g.Expect(accessibleCondition.Message).To(Equal("ServiceAccount has cluster admin permissions"))
 			// ManagedResourcesDeployed condition validation.
 			managedResourcesDeployes := validCluster.Status.GetConditionByType(greenhousev1alpha1.ManagedResourcesDeployed)
 			g.Expect(managedResourcesDeployes).ToNot(BeNil(), "The ManagedResourcesDeployed condition should be present")
@@ -237,15 +237,15 @@ var _ = Describe("Cluster status", Ordered, func() {
 			g.Expect(test.K8sClient.Get(test.Ctx, types.NamespacedName{Name: invalidCluster.Name, Namespace: setup.Namespace()}, invalidCluster)).ShouldNot(HaveOccurred(), "There should be no error getting the cluster resource")
 			g.Expect(invalidCluster.Status.StatusConditions).ToNot(BeNil())
 			// Accessible condition validation.
-			accessibleCondition := invalidCluster.Status.GetConditionByType(greenhousev1alpha1.Accessible)
+			accessibleCondition := invalidCluster.Status.GetConditionByType(greenhousev1alpha1.PermissionsVerified)
 			g.Expect(accessibleCondition).ToNot(BeNil(), "The Accessible condition should be present")
 			g.Expect(accessibleCondition.Status).To(Equal(metav1.ConditionUnknown), "The Accessible condition should be unknown")
-			g.Expect(accessibleCondition.Message).To(Equal("accessibility could not be validated"))
+			g.Expect(accessibleCondition.Message).To(Equal("kubeconfig not valid - cannot validate cluster access"))
 			// ManagedResourcesDeployed condition validation.
 			managedResourcesDeployes := invalidCluster.Status.GetConditionByType(greenhousev1alpha1.ManagedResourcesDeployed)
 			g.Expect(managedResourcesDeployes).ToNot(BeNil(), "The ManagedResourcesDeployed condition should be present")
 			g.Expect(managedResourcesDeployes.Status).To(Equal(metav1.ConditionUnknown), "The ManagedResourcesDeployed condition should be unknown")
-			g.Expect(managedResourcesDeployes.Message).To(Equal("managed resources could not be validated"))
+			g.Expect(managedResourcesDeployes.Message).To(Equal("kubeconfig not valid - cannot validate managed resources"))
 			// KubeConfigValid condition validation.
 			kubeConfigValidCondition := invalidCluster.Status.GetConditionByType(greenhousev1alpha1.KubeConfigValid)
 			g.Expect(kubeConfigValidCondition).ToNot(BeNil(), "The KubeConfigValid condition should be present")

--- a/internal/controller/cluster/status_test.go
+++ b/internal/controller/cluster/status_test.go
@@ -138,16 +138,26 @@ var _ = Describe("Cluster status", Ordered, func() {
 
 	It("should reconcile the status of a cluster", func() {
 		By("checking cluster node status")
-		Eventually(func(g Gomega) bool {
+		Eventually(func(g Gomega) {
 			g.Expect(test.K8sClient.Get(test.Ctx, types.NamespacedName{Name: validCluster.Name, Namespace: setup.Namespace()}, &validCluster)).ShouldNot(HaveOccurred(), "There should be no error getting the cluster resource")
+			// Accessible condition validation.
+			accessibleCondition := validCluster.Status.GetConditionByType(greenhousev1alpha1.Accessible)
+			g.Expect(accessibleCondition).ToNot(BeNil(), "The Accessible condition should be present")
+			g.Expect(accessibleCondition.Status).To(Equal(metav1.ConditionTrue), "The Accessible condition should be true")
+			g.Expect(accessibleCondition.Message).To(BeEmpty())
+			// ManagedResourcesDeployed condition validation.
+			managedResourcesDeployes := validCluster.Status.GetConditionByType(greenhousev1alpha1.ManagedResourcesDeployed)
+			g.Expect(managedResourcesDeployes).ToNot(BeNil(), "The ManagedResourcesDeployed condition should be present")
+			g.Expect(managedResourcesDeployes.Status).To(Equal(metav1.ConditionTrue), "The ManagedResourcesDeployed condition should be true")
+			g.Expect(managedResourcesDeployes.Message).To(BeEmpty())
+			// AllNodesReady condition validation.
 			g.Expect(validCluster.Status.GetConditionByType(greenhousev1alpha1.AllNodesReady)).ToNot(BeNil(), "The AllNodesReady condition should be present")
 			g.Expect(validCluster.Status.GetConditionByType(greenhousev1alpha1.AllNodesReady).Status).To(Equal(metav1.ConditionFalse))
 			g.Expect(validCluster.Status.GetConditionByType(greenhousev1alpha1.AllNodesReady).Message).To(ContainSubstring("test-node not ready, test-node-3 not ready"))
 			g.Expect(validCluster.Status.Nodes).ToNot(BeEmpty())
 			g.Expect(validCluster.Status.Nodes["test-node"].Conditions).ToNot(BeEmpty())
 			g.Expect(validCluster.Status.Nodes["test-node"].Ready).To(BeFalse())
-			return true
-		}).Should(BeTrue())
+		}).Should(Succeed())
 
 		By("updating the node ready condition")
 		node := &corev1.Node{}
@@ -174,12 +184,11 @@ var _ = Describe("Cluster status", Ordered, func() {
 		}
 		Expect(remoteClient.Status().Update(test.Ctx, node)).
 			Should(Succeed(), "there should be no error updating the third remote node")
-		Eventually(func(g Gomega) bool {
+		Eventually(func(g Gomega) {
 			g.Expect(remoteClient.Get(test.Ctx, types.NamespacedName{Name: "test-node"}, node)).Should(Succeed(), "There should be no error getting the remote node")
 			g.Expect(node.Status.Conditions[0].Type).To(Equal(corev1.NodeReady))
 			g.Expect(node.Status.Conditions[0].Status).To(Equal(corev1.ConditionTrue))
-			return true
-		}).Should(BeTrue(), "we should see the condition change on the remote node")
+		}).Should(Succeed(), "we should see the condition change on the remote node")
 
 		By("Triggering a cluster reconcile by adding a label to speed up things. Requeue interval is set to 2min")
 		Expect(test.K8sClient.Get(test.Ctx, types.NamespacedName{Name: validCluster.Name, Namespace: setup.Namespace()}, &validCluster)).ShouldNot(HaveOccurred(), "There should be no error getting the cluster resource")
@@ -189,44 +198,64 @@ var _ = Describe("Cluster status", Ordered, func() {
 		validCluster.Labels["reconcile-me"] = "true"
 		Expect(test.K8sClient.Update(test.Ctx, &validCluster)).ShouldNot(HaveOccurred(), "There should be no error updating the cluster resource")
 
-		Eventually(func(g Gomega) bool {
+		Eventually(func(g Gomega) {
 			g.Expect(test.K8sClient.Get(test.Ctx, types.NamespacedName{Name: validCluster.Name, Namespace: setup.Namespace()}, &validCluster)).ShouldNot(HaveOccurred(), "There should be no error getting the cluster resource")
+			// Accessible condition validation.
+			accessibleCondition := validCluster.Status.GetConditionByType(greenhousev1alpha1.Accessible)
+			g.Expect(accessibleCondition).ToNot(BeNil(), "The Accessible condition should be present")
+			g.Expect(accessibleCondition.Status).To(Equal(metav1.ConditionTrue), "The Accessible condition should be true")
+			g.Expect(accessibleCondition.Message).To(BeEmpty())
+			// ManagedResourcesDeployed condition validation.
+			managedResourcesDeployes := validCluster.Status.GetConditionByType(greenhousev1alpha1.ManagedResourcesDeployed)
+			g.Expect(managedResourcesDeployes).ToNot(BeNil(), "The ManagedResourcesDeployed condition should be present")
+			g.Expect(managedResourcesDeployes.Status).To(Equal(metav1.ConditionTrue), "The ManagedResourcesDeployed condition should be true")
+			g.Expect(managedResourcesDeployes.Message).To(BeEmpty())
+			// AllNodesReady condition validation.
 			g.Expect(validCluster.Status.GetConditionByType(greenhousev1alpha1.AllNodesReady)).ToNot(BeNil(), "The AllNodesReady condition should be present")
 			g.Expect(validCluster.Status.GetConditionByType(greenhousev1alpha1.AllNodesReady).Status).To(Equal(metav1.ConditionTrue), "The AllNodesReady condition should be true")
 			g.Expect(validCluster.Status.GetConditionByType(greenhousev1alpha1.AllNodesReady).Message).To(BeEmpty())
 			g.Expect(validCluster.Status.Nodes).ToNot(BeEmpty())
 			g.Expect(validCluster.Status.Nodes["test-node"].Conditions).ToNot(BeEmpty())
 			g.Expect(validCluster.Status.Nodes["test-node"].Ready).To(BeTrue())
-			return true
-		}).Should(BeTrue())
+		}).Should(Succeed())
 
 		By("checking cluster ready condition")
-		Eventually(func(g Gomega) bool {
+		Eventually(func(g Gomega) {
 			g.Expect(test.K8sClient.Get(test.Ctx, types.NamespacedName{Name: validCluster.Name, Namespace: setup.Namespace()}, &validCluster)).ShouldNot(HaveOccurred(), "There should be no error getting the cluster resource")
 			g.Expect(validCluster.Status.StatusConditions).ToNot(BeNil())
 			readyCondition := validCluster.Status.GetConditionByType(greenhousemetav1alpha1.ReadyCondition)
 			g.Expect(readyCondition).ToNot(BeNil(), "The ClusterReady condition should be present")
 			g.Expect(readyCondition.Status).To(Equal(metav1.ConditionTrue))
 			g.Expect(validCluster.Status.KubernetesVersion).ToNot(BeNil())
-			return true
-		}).Should(BeTrue())
+		}).Should(Succeed())
 
 	})
 
 	It("should reconcile the status of a cluster without a secret", func() {
 		By("checking cluster conditions")
-		Eventually(func(g Gomega) bool {
+		Eventually(func(g Gomega) {
 			g.Expect(test.K8sClient.Get(test.Ctx, types.NamespacedName{Name: invalidCluster.Name, Namespace: setup.Namespace()}, invalidCluster)).ShouldNot(HaveOccurred(), "There should be no error getting the cluster resource")
 			g.Expect(invalidCluster.Status.StatusConditions).ToNot(BeNil())
+			// Accessible condition validation.
+			accessibleCondition := invalidCluster.Status.GetConditionByType(greenhousev1alpha1.Accessible)
+			g.Expect(accessibleCondition).ToNot(BeNil(), "The Accessible condition should be present")
+			g.Expect(accessibleCondition.Status).To(Equal(metav1.ConditionUnknown), "The Accessible condition should be unknown")
+			g.Expect(accessibleCondition.Message).To(Equal("accessibility could not be validated"))
+			// ManagedResourcesDeployed condition validation.
+			managedResourcesDeployes := invalidCluster.Status.GetConditionByType(greenhousev1alpha1.ManagedResourcesDeployed)
+			g.Expect(managedResourcesDeployes).ToNot(BeNil(), "The ManagedResourcesDeployed condition should be present")
+			g.Expect(managedResourcesDeployes.Status).To(Equal(metav1.ConditionUnknown), "The ManagedResourcesDeployed condition should be unknown")
+			g.Expect(managedResourcesDeployes.Message).To(Equal("managed resources could not be validated"))
+			// KubeConfigValid condition validation.
 			kubeConfigValidCondition := invalidCluster.Status.GetConditionByType(greenhousev1alpha1.KubeConfigValid)
 			g.Expect(kubeConfigValidCondition).ToNot(BeNil(), "The KubeConfigValid condition should be present")
 			g.Expect(kubeConfigValidCondition.Status).To(Equal(metav1.ConditionFalse))
 			g.Expect(kubeConfigValidCondition.Message).To(ContainSubstring("Secret \"" + invalidCluster.Name + "\" not found"))
+			// Ready condition validation.
 			readyCondition := invalidCluster.Status.GetConditionByType(greenhousemetav1alpha1.ReadyCondition)
 			g.Expect(readyCondition).ToNot(BeNil(), "The ClusterReady condition should be present")
 			g.Expect(readyCondition.Status).To(Equal(metav1.ConditionFalse))
-			return true
-		}).Should(BeTrue())
+		}).Should(Succeed())
 	})
 
 	It("should set the deletion condition when the cluster is marked for deletion", func() {
@@ -238,11 +267,10 @@ var _ = Describe("Cluster status", Ordered, func() {
 		Expect(test.K8sClient.Update(test.Ctx, &validCluster)).To(Succeed(), "there must be no error updating the object", "key", client.ObjectKeyFromObject(&validCluster))
 
 		By("checking the deletion condition")
-		Eventually(func(g Gomega) bool {
+		Eventually(func(g Gomega) {
 			g.Expect(test.K8sClient.Get(test.Ctx, types.NamespacedName{Name: validCluster.Name, Namespace: setup.Namespace()}, &validCluster)).ShouldNot(HaveOccurred(), "There should be no error getting the cluster resource")
 			g.Expect(validCluster.Status.GetConditionByType(greenhousemetav1alpha1.DeleteCondition)).ToNot(BeNil(), "The Delete condition should be present")
 			g.Expect(validCluster.Status.GetConditionByType(greenhousemetav1alpha1.DeleteCondition).Reason).To(Equal(lifecycle.ScheduledDeletionReason))
-			return true
-		}).Should(BeTrue())
+		}).Should(Succeed())
 	})
 })


### PR DESCRIPTION
## Description
- Introduce two new `Cluster` status conditions: `PermissionsVerified` and `ManagedResourcesDeployed`
- Centralize permission-checking logic by moving it to `internal/common/permissions.go`


## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

- Closes #1034

## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Validation checks for the `kubeconfig` secret setup have been added to the test suite. However, it is not currently possible to exercise the conditions when they evaluate to false: deleting resources such as the Namespace or ServiceAccount prior to reconciliation is ineffective, because the controller immediately re‑creates them and the validation conditions remain satisfied.

## Added to documentation?

- [ ] 📜 README.md
- [x] 🤝 Documentation pages updated
- [ ] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
