### PR TITLE
refactor(tests): add helper for pluginoptionvalue with template

### DIFF
--- a/e2e/plugin/scenarios/flux_controller.go
+++ b/e2e/plugin/scenarios/flux_controller.go
@@ -54,7 +54,7 @@ func FluxControllerPodInfoByPlugin(ctx context.Context, adminClient, remoteClien
 		test.WithPluginDefinition(testPluginDefinition.Name),
 		test.WithReleaseName("test-podinfo-plugin"),
 		test.WithReleaseNamespace(env.TestNamespace),
-		test.WithPluginOptionValue("replicaCount", &apiextensionsv1.JSON{Raw: []byte("1")}, nil))
+		test.WithPluginOptionValue("replicaCount", &apiextensionsv1.JSON{Raw: []byte("1")}))
 
 	By("Add labels to remote cluster")
 	remoteCluster := &greenhousev1alpha1.Cluster{}

--- a/e2e/plugin/scenarios/plugin_controller.go
+++ b/e2e/plugin/scenarios/plugin_controller.go
@@ -58,7 +58,7 @@ func PluginControllerNginxByPlugin(ctx context.Context, adminClient, remoteClien
 		test.WithPluginDefinition(testPluginDefinition.Name),
 		test.WithCluster(remoteClusterName),
 		test.WithReleaseNamespace(env.TestNamespace),
-		test.WithPluginOptionValue("replicaCount", &apiextensionsv1.JSON{Raw: []byte("1")}, nil),
+		test.WithPluginOptionValue("replicaCount", &apiextensionsv1.JSON{Raw: []byte("1")}),
 		test.WithReleaseName(nginxPluginOne),
 		test.WithPluginLabel(greenhouseapis.LabelKeyOwnedBy, teamName),
 	)
@@ -130,7 +130,7 @@ func PluginControllerNginxByPreset(ctx context.Context, adminClient, remoteClien
 	testPlugin := fixtures.PreparePlugin(nginxPluginTwo, env.TestNamespace,
 		test.WithPluginDefinition(testPluginDefinition.Name),
 		test.WithReleaseNamespace(env.TestNamespace),
-		test.WithPluginOptionValue("replicaCount", &apiextensionsv1.JSON{Raw: []byte("1")}, nil),
+		test.WithPluginOptionValue("replicaCount", &apiextensionsv1.JSON{Raw: []byte("1")}),
 		test.WithReleaseName(nginxPluginTwo),
 		test.WithPluginLabel(greenhouseapis.LabelKeyOwnedBy, teamName),
 	)

--- a/internal/controller/plugin/plugin_controller_flux_test.go
+++ b/internal/controller/plugin/plugin_controller_flux_test.go
@@ -59,8 +59,7 @@ var (
 				Name: "test-cluster",
 				Key:  greenhouseapis.GreenHouseKubeConfigKey,
 			},
-		},
-		),
+		}),
 	)
 	testPluginDefinition = test.NewClusterPluginDefinition(
 		test.Ctx,

--- a/internal/controller/plugin/plugin_controller_flux_test.go
+++ b/internal/controller/plugin/plugin_controller_flux_test.go
@@ -52,9 +52,9 @@ var (
 		test.WithReleaseName("release-test-flux"),
 		test.WithReleaseNamespace(test.TestNamespace),
 		test.WithPluginLabel(greenhouseapis.LabelKeyOwnedBy, testPluginTeam.Name),
-		test.WithPluginOptionValue("flatOption", test.MustReturnJSONFor("flatValue"), nil),
-		test.WithPluginOptionValue("nested.option", test.MustReturnJSONFor("nestedValue"), nil),
-		test.WithPluginOptionValue("nested.secretOption", nil, &greenhousev1alpha1.ValueFromSource{
+		test.WithPluginOptionValue("flatOption", test.MustReturnJSONFor("flatValue")),
+		test.WithPluginOptionValue("nested.option", test.MustReturnJSONFor("nestedValue")),
+		test.WithPluginOptionValueFrom("nested.secretOption", &greenhousev1alpha1.ValueFromSource{
 			Secret: &greenhousev1alpha1.SecretKeyReference{
 				Name: "test-cluster",
 				Key:  greenhouseapis.GreenHouseKubeConfigKey,

--- a/internal/controller/plugin/pluginpreset_controller_test.go
+++ b/internal/controller/plugin/pluginpreset_controller_test.go
@@ -598,7 +598,7 @@ var _ = Describe("Plugin Preset skip changes", Ordered, func() {
 				test.WithPresetLabelValue(pluginPresetName),
 				test.WithPluginDefinition(pluginPresetDefinitionName),
 				test.WithPluginOptionValue("global.greenhouse.test_parameter",
-					test.MustReturnJSONFor(2), nil),
+					test.MustReturnJSONFor(2)),
 			),
 			&greenhousev1alpha1.PluginPreset{
 				ObjectMeta: metav1.ObjectMeta{
@@ -625,9 +625,9 @@ var _ = Describe("Plugin Preset skip changes", Ordered, func() {
 				test.WithPresetLabelValue(pluginPresetName),
 				test.WithPluginDefinition(pluginPresetDefinitionName),
 				test.WithPluginOptionValue("global.greenhouse.test_parameter",
-					test.MustReturnJSONFor(2), nil),
+					test.MustReturnJSONFor(2)),
 				test.WithPluginOptionValue("plugin_preset.test_parameter",
-					test.MustReturnJSONFor(2), nil),
+					test.MustReturnJSONFor(2)),
 			),
 			&greenhousev1alpha1.PluginPreset{
 				ObjectMeta: metav1.ObjectMeta{
@@ -654,13 +654,13 @@ var _ = Describe("Plugin Preset skip changes", Ordered, func() {
 				test.WithPresetLabelValue(pluginPresetName),
 				test.WithPluginDefinition(pluginPresetDefinitionName),
 				test.WithPluginOptionValue("global.greenhouse.test_parameter",
-					test.MustReturnJSONFor(2), nil),
+					test.MustReturnJSONFor(2)),
 				test.WithPluginOptionValue("plugin_preset.test_parameter_1",
-					test.MustReturnJSONFor(1), nil),
+					test.MustReturnJSONFor(1)),
 				test.WithPluginOptionValue("plugin_preset.test_parameter_2",
-					test.MustReturnJSONFor(2), nil),
+					test.MustReturnJSONFor(2)),
 				test.WithPluginOptionValue("plugin_preset.test_parameter_4",
-					test.MustReturnJSONFor(3), nil),
+					test.MustReturnJSONFor(3)),
 			),
 			&greenhousev1alpha1.PluginPreset{
 				ObjectMeta: metav1.ObjectMeta{
@@ -695,9 +695,9 @@ var _ = Describe("Plugin Preset skip changes", Ordered, func() {
 				test.WithPresetLabelValue(pluginPresetName),
 				test.WithPluginDefinition(pluginPresetDefinitionName),
 				test.WithPluginOptionValue("global.greenhouse.test_parameter",
-					test.MustReturnJSONFor(2), nil),
+					test.MustReturnJSONFor(2)),
 				test.WithPluginOptionValue("plugin_preset.test_parameter",
-					test.MustReturnJSONFor(3), nil),
+					test.MustReturnJSONFor(3)),
 			),
 			&greenhousev1alpha1.PluginPreset{
 				ObjectMeta: metav1.ObjectMeta{
@@ -724,11 +724,11 @@ var _ = Describe("Plugin Preset skip changes", Ordered, func() {
 				test.WithPresetLabelValue(pluginPresetName),
 				test.WithPluginDefinition(pluginPresetDefinitionName),
 				test.WithPluginOptionValue("global.greenhouse.test_parameter",
-					test.MustReturnJSONFor(2), nil),
+					test.MustReturnJSONFor(2)),
 				test.WithPluginOptionValue("plugin_preset.test_parameter",
-					test.MustReturnJSONFor(3), nil),
+					test.MustReturnJSONFor(3)),
 				test.WithPluginOptionValue("custom_parameter",
-					test.MustReturnJSONFor(123), nil),
+					test.MustReturnJSONFor(123)),
 			),
 			&greenhousev1alpha1.PluginPreset{
 				ObjectMeta: metav1.ObjectMeta{
@@ -755,9 +755,9 @@ var _ = Describe("Plugin Preset skip changes", Ordered, func() {
 				test.WithPresetLabelValue(pluginPresetName),
 				test.WithPluginDefinition(pluginPresetDefinitionName),
 				test.WithPluginOptionValue("global.greenhouse.test_parameter",
-					test.MustReturnJSONFor(2), nil),
+					test.MustReturnJSONFor(2)),
 				test.WithPluginOptionValue("plugin_definition.test_parameter",
-					test.MustReturnJSONFor(3), nil),
+					test.MustReturnJSONFor(3)),
 			),
 			&greenhousev1alpha1.PluginPreset{
 				ObjectMeta: metav1.ObjectMeta{
@@ -791,9 +791,9 @@ var _ = Describe("Plugin Preset skip changes", Ordered, func() {
 				test.WithPresetLabelValue(pluginPresetName),
 				test.WithPluginDefinition(pluginPresetDefinitionName),
 				test.WithPluginOptionValue("global.greenhouse.test_parameter",
-					test.MustReturnJSONFor(2), nil),
+					test.MustReturnJSONFor(2)),
 				test.WithPluginOptionValue("plugin_definition.test_parameter",
-					test.MustReturnJSONFor(3), nil),
+					test.MustReturnJSONFor(3)),
 			),
 			&greenhousev1alpha1.PluginPreset{
 				ObjectMeta: metav1.ObjectMeta{
@@ -826,9 +826,9 @@ var _ = Describe("Plugin Preset skip changes", Ordered, func() {
 				test.WithPresetLabelValue(pluginPresetName),
 				test.WithPluginDefinition(pluginPresetDefinitionName),
 				test.WithPluginOptionValue("global.greenhouse.test_parameter",
-					test.MustReturnJSONFor(2), nil),
-				test.WithPluginOptionValue("plugin_definition.test_parameter",
-					nil, &greenhousev1alpha1.ValueFromSource{
+					test.MustReturnJSONFor(2)),
+				test.WithPluginOptionValueFrom("plugin_definition.test_parameter",
+					&greenhousev1alpha1.ValueFromSource{
 						Secret: &greenhousev1alpha1.SecretKeyReference{
 							Name: "test-secret",
 							Key:  "test-key",
@@ -866,9 +866,9 @@ var _ = Describe("Plugin Preset skip changes", Ordered, func() {
 				test.WithPresetLabelValue(pluginPresetName),
 				test.WithPluginDefinition(pluginPresetDefinitionName),
 				test.WithPluginOptionValue("global.greenhouse.test_parameter",
-					test.MustReturnJSONFor(2), nil),
-				test.WithPluginOptionValue("plugin_definition.test_parameter",
-					nil, &greenhousev1alpha1.ValueFromSource{
+					test.MustReturnJSONFor(2)),
+				test.WithPluginOptionValueFrom("plugin_definition.test_parameter",
+					&greenhousev1alpha1.ValueFromSource{
 						Secret: &greenhousev1alpha1.SecretKeyReference{
 							Name: "test-secret",
 							Key:  "test-key",
@@ -915,7 +915,7 @@ var _ = Describe("Plugin Preset skip changes", Ordered, func() {
 				test.WithPresetLabelValue(pluginPresetName),
 				test.WithPluginDefinition(pluginPresetDefinitionName),
 				test.WithPluginOptionValue("global.greenhouse.test_parameter",
-					test.MustReturnJSONFor(2), nil),
+					test.MustReturnJSONFor(2)),
 			),
 			&greenhousev1alpha1.PluginPreset{
 				ObjectMeta: metav1.ObjectMeta{
@@ -952,7 +952,7 @@ var _ = Describe("Plugin Preset skip changes", Ordered, func() {
 				test.WithPresetLabelValue(pluginPresetName),
 				test.WithPluginDefinition(pluginPresetDefinitionName),
 				test.WithPluginOptionValue("global.greenhouse.test_parameter",
-					test.MustReturnJSONFor(2), nil),
+					test.MustReturnJSONFor(2)),
 			),
 			&greenhousev1alpha1.PluginPreset{
 				ObjectMeta: metav1.ObjectMeta{
@@ -994,18 +994,18 @@ var _ = Describe("overridesPluginOptionValues", Ordered, func() {
 		Expect(plugin).To(BeEquivalentTo(expectedPlugin))
 	},
 		Entry("with no defined pluginPresetOverrides",
-			test.NewPlugin(test.Ctx, "", "", test.WithPluginOptionValue("option-1", test.MustReturnJSONFor(2), nil), test.WithPluginLabel(greenhouseapis.LabelKeyOwnedBy, testTeam.Name)),
+			test.NewPlugin(test.Ctx, "", "", test.WithPluginOptionValue("option-1", test.MustReturnJSONFor(2)), test.WithPluginLabel(greenhouseapis.LabelKeyOwnedBy, testTeam.Name)),
 			&greenhousev1alpha1.PluginPreset{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{greenhouseapis.LabelKeyOwnedBy: testTeam.Name},
 				},
 				Spec: greenhousev1alpha1.PluginPresetSpec{},
 			},
-			test.NewPlugin(test.Ctx, "", "", test.WithPluginOptionValue("option-1", test.MustReturnJSONFor(2), nil), test.WithPluginLabel(greenhouseapis.LabelKeyOwnedBy, testTeam.Name)),
+			test.NewPlugin(test.Ctx, "", "", test.WithPluginOptionValue("option-1", test.MustReturnJSONFor(2)), test.WithPluginLabel(greenhouseapis.LabelKeyOwnedBy, testTeam.Name)),
 		),
 		Entry("with defined pluginPresetOverrides but for another cluster",
 			test.NewPlugin(test.Ctx, "", clusterA, test.WithPluginLabel(greenhouseapis.LabelKeyOwnedBy, testTeam.Name),
-				test.WithCluster(clusterA), test.WithPluginOptionValue("option-1", test.MustReturnJSONFor(2), nil)),
+				test.WithCluster(clusterA), test.WithPluginOptionValue("option-1", test.MustReturnJSONFor(2))),
 			&greenhousev1alpha1.PluginPreset{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{greenhouseapis.LabelKeyOwnedBy: testTeam.Name},
@@ -1025,10 +1025,10 @@ var _ = Describe("overridesPluginOptionValues", Ordered, func() {
 				},
 			},
 			test.NewPlugin(test.Ctx, "", clusterA, test.WithPluginLabel(greenhouseapis.LabelKeyOwnedBy, testTeam.Name),
-				test.WithCluster(clusterA), test.WithPluginOptionValue("option-1", test.MustReturnJSONFor(2), nil)),
+				test.WithCluster(clusterA), test.WithPluginOptionValue("option-1", test.MustReturnJSONFor(2))),
 		),
 		Entry("with defined pluginPresetOverrides for the correct cluster",
-			test.NewPlugin(test.Ctx, "", clusterA, test.WithCluster(clusterA), test.WithPluginOptionValue("option-1", test.MustReturnJSONFor(2), nil), test.WithPluginLabel(greenhouseapis.LabelKeyOwnedBy, testTeam.Name)),
+			test.NewPlugin(test.Ctx, "", clusterA, test.WithCluster(clusterA), test.WithPluginOptionValue("option-1", test.MustReturnJSONFor(2)), test.WithPluginLabel(greenhouseapis.LabelKeyOwnedBy, testTeam.Name)),
 			&greenhousev1alpha1.PluginPreset{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{greenhouseapis.LabelKeyOwnedBy: testTeam.Name},
@@ -1047,7 +1047,7 @@ var _ = Describe("overridesPluginOptionValues", Ordered, func() {
 					},
 				},
 			},
-			test.NewPlugin(test.Ctx, "", clusterA, test.WithCluster(clusterA), test.WithPluginOptionValue("option-1", test.MustReturnJSONFor(1), nil), test.WithPluginLabel(greenhouseapis.LabelKeyOwnedBy, testTeam.Name)),
+			test.NewPlugin(test.Ctx, "", clusterA, test.WithCluster(clusterA), test.WithPluginOptionValue("option-1", test.MustReturnJSONFor(1)), test.WithPluginLabel(greenhouseapis.LabelKeyOwnedBy, testTeam.Name)),
 		),
 		Entry("with defined pluginPresetOverrides for the cluster and plugin with empty option values",
 			test.NewPlugin(test.Ctx, "", clusterA, test.WithCluster(clusterA), test.WithPluginLabel(greenhouseapis.LabelKeyOwnedBy, testTeam.Name)),
@@ -1069,10 +1069,10 @@ var _ = Describe("overridesPluginOptionValues", Ordered, func() {
 					},
 				},
 			},
-			test.NewPlugin(test.Ctx, "", clusterA, test.WithCluster(clusterA), test.WithPluginOptionValue("option-1", test.MustReturnJSONFor(1), nil), test.WithPluginLabel(greenhouseapis.LabelKeyOwnedBy, testTeam.Name)),
+			test.NewPlugin(test.Ctx, "", clusterA, test.WithCluster(clusterA), test.WithPluginOptionValue("option-1", test.MustReturnJSONFor(1)), test.WithPluginLabel(greenhouseapis.LabelKeyOwnedBy, testTeam.Name)),
 		),
 		Entry("with defined pluginPresetOverrides and plugin has two options",
-			test.NewPlugin(test.Ctx, "", clusterA, test.WithCluster(clusterA), test.WithPluginOptionValue("option-1", test.MustReturnJSONFor(1), nil), test.WithPluginOptionValue("option-2", test.MustReturnJSONFor(1), nil), test.WithPluginLabel(greenhouseapis.LabelKeyOwnedBy, testTeam.Name)),
+			test.NewPlugin(test.Ctx, "", clusterA, test.WithCluster(clusterA), test.WithPluginOptionValue("option-1", test.MustReturnJSONFor(1)), test.WithPluginOptionValue("option-2", test.MustReturnJSONFor(1)), test.WithPluginLabel(greenhouseapis.LabelKeyOwnedBy, testTeam.Name)),
 			&greenhousev1alpha1.PluginPreset{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{greenhouseapis.LabelKeyOwnedBy: testTeam.Name},
@@ -1091,13 +1091,13 @@ var _ = Describe("overridesPluginOptionValues", Ordered, func() {
 					},
 				},
 			},
-			test.NewPlugin(test.Ctx, "", clusterA, test.WithCluster(clusterA), test.WithPluginOptionValue("option-1", test.MustReturnJSONFor(1), nil), test.WithPluginOptionValue("option-2", test.MustReturnJSONFor(2), nil), test.WithPluginLabel(greenhouseapis.LabelKeyOwnedBy, testTeam.Name)),
+			test.NewPlugin(test.Ctx, "", clusterA, test.WithCluster(clusterA), test.WithPluginOptionValue("option-1", test.MustReturnJSONFor(1)), test.WithPluginOptionValue("option-2", test.MustReturnJSONFor(2)), test.WithPluginLabel(greenhouseapis.LabelKeyOwnedBy, testTeam.Name)),
 		),
 		Entry("with defined pluginPresetOverrides has multiple options to override",
 			test.NewPlugin(test.Ctx, "", clusterA, test.WithCluster(clusterA),
-				test.WithPluginOptionValue("option-1", test.MustReturnJSONFor(1), nil),
-				test.WithPluginOptionValue("option-2", test.MustReturnJSONFor(1), nil),
-				test.WithPluginOptionValue("option-3", test.MustReturnJSONFor(1), nil),
+				test.WithPluginOptionValue("option-1", test.MustReturnJSONFor(1)),
+				test.WithPluginOptionValue("option-2", test.MustReturnJSONFor(1)),
+				test.WithPluginOptionValue("option-3", test.MustReturnJSONFor(1)),
 				test.WithPluginLabel(greenhouseapis.LabelKeyOwnedBy, testTeam.Name)),
 			&greenhousev1alpha1.PluginPreset{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1126,10 +1126,10 @@ var _ = Describe("overridesPluginOptionValues", Ordered, func() {
 				},
 			},
 			test.NewPlugin(test.Ctx, "", clusterA, test.WithCluster(clusterA), test.WithPluginLabel(greenhouseapis.LabelKeyOwnedBy, testTeam.Name),
-				test.WithPluginOptionValue("option-1", test.MustReturnJSONFor(1), nil),
-				test.WithPluginOptionValue("option-2", test.MustReturnJSONFor(2), nil),
-				test.WithPluginOptionValue("option-3", test.MustReturnJSONFor(2), nil),
-				test.WithPluginOptionValue("option-4", test.MustReturnJSONFor(2), nil)),
+				test.WithPluginOptionValue("option-1", test.MustReturnJSONFor(1)),
+				test.WithPluginOptionValue("option-2", test.MustReturnJSONFor(2)),
+				test.WithPluginOptionValue("option-3", test.MustReturnJSONFor(2)),
+				test.WithPluginOptionValue("option-4", test.MustReturnJSONFor(2))),
 		),
 	)
 })

--- a/internal/controller/plugin/remote_cluster_test.go
+++ b/internal/controller/plugin/remote_cluster_test.go
@@ -47,7 +47,7 @@ var (
 		test.WithCluster("test-cluster"),
 		test.WithPluginDefinition("test-plugindefinition"),
 		test.WithReleaseName("release-with-secretref"),
-		test.WithPluginOptionValue("secretValue", nil, &greenhousev1alpha1.ValueFromSource{
+		test.WithPluginOptionValueFrom("secretValue", &greenhousev1alpha1.ValueFromSource{
 			Secret: &greenhousev1alpha1.SecretKeyReference{
 				Name: "test-secret",
 				Key:  "test-key",

--- a/internal/controller/plugin/suite_test.go
+++ b/internal/controller/plugin/suite_test.go
@@ -173,7 +173,7 @@ var _ = Describe("HelmControllerTest", Serial, func() {
 			test.WithPluginDefinition(PluginDefinitionName),
 			test.WithPluginLabel(greenhouseapis.LabelKeyOwnedBy, testTeam.Name),
 			test.WithReleaseName(ReleaseName),
-			test.WithPluginOptionValue(PluginOptionRequired, test.MustReturnJSONFor(PluginRequiredOptionValue), nil))
+			test.WithPluginOptionValue(PluginOptionRequired, test.MustReturnJSONFor(PluginRequiredOptionValue)))
 
 		Expect(test.K8sClient.Create(test.Ctx, testPlugin)).Should(Succeed())
 
@@ -499,11 +499,11 @@ var _ = Describe("HelmControllerTest", Serial, func() {
 				test.WithPluginLabel(greenhouseapis.LabelKeyOwnedBy, testTeam.Name),
 				test.WithPluginDefinition(pluginWithEveryOption),
 				test.WithReleaseName(ReleaseName),
-				test.WithPluginOptionValue(PluginOptionDefault, test.MustReturnJSONFor(stringVal), nil),
-				test.WithPluginOptionValue(PluginOptionBool, test.MustReturnJSONFor(boolVal), nil),
-				test.WithPluginOptionValue(PluginOptionInt, test.MustReturnJSONFor(intVal), nil),
-				test.WithPluginOptionValue(PluginOptionList, test.MustReturnJSONFor(listVal), nil),
-				test.WithPluginOptionValue(PluginOptionMap, test.MustReturnJSONFor(mapVal), nil),
+				test.WithPluginOptionValue(PluginOptionDefault, test.MustReturnJSONFor(stringVal)),
+				test.WithPluginOptionValue(PluginOptionBool, test.MustReturnJSONFor(boolVal)),
+				test.WithPluginOptionValue(PluginOptionInt, test.MustReturnJSONFor(intVal)),
+				test.WithPluginOptionValue(PluginOptionList, test.MustReturnJSONFor(listVal)),
+				test.WithPluginOptionValue(PluginOptionMap, test.MustReturnJSONFor(mapVal)),
 			)
 
 			Expect(test.K8sClient.Create(test.Ctx, complexPlugin)).Should(Succeed())
@@ -549,7 +549,7 @@ var _ = Describe("HelmControllerTest", Serial, func() {
 		plugin := test.NewPlugin(test.Ctx, "testPlugin", Namespace,
 			test.WithPluginDefinition("testPlugin"),
 			test.WithReleaseName(ReleaseName),
-			test.WithPluginOptionValue(option, test.MustReturnJSONFor(value), nil))
+			test.WithPluginOptionValue(option, test.MustReturnJSONFor(value)))
 		Expect(test.K8sClient.Create(test.Ctx, plugin)).Should(Not(Succeed()), "creating a plugin with wrong types should not be successful")
 	},
 		Entry("string with wrong type", PluginOptionRequired, 1),

--- a/internal/helm/diff_test.go
+++ b/internal/helm/diff_test.go
@@ -46,7 +46,7 @@ var _ = Describe("ensure helm diff against the release manifest works as expecte
 		pluginUT = test.NewPlugin(test.Ctx, "test-plugin", namespace,
 			test.WithPluginLabel(greenhouseapis.LabelKeyOwnedBy, "test-team-1"),
 			test.WithPluginDefinition("test-plugindefinition"),
-			test.WithPluginOptionValue("enabled", test.MustReturnJSONFor(true), nil),
+			test.WithPluginOptionValue("enabled", test.MustReturnJSONFor(true)),
 			test.WithReleaseNamespace(namespace),
 		)
 
@@ -178,7 +178,7 @@ var _ = Describe("ensure helm with hooks diff against the release manifest works
 		pluginUT = test.NewPlugin(test.Ctx, "test-plugin", namespace,
 			test.WithPluginLabel(greenhouseapis.LabelKeyOwnedBy, "test-team-1"),
 			test.WithPluginDefinition("test-plugindefinition"),
-			test.WithPluginOptionValue("hook_enabled", test.MustReturnJSONFor(false), nil),
+			test.WithPluginOptionValue("hook_enabled", test.MustReturnJSONFor(false)),
 			test.WithReleaseNamespace(namespace),
 		)
 

--- a/internal/helm/helm_test.go
+++ b/internal/helm/helm_test.go
@@ -255,7 +255,7 @@ var _ = DescribeTable("getting helm values from Plugin", func(defaultValue any, 
 	pluginWithOptionValue := test.NewPlugin(test.Ctx, "green", "house",
 		test.WithPluginLabel(greenhouseapis.LabelKeyOwnedBy, "test-team-1"),
 		test.WithPluginDefinition("greenhouse"),
-		test.WithPluginOptionValue("value1", test.MustReturnJSONFor(defaultValue), nil),
+		test.WithPluginOptionValue("value1", test.MustReturnJSONFor(defaultValue)),
 	)
 
 	helmValues, err := helm.ExportGetValuesForHelmChart(context.Background(), test.K8sClient, helmChart, pluginWithOptionValue)

--- a/internal/test/resources.go
+++ b/internal/test/resources.go
@@ -251,16 +251,14 @@ func WithPluginLabel(key, value string) func(*greenhousev1alpha1.Plugin) {
 	}
 }
 
-// WithPluginOptionValue sets the value of a PluginOptionValue
-func WithPluginOptionValue(name string, value *apiextensionsv1.JSON, valueFrom *greenhousev1alpha1.ValueFromSource) func(*greenhousev1alpha1.Plugin) {
+// WithPluginOptionValue sets the value of a PluginOptionValue, clears ValueFrom and Template
+func WithPluginOptionValue(name string, value *apiextensionsv1.JSON) func(*greenhousev1alpha1.Plugin) {
 	return func(p *greenhousev1alpha1.Plugin) {
-		if value != nil && valueFrom != nil {
-			Fail("value and valueFrom are mutually exclusive")
-		}
 		for i, v := range p.Spec.OptionValues {
 			if v.Name == name {
 				v.Value = value
-				v.ValueFrom = valueFrom
+				v.ValueFrom = nil
+				v.Template = nil
 				p.Spec.OptionValues[i] = v
 				return
 			}
@@ -268,7 +266,50 @@ func WithPluginOptionValue(name string, value *apiextensionsv1.JSON, valueFrom *
 		p.Spec.OptionValues = append(p.Spec.OptionValues, greenhousev1alpha1.PluginOptionValue{
 			Name:      name,
 			Value:     value,
+			ValueFrom: nil,
+			Template:  nil,
+		})
+	}
+}
+
+// WithPluginOptionValue sets the value of a PluginOptionValue, clears Value and Template
+func WithPluginOptionValueFrom(name string, valueFrom *greenhousev1alpha1.ValueFromSource) func(*greenhousev1alpha1.Plugin) {
+	return func(p *greenhousev1alpha1.Plugin) {
+		for i, v := range p.Spec.OptionValues {
+			if v.Name == name {
+				v.Value = nil
+				v.ValueFrom = valueFrom
+				v.Template = nil
+				p.Spec.OptionValues[i] = v
+				return
+			}
+		}
+		p.Spec.OptionValues = append(p.Spec.OptionValues, greenhousev1alpha1.PluginOptionValue{
+			Name:      name,
+			Value:     nil,
 			ValueFrom: valueFrom,
+			Template:  nil,
+		})
+	}
+}
+
+// WithPluginOptionValue sets the template of a PluginOptionValue,
+func WithPluginOptionValueTemplate(name string, template *string) func(*greenhousev1alpha1.Plugin) {
+	return func(p *greenhousev1alpha1.Plugin) {
+		for i, v := range p.Spec.OptionValues {
+			if v.Name == name {
+				v.Value = nil
+				v.Template = template
+				v.ValueFrom = nil
+				p.Spec.OptionValues[i] = v
+				return
+			}
+		}
+		p.Spec.OptionValues = append(p.Spec.OptionValues, greenhousev1alpha1.PluginOptionValue{
+			Name:      name,
+			Value:     nil,
+			Template:  template,
+			ValueFrom: nil,
 		})
 	}
 }

--- a/internal/webhook/v1alpha1/plugin_webhook_test.go
+++ b/internal/webhook/v1alpha1/plugin_webhook_test.go
@@ -301,6 +301,30 @@ var _ = Describe("Validate plugin spec fields", Ordered, func() {
 		expectClusterNotFoundError(test.K8sClient.Create(test.Ctx, testPlugin))
 	})
 
+	It("should keep the template field when merging option values", func() {
+		By("creating the plugin")
+		testPlugin = setup.CreatePlugin(test.Ctx, "test-plugin",
+			test.WithPluginDefinition(testPluginDefinition.Name),
+			test.WithCluster(testCluster.Name),
+			test.WithReleaseNamespace("test-namespace"),
+			test.WithReleaseName("test-release"),
+			test.WithPluginLabel(greenhouseapis.LabelKeyOwnedBy, team.Name),
+			test.WithPluginOptionValueTemplate("templateOption", ptr.To("{{ .global.greenhouse.clusterName }}")))
+
+		By("checking that the label is kept after merging options and optionvalues")
+		actPlugin := &greenhousev1alpha1.Plugin{}
+		err := test.K8sClient.Get(test.Ctx, types.NamespacedName{Name: testPlugin.Name, Namespace: testPlugin.Namespace}, actPlugin)
+		Expect(err).ToNot(HaveOccurred(), "there should be no error getting the plugin")
+		Eventually(func() bool {
+			for _, actOption := range actPlugin.Spec.OptionValues {
+				if actOption.Name == "templateOption" {
+					return actOption.Template != nil
+				}
+			}
+			return false
+		}).Should(BeTrue(), "the plugin should have the template field set on the optionValue")
+	})
+
 	It("should accept the plugin when the cluster with clusterName exists", func() {
 		By("creating the plugin")
 		testPlugin = setup.CreatePlugin(test.Ctx, "test-plugin",


### PR DESCRIPTION

<!--
Please ensure the PR title follows the conventional commit format:
<type>(<scope>): description

For a list of accepted types and scopes see the workflow documentation: https://github.com/cloudoperators/greenhouse/blob/main/.github/workflows/ci-pr-title.yaml

-->

## Description

dedicated methods for value, valuefrom, template to avoid unnecessary setting of nil values.
method never allowed setting both value, valueFrom


## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [x] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 

- Related Issue # (issue)
- Closes # (issue)
- Fixes # (issue)

-->

## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [ ] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
