### PR TITLE
refactor(tests): consolidate apiextensionv1.JSON helper funcs

### DIFF
--- a/internal/controller/flux/plugin_controller_test.go
+++ b/internal/controller/flux/plugin_controller_test.go
@@ -52,8 +52,8 @@ var (
 		test.WithReleaseName("release-test"),
 		test.WithReleaseNamespace(test.TestNamespace),
 		test.WithPluginLabel(greenhouseapis.LabelKeyOwnedBy, testTeam.Name),
-		test.WithPluginOptionValue("flatOption", test.AsAPIExtensionJSON("flatValue"), nil),
-		test.WithPluginOptionValue("nested.option", test.AsAPIExtensionJSON("nestedValue"), nil),
+		test.WithPluginOptionValue("flatOption", test.MustReturnJSONFor("flatValue"), nil),
+		test.WithPluginOptionValue("nested.option", test.MustReturnJSONFor("nestedValue"), nil),
 		test.WithPluginOptionValue("nested.secretOption", nil, &greenhousev1alpha1.ValueFromSource{
 			Secret: &greenhousev1alpha1.SecretKeyReference{
 				Name: "test-cluster",
@@ -69,13 +69,13 @@ var (
 			greenhousev1alpha1.PluginOption{
 				Name:    "flatOptionDefault",
 				Type:    greenhousev1alpha1.PluginOptionTypeString,
-				Default: test.AsAPIExtensionJSON("flatDefault"),
+				Default: test.MustReturnJSONFor("flatDefault"),
 			}),
 		test.AppendPluginOption(
 			greenhousev1alpha1.PluginOption{
 				Name:    "nested.optionDefault",
 				Type:    greenhousev1alpha1.PluginOptionTypeString,
-				Default: test.AsAPIExtensionJSON("nestedDefault"),
+				Default: test.MustReturnJSONFor("nestedDefault"),
 			},
 		),
 	)

--- a/internal/controller/plugin/pluginpreset_controller_test.go
+++ b/internal/controller/plugin/pluginpreset_controller_test.go
@@ -598,7 +598,7 @@ var _ = Describe("Plugin Preset skip changes", Ordered, func() {
 				test.WithPresetLabelValue(pluginPresetName),
 				test.WithPluginDefinition(pluginPresetDefinitionName),
 				test.WithPluginOptionValue("global.greenhouse.test_parameter",
-					test.AsAPIExtensionJSON(2), nil),
+					test.MustReturnJSONFor(2), nil),
 			),
 			&greenhousev1alpha1.PluginPreset{
 				ObjectMeta: metav1.ObjectMeta{
@@ -610,7 +610,7 @@ var _ = Describe("Plugin Preset skip changes", Ordered, func() {
 						OptionValues: []greenhousev1alpha1.PluginOptionValue{
 							{
 								Name:  "plugin_preset.test_parameter",
-								Value: test.AsAPIExtensionJSON(3),
+								Value: test.MustReturnJSONFor(3),
 							},
 						},
 					},
@@ -625,9 +625,9 @@ var _ = Describe("Plugin Preset skip changes", Ordered, func() {
 				test.WithPresetLabelValue(pluginPresetName),
 				test.WithPluginDefinition(pluginPresetDefinitionName),
 				test.WithPluginOptionValue("global.greenhouse.test_parameter",
-					test.AsAPIExtensionJSON(2), nil),
+					test.MustReturnJSONFor(2), nil),
 				test.WithPluginOptionValue("plugin_preset.test_parameter",
-					test.AsAPIExtensionJSON(2), nil),
+					test.MustReturnJSONFor(2), nil),
 			),
 			&greenhousev1alpha1.PluginPreset{
 				ObjectMeta: metav1.ObjectMeta{
@@ -639,7 +639,7 @@ var _ = Describe("Plugin Preset skip changes", Ordered, func() {
 						OptionValues: []greenhousev1alpha1.PluginOptionValue{
 							{
 								Name:  "plugin_preset.test_parameter",
-								Value: test.AsAPIExtensionJSON(3),
+								Value: test.MustReturnJSONFor(3),
 							},
 						},
 					},
@@ -654,13 +654,13 @@ var _ = Describe("Plugin Preset skip changes", Ordered, func() {
 				test.WithPresetLabelValue(pluginPresetName),
 				test.WithPluginDefinition(pluginPresetDefinitionName),
 				test.WithPluginOptionValue("global.greenhouse.test_parameter",
-					test.AsAPIExtensionJSON(2), nil),
+					test.MustReturnJSONFor(2), nil),
 				test.WithPluginOptionValue("plugin_preset.test_parameter_1",
-					test.AsAPIExtensionJSON(1), nil),
+					test.MustReturnJSONFor(1), nil),
 				test.WithPluginOptionValue("plugin_preset.test_parameter_2",
-					test.AsAPIExtensionJSON(2), nil),
+					test.MustReturnJSONFor(2), nil),
 				test.WithPluginOptionValue("plugin_preset.test_parameter_4",
-					test.AsAPIExtensionJSON(3), nil),
+					test.MustReturnJSONFor(3), nil),
 			),
 			&greenhousev1alpha1.PluginPreset{
 				ObjectMeta: metav1.ObjectMeta{
@@ -672,15 +672,15 @@ var _ = Describe("Plugin Preset skip changes", Ordered, func() {
 						OptionValues: []greenhousev1alpha1.PluginOptionValue{
 							{
 								Name:  "plugin_preset.test_parameter_1",
-								Value: test.AsAPIExtensionJSON(1),
+								Value: test.MustReturnJSONFor(1),
 							},
 							{
 								Name:  "plugin_preset.test_parameter_2",
-								Value: test.AsAPIExtensionJSON(2),
+								Value: test.MustReturnJSONFor(2),
 							},
 							{
 								Name:  "plugin_preset.test_parameter_4",
-								Value: test.AsAPIExtensionJSON(4),
+								Value: test.MustReturnJSONFor(4),
 							},
 						},
 					},
@@ -695,9 +695,9 @@ var _ = Describe("Plugin Preset skip changes", Ordered, func() {
 				test.WithPresetLabelValue(pluginPresetName),
 				test.WithPluginDefinition(pluginPresetDefinitionName),
 				test.WithPluginOptionValue("global.greenhouse.test_parameter",
-					test.AsAPIExtensionJSON(2), nil),
+					test.MustReturnJSONFor(2), nil),
 				test.WithPluginOptionValue("plugin_preset.test_parameter",
-					test.AsAPIExtensionJSON(3), nil),
+					test.MustReturnJSONFor(3), nil),
 			),
 			&greenhousev1alpha1.PluginPreset{
 				ObjectMeta: metav1.ObjectMeta{
@@ -709,7 +709,7 @@ var _ = Describe("Plugin Preset skip changes", Ordered, func() {
 						OptionValues: []greenhousev1alpha1.PluginOptionValue{
 							{
 								Name:  "plugin_preset.test_parameter",
-								Value: test.AsAPIExtensionJSON(3),
+								Value: test.MustReturnJSONFor(3),
 							},
 						},
 					},
@@ -724,11 +724,11 @@ var _ = Describe("Plugin Preset skip changes", Ordered, func() {
 				test.WithPresetLabelValue(pluginPresetName),
 				test.WithPluginDefinition(pluginPresetDefinitionName),
 				test.WithPluginOptionValue("global.greenhouse.test_parameter",
-					test.AsAPIExtensionJSON(2), nil),
+					test.MustReturnJSONFor(2), nil),
 				test.WithPluginOptionValue("plugin_preset.test_parameter",
-					test.AsAPIExtensionJSON(3), nil),
+					test.MustReturnJSONFor(3), nil),
 				test.WithPluginOptionValue("custom_parameter",
-					test.AsAPIExtensionJSON(123), nil),
+					test.MustReturnJSONFor(123), nil),
 			),
 			&greenhousev1alpha1.PluginPreset{
 				ObjectMeta: metav1.ObjectMeta{
@@ -740,7 +740,7 @@ var _ = Describe("Plugin Preset skip changes", Ordered, func() {
 						OptionValues: []greenhousev1alpha1.PluginOptionValue{
 							{
 								Name:  "plugin_preset.test_parameter",
-								Value: test.AsAPIExtensionJSON(3),
+								Value: test.MustReturnJSONFor(3),
 							},
 						},
 					},
@@ -755,9 +755,9 @@ var _ = Describe("Plugin Preset skip changes", Ordered, func() {
 				test.WithPresetLabelValue(pluginPresetName),
 				test.WithPluginDefinition(pluginPresetDefinitionName),
 				test.WithPluginOptionValue("global.greenhouse.test_parameter",
-					test.AsAPIExtensionJSON(2), nil),
+					test.MustReturnJSONFor(2), nil),
 				test.WithPluginOptionValue("plugin_definition.test_parameter",
-					test.AsAPIExtensionJSON(3), nil),
+					test.MustReturnJSONFor(3), nil),
 			),
 			&greenhousev1alpha1.PluginPreset{
 				ObjectMeta: metav1.ObjectMeta{
@@ -778,7 +778,7 @@ var _ = Describe("Plugin Preset skip changes", Ordered, func() {
 					Options: []greenhousev1alpha1.PluginOption{
 						{
 							Name:    "plugin_definition.test_parameter",
-							Default: test.AsAPIExtensionJSON(3),
+							Default: test.MustReturnJSONFor(3),
 						},
 					},
 				},
@@ -791,9 +791,9 @@ var _ = Describe("Plugin Preset skip changes", Ordered, func() {
 				test.WithPresetLabelValue(pluginPresetName),
 				test.WithPluginDefinition(pluginPresetDefinitionName),
 				test.WithPluginOptionValue("global.greenhouse.test_parameter",
-					test.AsAPIExtensionJSON(2), nil),
+					test.MustReturnJSONFor(2), nil),
 				test.WithPluginOptionValue("plugin_definition.test_parameter",
-					test.AsAPIExtensionJSON(3), nil),
+					test.MustReturnJSONFor(3), nil),
 			),
 			&greenhousev1alpha1.PluginPreset{
 				ObjectMeta: metav1.ObjectMeta{
@@ -814,7 +814,7 @@ var _ = Describe("Plugin Preset skip changes", Ordered, func() {
 					Options: []greenhousev1alpha1.PluginOption{
 						{
 							Name:    "plugin_definition.test_parameter",
-							Default: test.AsAPIExtensionJSON(4),
+							Default: test.MustReturnJSONFor(4),
 						},
 					},
 				},
@@ -826,7 +826,7 @@ var _ = Describe("Plugin Preset skip changes", Ordered, func() {
 				test.WithPresetLabelValue(pluginPresetName),
 				test.WithPluginDefinition(pluginPresetDefinitionName),
 				test.WithPluginOptionValue("global.greenhouse.test_parameter",
-					test.AsAPIExtensionJSON(2), nil),
+					test.MustReturnJSONFor(2), nil),
 				test.WithPluginOptionValue("plugin_definition.test_parameter",
 					nil, &greenhousev1alpha1.ValueFromSource{
 						Secret: &greenhousev1alpha1.SecretKeyReference{
@@ -854,7 +854,7 @@ var _ = Describe("Plugin Preset skip changes", Ordered, func() {
 					Options: []greenhousev1alpha1.PluginOption{
 						{
 							Name:    "plugin_definition.test_parameter",
-							Default: test.AsAPIExtensionJSON(4),
+							Default: test.MustReturnJSONFor(4),
 						},
 					},
 				},
@@ -866,7 +866,7 @@ var _ = Describe("Plugin Preset skip changes", Ordered, func() {
 				test.WithPresetLabelValue(pluginPresetName),
 				test.WithPluginDefinition(pluginPresetDefinitionName),
 				test.WithPluginOptionValue("global.greenhouse.test_parameter",
-					test.AsAPIExtensionJSON(2), nil),
+					test.MustReturnJSONFor(2), nil),
 				test.WithPluginOptionValue("plugin_definition.test_parameter",
 					nil, &greenhousev1alpha1.ValueFromSource{
 						Secret: &greenhousev1alpha1.SecretKeyReference{
@@ -903,7 +903,7 @@ var _ = Describe("Plugin Preset skip changes", Ordered, func() {
 					Options: []greenhousev1alpha1.PluginOption{
 						{
 							Name:    "plugin_definition.test_parameter",
-							Default: test.AsAPIExtensionJSON(4),
+							Default: test.MustReturnJSONFor(4),
 						},
 					},
 				},
@@ -915,7 +915,7 @@ var _ = Describe("Plugin Preset skip changes", Ordered, func() {
 				test.WithPresetLabelValue(pluginPresetName),
 				test.WithPluginDefinition(pluginPresetDefinitionName),
 				test.WithPluginOptionValue("global.greenhouse.test_parameter",
-					test.AsAPIExtensionJSON(2), nil),
+					test.MustReturnJSONFor(2), nil),
 			),
 			&greenhousev1alpha1.PluginPreset{
 				ObjectMeta: metav1.ObjectMeta{
@@ -927,7 +927,7 @@ var _ = Describe("Plugin Preset skip changes", Ordered, func() {
 						OptionValues: []greenhousev1alpha1.PluginOptionValue{
 							{
 								Name:  "global.greenhouse.test_parameter",
-								Value: test.AsAPIExtensionJSON(2),
+								Value: test.MustReturnJSONFor(2),
 							},
 						},
 					},
@@ -937,7 +937,7 @@ var _ = Describe("Plugin Preset skip changes", Ordered, func() {
 							Overrides: []greenhousev1alpha1.PluginOptionValue{
 								{
 									Name:  "global.greenhouse.test_parameter",
-									Value: test.AsAPIExtensionJSON(3),
+									Value: test.MustReturnJSONFor(3),
 								},
 							},
 						},
@@ -952,7 +952,7 @@ var _ = Describe("Plugin Preset skip changes", Ordered, func() {
 				test.WithPresetLabelValue(pluginPresetName),
 				test.WithPluginDefinition(pluginPresetDefinitionName),
 				test.WithPluginOptionValue("global.greenhouse.test_parameter",
-					test.AsAPIExtensionJSON(2), nil),
+					test.MustReturnJSONFor(2), nil),
 			),
 			&greenhousev1alpha1.PluginPreset{
 				ObjectMeta: metav1.ObjectMeta{
@@ -964,7 +964,7 @@ var _ = Describe("Plugin Preset skip changes", Ordered, func() {
 						OptionValues: []greenhousev1alpha1.PluginOptionValue{
 							{
 								Name:  "global.greenhouse.test_parameter",
-								Value: test.AsAPIExtensionJSON(2),
+								Value: test.MustReturnJSONFor(2),
 							},
 						},
 					},
@@ -974,7 +974,7 @@ var _ = Describe("Plugin Preset skip changes", Ordered, func() {
 							Overrides: []greenhousev1alpha1.PluginOptionValue{
 								{
 									Name:  "global.greenhouse.test_parameter",
-									Value: test.AsAPIExtensionJSON(3),
+									Value: test.MustReturnJSONFor(3),
 								},
 							},
 						},
@@ -994,18 +994,18 @@ var _ = Describe("overridesPluginOptionValues", Ordered, func() {
 		Expect(plugin).To(BeEquivalentTo(expectedPlugin))
 	},
 		Entry("with no defined pluginPresetOverrides",
-			test.NewPlugin(test.Ctx, "", "", test.WithPluginOptionValue("option-1", test.AsAPIExtensionJSON(2), nil), test.WithPluginLabel(greenhouseapis.LabelKeyOwnedBy, testTeam.Name)),
+			test.NewPlugin(test.Ctx, "", "", test.WithPluginOptionValue("option-1", test.MustReturnJSONFor(2), nil), test.WithPluginLabel(greenhouseapis.LabelKeyOwnedBy, testTeam.Name)),
 			&greenhousev1alpha1.PluginPreset{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{greenhouseapis.LabelKeyOwnedBy: testTeam.Name},
 				},
 				Spec: greenhousev1alpha1.PluginPresetSpec{},
 			},
-			test.NewPlugin(test.Ctx, "", "", test.WithPluginOptionValue("option-1", test.AsAPIExtensionJSON(2), nil), test.WithPluginLabel(greenhouseapis.LabelKeyOwnedBy, testTeam.Name)),
+			test.NewPlugin(test.Ctx, "", "", test.WithPluginOptionValue("option-1", test.MustReturnJSONFor(2), nil), test.WithPluginLabel(greenhouseapis.LabelKeyOwnedBy, testTeam.Name)),
 		),
 		Entry("with defined pluginPresetOverrides but for another cluster",
 			test.NewPlugin(test.Ctx, "", clusterA, test.WithPluginLabel(greenhouseapis.LabelKeyOwnedBy, testTeam.Name),
-				test.WithCluster(clusterA), test.WithPluginOptionValue("option-1", test.AsAPIExtensionJSON(2), nil)),
+				test.WithCluster(clusterA), test.WithPluginOptionValue("option-1", test.MustReturnJSONFor(2), nil)),
 			&greenhousev1alpha1.PluginPreset{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{greenhouseapis.LabelKeyOwnedBy: testTeam.Name},
@@ -1017,7 +1017,7 @@ var _ = Describe("overridesPluginOptionValues", Ordered, func() {
 							Overrides: []greenhousev1alpha1.PluginOptionValue{
 								{
 									Name:  "option-1",
-									Value: test.AsAPIExtensionJSON(1),
+									Value: test.MustReturnJSONFor(1),
 								},
 							},
 						},
@@ -1025,10 +1025,10 @@ var _ = Describe("overridesPluginOptionValues", Ordered, func() {
 				},
 			},
 			test.NewPlugin(test.Ctx, "", clusterA, test.WithPluginLabel(greenhouseapis.LabelKeyOwnedBy, testTeam.Name),
-				test.WithCluster(clusterA), test.WithPluginOptionValue("option-1", test.AsAPIExtensionJSON(2), nil)),
+				test.WithCluster(clusterA), test.WithPluginOptionValue("option-1", test.MustReturnJSONFor(2), nil)),
 		),
 		Entry("with defined pluginPresetOverrides for the correct cluster",
-			test.NewPlugin(test.Ctx, "", clusterA, test.WithCluster(clusterA), test.WithPluginOptionValue("option-1", test.AsAPIExtensionJSON(2), nil), test.WithPluginLabel(greenhouseapis.LabelKeyOwnedBy, testTeam.Name)),
+			test.NewPlugin(test.Ctx, "", clusterA, test.WithCluster(clusterA), test.WithPluginOptionValue("option-1", test.MustReturnJSONFor(2), nil), test.WithPluginLabel(greenhouseapis.LabelKeyOwnedBy, testTeam.Name)),
 			&greenhousev1alpha1.PluginPreset{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{greenhouseapis.LabelKeyOwnedBy: testTeam.Name},
@@ -1040,14 +1040,14 @@ var _ = Describe("overridesPluginOptionValues", Ordered, func() {
 							Overrides: []greenhousev1alpha1.PluginOptionValue{
 								{
 									Name:  "option-1",
-									Value: test.AsAPIExtensionJSON(1),
+									Value: test.MustReturnJSONFor(1),
 								},
 							},
 						},
 					},
 				},
 			},
-			test.NewPlugin(test.Ctx, "", clusterA, test.WithCluster(clusterA), test.WithPluginOptionValue("option-1", test.AsAPIExtensionJSON(1), nil), test.WithPluginLabel(greenhouseapis.LabelKeyOwnedBy, testTeam.Name)),
+			test.NewPlugin(test.Ctx, "", clusterA, test.WithCluster(clusterA), test.WithPluginOptionValue("option-1", test.MustReturnJSONFor(1), nil), test.WithPluginLabel(greenhouseapis.LabelKeyOwnedBy, testTeam.Name)),
 		),
 		Entry("with defined pluginPresetOverrides for the cluster and plugin with empty option values",
 			test.NewPlugin(test.Ctx, "", clusterA, test.WithCluster(clusterA), test.WithPluginLabel(greenhouseapis.LabelKeyOwnedBy, testTeam.Name)),
@@ -1062,17 +1062,17 @@ var _ = Describe("overridesPluginOptionValues", Ordered, func() {
 							Overrides: []greenhousev1alpha1.PluginOptionValue{
 								{
 									Name:  "option-1",
-									Value: test.AsAPIExtensionJSON(1),
+									Value: test.MustReturnJSONFor(1),
 								},
 							},
 						},
 					},
 				},
 			},
-			test.NewPlugin(test.Ctx, "", clusterA, test.WithCluster(clusterA), test.WithPluginOptionValue("option-1", test.AsAPIExtensionJSON(1), nil), test.WithPluginLabel(greenhouseapis.LabelKeyOwnedBy, testTeam.Name)),
+			test.NewPlugin(test.Ctx, "", clusterA, test.WithCluster(clusterA), test.WithPluginOptionValue("option-1", test.MustReturnJSONFor(1), nil), test.WithPluginLabel(greenhouseapis.LabelKeyOwnedBy, testTeam.Name)),
 		),
 		Entry("with defined pluginPresetOverrides and plugin has two options",
-			test.NewPlugin(test.Ctx, "", clusterA, test.WithCluster(clusterA), test.WithPluginOptionValue("option-1", test.AsAPIExtensionJSON(1), nil), test.WithPluginOptionValue("option-2", test.AsAPIExtensionJSON(1), nil), test.WithPluginLabel(greenhouseapis.LabelKeyOwnedBy, testTeam.Name)),
+			test.NewPlugin(test.Ctx, "", clusterA, test.WithCluster(clusterA), test.WithPluginOptionValue("option-1", test.MustReturnJSONFor(1), nil), test.WithPluginOptionValue("option-2", test.MustReturnJSONFor(1), nil), test.WithPluginLabel(greenhouseapis.LabelKeyOwnedBy, testTeam.Name)),
 			&greenhousev1alpha1.PluginPreset{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{greenhouseapis.LabelKeyOwnedBy: testTeam.Name},
@@ -1084,20 +1084,20 @@ var _ = Describe("overridesPluginOptionValues", Ordered, func() {
 							Overrides: []greenhousev1alpha1.PluginOptionValue{
 								{
 									Name:  "option-2",
-									Value: test.AsAPIExtensionJSON(2),
+									Value: test.MustReturnJSONFor(2),
 								},
 							},
 						},
 					},
 				},
 			},
-			test.NewPlugin(test.Ctx, "", clusterA, test.WithCluster(clusterA), test.WithPluginOptionValue("option-1", test.AsAPIExtensionJSON(1), nil), test.WithPluginOptionValue("option-2", test.AsAPIExtensionJSON(2), nil), test.WithPluginLabel(greenhouseapis.LabelKeyOwnedBy, testTeam.Name)),
+			test.NewPlugin(test.Ctx, "", clusterA, test.WithCluster(clusterA), test.WithPluginOptionValue("option-1", test.MustReturnJSONFor(1), nil), test.WithPluginOptionValue("option-2", test.MustReturnJSONFor(2), nil), test.WithPluginLabel(greenhouseapis.LabelKeyOwnedBy, testTeam.Name)),
 		),
 		Entry("with defined pluginPresetOverrides has multiple options to override",
 			test.NewPlugin(test.Ctx, "", clusterA, test.WithCluster(clusterA),
-				test.WithPluginOptionValue("option-1", test.AsAPIExtensionJSON(1), nil),
-				test.WithPluginOptionValue("option-2", test.AsAPIExtensionJSON(1), nil),
-				test.WithPluginOptionValue("option-3", test.AsAPIExtensionJSON(1), nil),
+				test.WithPluginOptionValue("option-1", test.MustReturnJSONFor(1), nil),
+				test.WithPluginOptionValue("option-2", test.MustReturnJSONFor(1), nil),
+				test.WithPluginOptionValue("option-3", test.MustReturnJSONFor(1), nil),
 				test.WithPluginLabel(greenhouseapis.LabelKeyOwnedBy, testTeam.Name)),
 			&greenhousev1alpha1.PluginPreset{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1110,15 +1110,15 @@ var _ = Describe("overridesPluginOptionValues", Ordered, func() {
 							Overrides: []greenhousev1alpha1.PluginOptionValue{
 								{
 									Name:  "option-2",
-									Value: test.AsAPIExtensionJSON(2),
+									Value: test.MustReturnJSONFor(2),
 								},
 								{
 									Name:  "option-3",
-									Value: test.AsAPIExtensionJSON(2),
+									Value: test.MustReturnJSONFor(2),
 								},
 								{
 									Name:  "option-4",
-									Value: test.AsAPIExtensionJSON(2),
+									Value: test.MustReturnJSONFor(2),
 								},
 							},
 						},
@@ -1126,10 +1126,10 @@ var _ = Describe("overridesPluginOptionValues", Ordered, func() {
 				},
 			},
 			test.NewPlugin(test.Ctx, "", clusterA, test.WithCluster(clusterA), test.WithPluginLabel(greenhouseapis.LabelKeyOwnedBy, testTeam.Name),
-				test.WithPluginOptionValue("option-1", test.AsAPIExtensionJSON(1), nil),
-				test.WithPluginOptionValue("option-2", test.AsAPIExtensionJSON(2), nil),
-				test.WithPluginOptionValue("option-3", test.AsAPIExtensionJSON(2), nil),
-				test.WithPluginOptionValue("option-4", test.AsAPIExtensionJSON(2), nil)),
+				test.WithPluginOptionValue("option-1", test.MustReturnJSONFor(1), nil),
+				test.WithPluginOptionValue("option-2", test.MustReturnJSONFor(2), nil),
+				test.WithPluginOptionValue("option-3", test.MustReturnJSONFor(2), nil),
+				test.WithPluginOptionValue("option-4", test.MustReturnJSONFor(2), nil)),
 		),
 	)
 })

--- a/internal/controller/plugin/suite_test.go
+++ b/internal/controller/plugin/suite_test.go
@@ -152,7 +152,7 @@ var _ = Describe("HelmControllerTest", Serial, func() {
 				Name:        PluginOptionDefault,
 				Description: "This is my default test plugin option",
 				Required:    false,
-				Default:     test.AsAPIExtensionJSON(PluginOptionDefaultValue),
+				Default:     test.MustReturnJSONFor(PluginOptionDefaultValue),
 				Type:        greenhousev1alpha1.PluginOptionTypeString,
 			}),
 		)
@@ -173,7 +173,7 @@ var _ = Describe("HelmControllerTest", Serial, func() {
 			test.WithPluginDefinition(PluginDefinitionName),
 			test.WithPluginLabel(greenhouseapis.LabelKeyOwnedBy, testTeam.Name),
 			test.WithReleaseName(ReleaseName),
-			test.WithPluginOptionValue(PluginOptionRequired, test.AsAPIExtensionJSON(PluginRequiredOptionValue), nil))
+			test.WithPluginOptionValue(PluginOptionRequired, test.MustReturnJSONFor(PluginRequiredOptionValue), nil))
 
 		Expect(test.K8sClient.Create(test.Ctx, testPlugin)).Should(Succeed())
 
@@ -412,14 +412,14 @@ var _ = Describe("HelmControllerTest", Serial, func() {
 		Eventually(func() error {
 			return test.K8sClient.Get(test.Ctx, pluginDefinitionID, actPluginDefinition)
 		}).Should(Succeed())
-		Expect(actPluginDefinition.Spec.Options).To(ContainElement(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{"Name": Equal(PluginOptionDefault), "Default": Equal(test.AsAPIExtensionJSON(PluginOptionDefaultValue))})))
+		Expect(actPluginDefinition.Spec.Options).To(ContainElement(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{"Name": Equal(PluginOptionDefault), "Default": Equal(test.MustReturnJSONFor(PluginOptionDefaultValue))})))
 
 		actPlugin := &greenhousev1alpha1.Plugin{}
 		Eventually(func() error {
 			return test.K8sClient.Get(test.Ctx, pluginID, actPlugin)
 		}).Should(Succeed())
 
-		Expect(actPlugin.Spec.OptionValues).To(ContainElement(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{"Name": Equal(PluginOptionDefault), "Value": Equal(test.AsAPIExtensionJSON(PluginOptionDefaultValue))})))
+		Expect(actPlugin.Spec.OptionValues).To(ContainElement(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{"Name": Equal(PluginOptionDefault), "Value": Equal(test.MustReturnJSONFor(PluginOptionDefaultValue))})))
 	})
 
 	It("should successfully create a Plugin with every type of OptionValue", func() {
@@ -449,35 +449,35 @@ var _ = Describe("HelmControllerTest", Serial, func() {
 					Name:        PluginOptionDefault,
 					Description: "This is my default test plugin option",
 					Required:    false,
-					Default:     test.AsAPIExtensionJSON(PluginOptionDefaultValue),
+					Default:     test.MustReturnJSONFor(PluginOptionDefaultValue),
 					Type:        greenhousev1alpha1.PluginOptionTypeString,
 				}),
 				test.AppendPluginOption(greenhousev1alpha1.PluginOption{
 					Name:        PluginOptionBool,
 					Description: "This is my default test plugin option with a bool value",
 					Required:    false,
-					Default:     test.AsAPIExtensionJSON(PluginOptionBoolDefault),
+					Default:     test.MustReturnJSONFor(PluginOptionBoolDefault),
 					Type:        greenhousev1alpha1.PluginOptionTypeBool,
 				}),
 				test.AppendPluginOption(greenhousev1alpha1.PluginOption{
 					Name:        PluginOptionInt,
 					Description: "This is my default test plugin option with an int value",
 					Required:    false,
-					Default:     test.AsAPIExtensionJSON(PluginOptionIntDefault),
+					Default:     test.MustReturnJSONFor(PluginOptionIntDefault),
 					Type:        greenhousev1alpha1.PluginOptionTypeInt,
 				}),
 				test.AppendPluginOption(greenhousev1alpha1.PluginOption{
 					Name:        PluginOptionList,
 					Description: "This is my default test plugin option with a list value",
 					Required:    false,
-					Default:     test.AsAPIExtensionJSON(PluginOptionListDefault),
+					Default:     test.MustReturnJSONFor(PluginOptionListDefault),
 					Type:        greenhousev1alpha1.PluginOptionTypeList,
 				}),
 				test.AppendPluginOption(greenhousev1alpha1.PluginOption{
 					Name:        PluginOptionMap,
 					Description: "This is my default test plugin option with a map value",
 					Required:    false,
-					Default:     test.AsAPIExtensionJSON(PluginOptionMapDefault),
+					Default:     test.MustReturnJSONFor(PluginOptionMapDefault),
 					Type:        greenhousev1alpha1.PluginOptionTypeMap,
 				}),
 			)
@@ -499,11 +499,11 @@ var _ = Describe("HelmControllerTest", Serial, func() {
 				test.WithPluginLabel(greenhouseapis.LabelKeyOwnedBy, testTeam.Name),
 				test.WithPluginDefinition(pluginWithEveryOption),
 				test.WithReleaseName(ReleaseName),
-				test.WithPluginOptionValue(PluginOptionDefault, test.AsAPIExtensionJSON(stringVal), nil),
-				test.WithPluginOptionValue(PluginOptionBool, test.AsAPIExtensionJSON(boolVal), nil),
-				test.WithPluginOptionValue(PluginOptionInt, test.AsAPIExtensionJSON(intVal), nil),
-				test.WithPluginOptionValue(PluginOptionList, test.AsAPIExtensionJSON(listVal), nil),
-				test.WithPluginOptionValue(PluginOptionMap, test.AsAPIExtensionJSON(mapVal), nil),
+				test.WithPluginOptionValue(PluginOptionDefault, test.MustReturnJSONFor(stringVal), nil),
+				test.WithPluginOptionValue(PluginOptionBool, test.MustReturnJSONFor(boolVal), nil),
+				test.WithPluginOptionValue(PluginOptionInt, test.MustReturnJSONFor(intVal), nil),
+				test.WithPluginOptionValue(PluginOptionList, test.MustReturnJSONFor(listVal), nil),
+				test.WithPluginOptionValue(PluginOptionMap, test.MustReturnJSONFor(mapVal), nil),
 			)
 
 			Expect(test.K8sClient.Create(test.Ctx, complexPlugin)).Should(Succeed())
@@ -549,7 +549,7 @@ var _ = Describe("HelmControllerTest", Serial, func() {
 		plugin := test.NewPlugin(test.Ctx, "testPlugin", Namespace,
 			test.WithPluginDefinition("testPlugin"),
 			test.WithReleaseName(ReleaseName),
-			test.WithPluginOptionValue(option, test.AsAPIExtensionJSON(value), nil))
+			test.WithPluginOptionValue(option, test.MustReturnJSONFor(value), nil))
 		Expect(test.K8sClient.Create(test.Ctx, plugin)).Should(Not(Succeed()), "creating a plugin with wrong types should not be successful")
 	},
 		Entry("string with wrong type", PluginOptionRequired, 1),

--- a/internal/controller/plugindefinition/plugindefinition_controller_test.go
+++ b/internal/controller/plugindefinition/plugindefinition_controller_test.go
@@ -62,7 +62,7 @@ func mockPluginDefinition() *greenhousev1alpha1.PluginDefinition {
 			Name:        PluginOptionDefault,
 			Description: "This is my default test plugin option",
 			Required:    false,
-			Default:     test.AsAPIExtensionJSON(PluginOptionDefaultValue),
+			Default:     test.MustReturnJSONFor(PluginOptionDefaultValue),
 			Type:        greenhousev1alpha1.PluginOptionTypeString,
 		}),
 	)

--- a/internal/test/util.go
+++ b/internal/test/util.go
@@ -89,6 +89,7 @@ func SetClusterReadyCondition(ctx context.Context, c client.Client, cluster *gre
 
 // MustReturnJSONFor marshals val to JSON and returns an apiextensionsv1.JSON.
 func MustReturnJSONFor(val any) *apiextensionsv1.JSON {
+	GinkgoHelper()
 	raw, err := json.Marshal(val)
 	Expect(err).ShouldNot(HaveOccurred(), "there should be no error marshalling the value")
 	return &apiextensionsv1.JSON{Raw: raw}
@@ -113,12 +114,4 @@ func KubeconfigFromEnvVar(envVar string) ([]byte, error) {
 		return nil, err
 	}
 	return kubeconfig, nil
-}
-
-// AsAPIExtensionJSON - marshals v into a JSON and returns an apiextensionsv1.JSON object
-func AsAPIExtensionJSON(v any) *apiextensionsv1.JSON {
-	GinkgoHelper()
-	bs, err := json.Marshal(v)
-	Expect(err).ToNot(HaveOccurred(), "error marshalling value")
-	return &apiextensionsv1.JSON{Raw: bs}
 }


### PR DESCRIPTION

<!--
Please ensure the PR title follows the conventional commit format:
<type>(<scope>): description

For a list of accepted types and scopes see the workflow documentation: https://github.com/cloudoperators/greenhouse/blob/main/.github/workflows/ci-pr-title.yaml

-->

## Description

both MustReturnJSONFor and AsAPIExtensionJSON perform the same added GinkgoHelper to the former


## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [x] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 

- Related Issue # (issue)
- Closes # (issue)
- Fixes # (issue)

-->

## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [ ] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
