### PR TITLE
docs(organizations): introduce org-admin team as support group

### DIFF
--- a/docs/getting-started/core-concepts/organizations.md
+++ b/docs/getting-started/core-concepts/organizations.md
@@ -15,7 +15,7 @@ See [creating an Organization](./../../user-guides/organization/creation.md) for
 The Organization's Namespace in the Greenhouse cluster contains all resources bound to the Organization. This Namespace is automatically provisioned when a new Organization is created and shares the Organization's name.
 Once the Namespace is created, Greenhouse will automatically seed RBAC [Roles](./../../../pkg/rbac/role.go) and [ClusterRoles](./../../../pkg/rbac/clusterrole.go) for the Organization. These are used to grant permissions for the Organization's resources to Teams.
 
-- The Administrators of an Organization are specified via a identity provider (IDP) group during the creation of the Organization.
+- The Administrators of an Organization are specified via a identity provider (IDP) group during the creation of the Organization. Greenhouse automatically creates a Team called `<org-name>-admin`. This Team is also a [support group](teams.md#support-groups) and all alerts created by the Greenhouse controller are routed to this admin Team, if no other ownership is provided. See [operational processes](./../operations/processes.md) and [ownership](./../operations/ownership.md) for details.
 - The Administrators for Plugins and Clusters need to be defined by the Organization Admins via `RoleBindings` for the seeded Roles `role:<org-name>:cluster-admin` and `role:<org-name>:plugin-admin`.
 - All authenticated users are considered members of the Organization and are granted the `organization:<org-name>` Role.
 


### PR DESCRIPTION


## Description
Introduces a passage to the docs about the `org-admin` Team with reference to its use as a support group.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [x] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents
https://github.com/cloudoperators/greenhouse/issues/1229
