### PR TITLE
fix(plugins): ensure empty KubeConfig in flux spec when there is no cluster name provided

### DIFF
--- a/internal/flux/builder_test.go
+++ b/internal/flux/builder_test.go
@@ -172,5 +172,23 @@ func TestHelmReleaseBuilder_WithKubeConfigEmptyIgnored(t *testing.T) {
 
 	spec, err := builder.Build()
 	assert.NoError(t, err)
-	assert.Equal(t, meta.SecretKeyReference{}, spec.KubeConfig.SecretRef)
+	assert.Nil(t, spec.KubeConfig)
+}
+
+func TestHelmReleaseBuilder_WithKubeConfigFromSecret(t *testing.T) {
+	builder := NewHelmReleaseSpecBuilder().
+		WithChart(helmv2.HelmChartTemplateSpec{
+			Chart:   "nginx",
+			Version: "1.0.0",
+		}).
+		WithKubeConfig(meta.SecretKeyReference{
+			Name: "kubeconfig-secret",
+			Key:  "kubeconfig",
+		})
+
+	spec, err := builder.Build()
+	assert.NoError(t, err)
+	assert.NotNil(t, spec.KubeConfig)
+	assert.Equal(t, "kubeconfig-secret", spec.KubeConfig.SecretRef.Name)
+	assert.Equal(t, "kubeconfig", spec.KubeConfig.SecretRef.Key)
 }


### PR DESCRIPTION
## Description

Currently the Plugin to Flux resources creates an empty struct for `HelmRelease.Spec.KubeConfig`.

When applying to kubernetes with a zero value struct  -

https://github.com/cloudoperators/greenhouse/blob/49c138707087655716797154483030a9030a7b88/internal/flux/builder.go#L48-L63

It is initialized with zero values for the inner struct as well, resulting in -

```yaml
apiVersion: helm.toolkit.fluxcd.io/v2
kind: HelmRelease
metadata:
  finalizers:
    - finalizers.fluxcd.io
  name: perses
  namespace: greenhouse
spec:
...
  install:
    createNamespace: true
    remediation:
      retries: 3
  interval: 5m0s
  maxHistory: 10
  releaseName: perses
  targetNamespace: greenhouse
  test: {}
  kubeConfig:
    secretRef:
      name: ""
      key: ""
  timeout: 5m0s
  upgrade:
    remediation:
      retries: 3
...
```

The resulting error from flux would be -

```yaml
    - lastTransitionTime: '2025-08-11T02:31:08Z'
      message: >-
        could not get KubeConfig secret 'greenhouse/': resource name may not be
        empty
      observedGeneration: 5
      reason: RESTClientError
      status: 'False'
      type: Ready
```

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

- ensure the builder outputs a nil value if `Plugin` is deployed to admin cluster (In-Cluster) via `Flux`

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [ ] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
