### PR TITLE
fix(plugins): filter out secret-based plugin option values when generating helm values

### DIFF
--- a/internal/controller/flux/plugin_controller.go
+++ b/internal/controller/flux/plugin_controller.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"slices"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -270,6 +271,11 @@ func addValuesToHelmRelease(ctx context.Context, c client.Client, plugin *greenh
 	if err != nil {
 		return nil, err
 	}
+
+	// remove all option values that are set from a secret, as these have a nil value
+	optionValues = slices.DeleteFunc(optionValues, func(v greenhousev1alpha1.PluginOptionValue) bool {
+		return v.ValueFrom != nil && v.ValueFrom.Secret != nil
+	})
 
 	jsonValue, err := helm.ConvertFlatValuesToHelmValues(optionValues)
 	if err != nil {

--- a/internal/controller/flux/plugin_controller_test.go
+++ b/internal/controller/flux/plugin_controller_test.go
@@ -54,6 +54,13 @@ var (
 		test.WithPluginLabel(greenhouseapis.LabelKeyOwnedBy, testTeam.Name),
 		test.WithPluginOptionValue("flatOption", test.AsAPIExtensionJSON("flatValue"), nil),
 		test.WithPluginOptionValue("nested.option", test.AsAPIExtensionJSON("nestedValue"), nil),
+		test.WithPluginOptionValue("nested.secretOption", nil, &greenhousev1alpha1.ValueFromSource{
+			Secret: &greenhousev1alpha1.SecretKeyReference{
+				Name: "test-cluster",
+				Key:  greenhouseapis.GreenHouseKubeConfigKey,
+			},
+		},
+		),
 	)
 	testPluginDefinition = test.NewClusterPluginDefinition(
 		test.Ctx,


### PR DESCRIPTION
<!--
Please ensure the PR title follows the conventional commit format:
<type>(<scope>): description

For a list of accepted types and scopes see the workflow documentation: https://github.com/cloudoperators/greenhouse/blob/main/.github/workflows/ci-pr-title.yaml

-->

## Description

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 

- Related Issue # (issue)
- Closes # (issue)
- Fixes # (issue)

-->

## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [ ] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
