### PR TITLE
feat(organizations): enable oauth2-proxy by default

### DIFF
--- a/internal/controller/organization/service_proxy.go
+++ b/internal/controller/organization/service_proxy.go
@@ -53,10 +53,6 @@ func (r *OrganizationReconciler) reconcileServiceProxy(ctx context.Context, org 
 
 // reconcileOAuth2ProxySecret - creates oauth2client redirect in dex for oauth2-proxy to authenticate
 func (r *OrganizationReconciler) reconcileOAuth2ProxySecret(ctx context.Context, org *greenhousev1alpha1.Organization) error {
-	if !isOauthProxyEnabled(org) {
-		log.FromContext(ctx).Info("oauth-proxy feature is disabled for the organization")
-		return nil
-	}
 	secret, err := r.getOrCreateOrgSecret(ctx, org)
 	if err != nil {
 		return err
@@ -145,14 +141,10 @@ func (r *OrganizationReconciler) reconcileServiceProxyPlugin(ctx context.Context
 		return nil
 	}
 
-	oauthProxyEnabled := isOauthProxyEnabled(org)
-
-	if oauthProxyEnabled {
-		// oauth2-proxy requires OIDC Client config
-		if org.Spec.Authentication == nil || org.Spec.Authentication.OIDCConfig == nil {
-			log.FromContext(ctx).Info("skipping service-proxy Plugin reconciliation, Organization has no OIDCConfig")
-			return nil
-		}
+	// oauth2-proxy requires OIDC Client config
+	if org.Spec.Authentication == nil || org.Spec.Authentication.OIDCConfig == nil {
+		log.FromContext(ctx).Info("skipping service-proxy Plugin reconciliation, Organization has no OIDCConfig")
+		return nil
 	}
 
 	plugin := &greenhousev1alpha1.Plugin{
@@ -182,44 +174,42 @@ func (r *OrganizationReconciler) reconcileServiceProxyPlugin(ctx context.Context
 		if plugin.Spec.ReleaseName == "" {
 			plugin.Spec.ReleaseName = serviceProxyName
 		}
-		if oauthProxyEnabled {
-			oauth2ProxyInternalSecretName := getInternalSecretName(org.GetName())
-			oauthProxyValues := []greenhousev1alpha1.PluginOptionValue{
-				{
-					Name:  "oauth2proxy.enabled",
-					Value: &apiextensionsv1.JSON{Raw: []byte("\"true\"")},
-				},
-				{
-					Name:  "oauth2proxy.issuerURL",
-					Value: &apiextensionsv1.JSON{Raw: []byte(fmt.Sprintf("\"%s\"", "https://auth."+common.DNSDomain))},
-				},
-				{
-					Name:  "oauth2proxy.clientIDRef.secret",
-					Value: &apiextensionsv1.JSON{Raw: []byte(fmt.Sprintf("\"%s\"", oauth2ProxyInternalSecretName))},
-				},
-				{
-					Name:  "oauth2proxy.clientIDRef.key",
-					Value: &apiextensionsv1.JSON{Raw: []byte(fmt.Sprintf("\"%s\"", dexOAuth2ProxyClientIDKey))},
-				},
-				{
-					Name:  "oauth2proxy.clientSecretRef.secret",
-					Value: &apiextensionsv1.JSON{Raw: []byte(fmt.Sprintf("\"%s\"", oauth2ProxyInternalSecretName))},
-				},
-				{
-					Name:  "oauth2proxy.clientSecretRef.key",
-					Value: &apiextensionsv1.JSON{Raw: []byte(fmt.Sprintf("\"%s\"", dexOAuth2ProxyClientSecretKey))},
-				},
-				{
-					Name:  "oauth2proxy.cookieSecretRef.secret",
-					Value: &apiextensionsv1.JSON{Raw: []byte(fmt.Sprintf("\"%s\"", org.Name+technicalSecretSuffix))},
-				},
-				{
-					Name:  "oauth2proxy.cookieSecretRef.key",
-					Value: &apiextensionsv1.JSON{Raw: []byte(fmt.Sprintf("\"%s\"", cookieSecretKey))},
-				},
-			}
-			plugin.Spec.OptionValues = append(plugin.Spec.OptionValues, oauthProxyValues...)
+		oauth2ProxyInternalSecretName := getInternalSecretName(org.GetName())
+		oauthProxyValues := []greenhousev1alpha1.PluginOptionValue{
+			{
+				Name:  "oauth2proxy.enabled",
+				Value: &apiextensionsv1.JSON{Raw: []byte("\"true\"")},
+			},
+			{
+				Name:  "oauth2proxy.issuerURL",
+				Value: &apiextensionsv1.JSON{Raw: []byte(fmt.Sprintf("\"%s\"", "https://auth."+common.DNSDomain))},
+			},
+			{
+				Name:  "oauth2proxy.clientIDRef.secret",
+				Value: &apiextensionsv1.JSON{Raw: []byte(fmt.Sprintf("\"%s\"", oauth2ProxyInternalSecretName))},
+			},
+			{
+				Name:  "oauth2proxy.clientIDRef.key",
+				Value: &apiextensionsv1.JSON{Raw: []byte(fmt.Sprintf("\"%s\"", dexOAuth2ProxyClientIDKey))},
+			},
+			{
+				Name:  "oauth2proxy.clientSecretRef.secret",
+				Value: &apiextensionsv1.JSON{Raw: []byte(fmt.Sprintf("\"%s\"", oauth2ProxyInternalSecretName))},
+			},
+			{
+				Name:  "oauth2proxy.clientSecretRef.key",
+				Value: &apiextensionsv1.JSON{Raw: []byte(fmt.Sprintf("\"%s\"", dexOAuth2ProxyClientSecretKey))},
+			},
+			{
+				Name:  "oauth2proxy.cookieSecretRef.secret",
+				Value: &apiextensionsv1.JSON{Raw: []byte(fmt.Sprintf("\"%s\"", org.Name+technicalSecretSuffix))},
+			},
+			{
+				Name:  "oauth2proxy.cookieSecretRef.key",
+				Value: &apiextensionsv1.JSON{Raw: []byte(fmt.Sprintf("\"%s\"", cookieSecretKey))},
+			},
 		}
+		plugin.Spec.OptionValues = append(plugin.Spec.OptionValues, oauthProxyValues...)
 		return controllerutil.SetControllerReference(org, plugin, r.Scheme())
 	})
 	if err != nil {
@@ -286,17 +276,6 @@ func listOrganizationsAsReconcileRequests(ctx context.Context, c client.Client, 
 
 func getInternalSecretName(orgName string) string {
 	return orgName + technicalSecretSuffix
-}
-
-// TODO: remove this once the feature is considered stable.
-// This allows to enable/disable the oauth-proxy feature for a specific organization
-// isOauthProxyEnabled - checks if the oauth-proxy feature is enabled for the organization
-func isOauthProxyEnabled(org *greenhousev1alpha1.Organization) bool {
-	oauthProxyEnabled := false
-	if val, ok := org.GetAnnotations()[oauthPreviewAnnotation]; ok {
-		oauthProxyEnabled = val == "true"
-	}
-	return oauthProxyEnabled
 }
 
 func generateOauth2ProxySecret() (string, error) {


### PR DESCRIPTION

<!--
Please ensure the PR title follows the conventional commit format:
<type>(<scope>): description

For a list of accepted types and scopes see the workflow documentation: https://github.com/cloudoperators/greenhouse/blob/main/.github/workflows/ci-pr-title.yaml

-->

## Description

organizations with a valid OIDC config will get the oauth2-proxy automatically configured


## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 

- Related Issue # (issue)
- Closes # (issue)
- Fixes # (issue)

-->

## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [ ] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
