### PR TITLE
feat(controller): server side priority and fairness check

### DIFF
--- a/cmd/greenhouse/main.go
+++ b/cmd/greenhouse/main.go
@@ -141,7 +141,9 @@ func main() {
 		isEnableLeaderElection = false
 	}
 
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+	restConfig := clientutil.GetConfigOrDieWithPriorityAndFairness()
+
+	mgr, err := ctrl.NewManager(restConfig, ctrl.Options{
 		Scheme: scheme,
 		Metrics: metricsserver.Options{
 			BindAddress: metricsAddr,

--- a/internal/clientutil/fairness.go
+++ b/internal/clientutil/fairness.go
@@ -1,0 +1,97 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Greenhouse contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package clientutil
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	flowcontrolapi "k8s.io/api/flowcontrol/v1beta2"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/transport"
+)
+
+const pingPath = "/livez/ping"
+
+// isPriorityAndFairnessEnabled - returns true if the server has the Priority and Fairness check
+// filter enabled.
+func isPriorityAndFairnessEnabled(ctx context.Context, config *rest.Config) (bool, error) {
+	transportConfig, err := config.TransportConfig()
+	if err != nil {
+		return false, fmt.Errorf("building transport config: %w", err)
+	}
+	trippy, err := transport.New(transportConfig)
+	if err != nil {
+		return false, fmt.Errorf("building round tripper: %w", err)
+	}
+
+	// Build the base api-server URL from the provided REST client config.
+	serverURL, err := apiServerURL(config)
+	if err != nil {
+		return false, fmt.Errorf("building server URL: %w", err)
+	}
+
+	// Use the ping endpoint, because it is fast.
+	// The endpoint for old clusters 1.23 range is behind a feature gate so even a 404 will still have the flow control headers.
+	serverURL.Path = pingPath
+
+	// Build HEAD request with an empty body.
+	req, err := http.NewRequestWithContext(ctx, http.MethodHead, serverURL.String(), http.NoBody)
+	if err != nil {
+		return false, fmt.Errorf("error building %s request: %w", pingPath, err)
+	}
+
+	if config.UserAgent != "" {
+		req.Header.Set("User-Agent", config.UserAgent)
+	}
+	// we don't need to set "Accept" header, because we don't need to worry about the response body, only the headers matter.
+
+	resp, err := trippy.RoundTrip(req)
+	if err != nil {
+		return false, fmt.Errorf("error making %s request: %w", pingPath, err)
+	}
+	// HEAD request should not have a body in general, but check nevertheless
+	if resp.Body != nil {
+		// close to free up resources
+		err := resp.Body.Close()
+		if err != nil {
+			return false, fmt.Errorf("closing response body: %w", err)
+		}
+	}
+
+	// If the response has one of the flow control headers,
+	// that means the server has the Priority and Fairness filter enabled.
+	// There are always two headers
+	// x-kubernetes-pf-prioritylevel-uid
+	// x-kubernetes-pf-flowschema-uid
+	// we only need to check one of them
+
+	// key = flowcontrolapi.ResponseHeaderMatchedPriorityLevelConfigurationUID
+	key := flowcontrolapi.ResponseHeaderMatchedFlowSchemaUID
+	if value := resp.Header.Get(key); value != "" {
+		// the value is a UUID, nothing to do with it.
+		return true, nil
+	}
+	return false, nil
+}
+
+// apiServerURL - returns the base URL for the cluster based on rest config.
+// Host and Version are required. GroupVersion is ignored.
+// Based on `defaultServerUrlFor` from k8s.io/client-go@v0.23.2/rest/url_utils.go
+func apiServerURL(config *rest.Config) (*url.URL, error) {
+	// config.Insecure is taken to mean "I want HTTPS but ignore check of certs against a CA."
+	hasCA := config.CAFile != "" || len(config.CAData) != 0
+	hasCert := config.CertFile != "" || len(config.CertData) != 0
+	defaultTLS := hasCA || hasCert || config.Insecure
+	host := config.Host
+	if host == "" {
+		host = "localhost"
+	}
+
+	hostURL, _, err := rest.DefaultServerURL(host, config.APIPath, schema.GroupVersion{}, defaultTLS)
+	return hostURL, err
+}

--- a/internal/clientutil/fairness_exports_test.go
+++ b/internal/clientutil/fairness_exports_test.go
@@ -1,0 +1,6 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Greenhouse contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package clientutil
+
+var ExportedIsPriorityAndFairnessEnabled = isPriorityAndFairnessEnabled

--- a/internal/clientutil/fairness_test.go
+++ b/internal/clientutil/fairness_test.go
@@ -1,0 +1,121 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Greenhouse contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package clientutil_test
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	flowcontrolapi "k8s.io/api/flowcontrol/v1beta2"
+	"k8s.io/client-go/rest"
+
+	"github.com/cloudoperators/greenhouse/internal/clientutil"
+)
+
+var _ = Describe("isPriorityAndFairnessEnabled", func() {
+	var ctx context.Context
+	var cancel context.CancelFunc
+
+	BeforeEach(func() {
+		ctx, cancel = context.WithTimeout(context.Background(), 10*time.Second)
+		DeferCleanup(cancel)
+	})
+
+	DescribeTable("should correctly detect Priority and Fairness support",
+		func(tc struct {
+			handler       func(req *http.Request) *http.Response
+			expectEnabled bool
+			expectErr     bool
+		}) {
+			// Setup configuration based on test case
+			var cfg *rest.Config
+			if tc.handler != nil {
+				ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					resp := tc.handler(r)
+					// copy headers
+					for k, vals := range resp.Header {
+						w.Header().Del(k)
+						for _, v := range vals {
+							w.Header().Add(k, v)
+						}
+					}
+					w.WriteHeader(resp.StatusCode)
+					// copy body
+					_, err := io.Copy(w, resp.Body)
+					Expect(err).ToNot(HaveOccurred())
+				}))
+				DeferCleanup(ts.Close)
+				cfg = &rest.Config{Host: ts.URL}
+			} else {
+				// invalid host scenario
+				cfg = &rest.Config{Host: "://bad-host"}
+			}
+
+			enabled, err := clientutil.ExportedIsPriorityAndFairnessEnabled(ctx, cfg)
+			if tc.expectErr {
+				Expect(err).To(HaveOccurred())
+			} else {
+				Expect(err).ToNot(HaveOccurred())
+				Expect(enabled).To(Equal(tc.expectEnabled))
+			}
+		},
+
+		Entry("header found",
+			struct {
+				handler       func(req *http.Request) *http.Response
+				expectEnabled bool
+				expectErr     bool
+			}{
+				handler: func(req *http.Request) *http.Response {
+					headers := http.Header{}
+					headers.Add(flowcontrolapi.ResponseHeaderMatchedFlowSchemaUID, "uuid-1234")
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Header:     headers,
+						Body:       io.NopCloser(bytes.NewReader(nil)),
+					}
+				},
+				expectEnabled: true,
+				expectErr:     false,
+			},
+		),
+
+		Entry("header not found",
+			struct {
+				handler       func(req *http.Request) *http.Response
+				expectEnabled bool
+				expectErr     bool
+			}{
+				handler: func(req *http.Request) *http.Response {
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Header:     http.Header{},
+						Body:       io.NopCloser(bytes.NewReader(nil)),
+					}
+				},
+				expectEnabled: false,
+				expectErr:     false,
+			},
+		),
+
+		Entry("invalid host",
+			struct {
+				handler       func(req *http.Request) *http.Response
+				expectEnabled bool
+				expectErr     bool
+			}{
+				handler:       nil,
+				expectEnabled: false,
+				expectErr:     true,
+			},
+		),
+	)
+})


### PR DESCRIPTION
## Description

This PR removes client side rate limiting by checking if there is a server side rate-limiting enabled via priority and fairness check.

The check is performed by making an HTTP request to `livez/ping` endpoint. The `livez/ping` is a very small and super fast endpoint and it should not block or delay startup time.

The response headers should indicate if flow control is enabled on server side.

The following headers in the response Indicate server side rate limiting -

- `x-kubernetes-pf-prioritylevel-uid`
- `x-kubernetes-pf-flowschema-uid`

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

- Closes #1306

## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

implemented tests for http request to the `livez/ping` endpoint

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [x] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
