### PR TITLE
feat(clusters): adds owned by printer column for clusters

### DIFF
--- a/api/v1alpha1/cluster_types.go
+++ b/api/v1alpha1/cluster_types.go
@@ -58,6 +58,8 @@ type ClusterStatus struct {
 	greenhousemetav1alpha1.StatusConditions `json:"statusConditions,omitempty"`
 	// Nodes provides a map of cluster node names to node statuses
 	Nodes map[string]NodeStatus `json:"nodes,omitempty"`
+	// OwnedBy reflects the owner of the cluster.
+	OwnedBy string `json:"ownedBy,omitempty"`
 }
 
 // ClusterConditionType is a valid condition of a cluster.
@@ -75,6 +77,7 @@ type NodeStatus struct {
 //+kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 //+kubebuilder:printcolumn:name="AccessMode",type="string",JSONPath=".spec.accessMode"
 //+kubebuilder:printcolumn:name="Ready",type="string",JSONPath=`.status.statusConditions.conditions[?(@.type == "Ready")].status`
+//+kubebuilder:printcolumn:name="OwnedBy",type="string",JSONPath=".status.ownedBy"
 
 // Cluster is the Schema for the clusters API
 type Cluster struct {

--- a/charts/manager/crds/greenhouse.sap_clusters.yaml
+++ b/charts/manager/crds/greenhouse.sap_clusters.yaml
@@ -27,6 +27,9 @@ spec:
     - jsonPath: .status.statusConditions.conditions[?(@.type == "Ready")].status
       name: Ready
       type: string
+    - jsonPath: .status.ownedBy
+      name: OwnedBy
+      type: string
     name: v1alpha1
     schema:
       openAPIV3Schema:
@@ -132,6 +135,9 @@ spec:
                   type: object
                 description: Nodes provides a map of cluster node names to node statuses
                 type: object
+              ownedBy:
+                description: OwnedBy reflects the owner of the cluster.
+                type: string
               statusConditions:
                 description: StatusConditions contain the different conditions that
                   constitute the status of the Cluster.

--- a/docs/reference/api/index.html
+++ b/docs/reference/api/index.html
@@ -1037,6 +1037,17 @@ map[string]../greenhouse/api/v1alpha1.NodeStatus
 <p>Nodes provides a map of cluster node names to node statuses</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>ownedBy</code><br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>OwnedBy reflects the owner of the cluster.</p>
+</td>
+</tr>
 </tbody>
 </table>
 </div>

--- a/docs/reference/api/openapi.yaml
+++ b/docs/reference/api/openapi.yaml
@@ -395,6 +395,9 @@ components:
                 type: object
               description: Nodes provides a map of cluster node names to node statuses
               type: object
+            ownedBy:
+              description: OwnedBy reflects the owner of the cluster.
+              type: string
             statusConditions:
               description: StatusConditions contain the different conditions that constitute the status of the Cluster.
               properties:

--- a/internal/controller/cluster/cluster_controller.go
+++ b/internal/controller/cluster/cluster_controller.go
@@ -142,7 +142,18 @@ func (r *RemoteClusterReconciler) EnsureCreated(ctx context.Context, resource li
 	if err := r.reconcileServiceAccountToken(ctx, restClientGetter, remoteClient, cluster, clusterSecret.Type); err != nil {
 		return ctrl.Result{}, lifecycle.Failed, err
 	}
+
+	setOwnerStatus(cluster)
 	return ctrl.Result{RequeueAfter: utils.DefaultRequeueInterval}, lifecycle.Success, nil
+}
+
+func setOwnerStatus(cluster *greenhousev1alpha1.Cluster) {
+	labels := cluster.GetLabels()
+	if labels != nil {
+		if owner, ok := labels[greenhouseapis.LabelKeyOwnedBy]; ok {
+			cluster.Status.OwnedBy = owner
+		}
+	}
 }
 
 // reconcileClusterRoleBindingInRemoteCluster - creates or updates the cluster role binding in the remote cluster

--- a/internal/controller/cluster/status_test.go
+++ b/internal/controller/cluster/status_test.go
@@ -116,7 +116,11 @@ var _ = Describe("Cluster status", Ordered, func() {
 		secret := setup.CreateSecret(test.Ctx, validClusterName,
 			test.WithSecretType(greenhouseapis.SecretTypeKubeConfig),
 			test.WithSecretData(map[string][]byte{greenhouseapis.KubeConfigKey: remoteKubeConfig}),
-			test.WithSecretLabel(greenhouseapis.LabelKeyOwnedBy, team.Name))
+			test.WithSecretLabel(greenhouseapis.LabelKeyOwnedBy, team.Name),
+			test.WithSecretAnnotations(map[string]string{
+				lifecycle.PropagateLabelsAnnotation: greenhouseapis.LabelKeyOwnedBy,
+			}),
+		)
 
 		By("Checking the cluster resource has been created")
 		Eventually(func() error {
@@ -208,6 +212,7 @@ var _ = Describe("Cluster status", Ordered, func() {
 			g.Expect(readyCondition).ToNot(BeNil(), "The ClusterReady condition should be present")
 			g.Expect(readyCondition.Status).To(Equal(metav1.ConditionTrue))
 			g.Expect(validCluster.Status.KubernetesVersion).ToNot(BeNil())
+			g.Expect(validCluster.Status.OwnedBy).To(Equal(team.Name), "The cluster should be owned by the team")
 			return true
 		}).Should(BeTrue())
 

--- a/types/typescript/schema.d.ts
+++ b/types/typescript/schema.d.ts
@@ -297,6 +297,8 @@ export interface components {
                         };
                     };
                 };
+                /** @description OwnedBy reflects the owner of the cluster. */
+                ownedBy?: string;
                 /** @description StatusConditions contain the different conditions that constitute the status of the Cluster. */
                 statusConditions?: {
                     conditions?: {


### PR DESCRIPTION
## Description

Adds `OwnedBy` printer column to `Cluster` CR fetched from status

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

- Related Issue #1301 

## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

status test verifies OwnedBy is set if the OwnerLabel key is propagated

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [x] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
