### PR TITLE
feat(core): add annotation to trigger reconcile

### DIFF
--- a/api/v1alpha1/types_constants.go
+++ b/api/v1alpha1/types_constants.go
@@ -1,0 +1,9 @@
+package v1alpha1
+
+const (
+	// GreenhouseOperation is the annotation used to trigger specific operations on a Greenhouse resource
+	GreenhouseOperation string = "greenhouse.sap/operation"
+
+	// GreenhouseOperationReconcile is the value used to trigger a reconcile operation on a Greenhouse resource
+	GreenhouseOperationReconcile string = "reconcile"
+)

--- a/internal/controller/plugin/pluginpreset_controller.go
+++ b/internal/controller/plugin/pluginpreset_controller.go
@@ -63,6 +63,7 @@ func (r *PluginPresetReconciler) SetupWithManager(name string, mgr ctrl.Manager)
 		Owns(&greenhousev1alpha1.Plugin{}, builder.WithPredicates(
 			predicate.Or(
 				predicate.GenerationChangedPredicate{},
+				predicate.AnnotationChangedPredicate{},
 				clientutil.PredicatePluginWithStatusReadyChange(),
 			))).
 		// Clusters and teams are passed as values to each Helm operation. Reconcile on change.


### PR DESCRIPTION

<!--
Please ensure the PR title follows the conventional commit format:
<type>(<scope>): description

For a list of accepted types and scopes see the workflow documentation: https://github.com/cloudoperators/greenhouse/blob/main/.github/workflows/ci-pr-title.yaml

-->

## Description

The new annotation 'greenhouse.sap/operation' should be used to trigger certain operations on the resources.

First supported operation is `reconcile` which is there to trigger the reconciliation of an object. The handling is added to the central lifecyle package, where the annotation is removed before continuing with the actual reconciliation loop of the respective resource


## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 

- Related Issue # (issue)
- Closes # (issue)
- Fixes # (issue)

-->

## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [x] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [ ] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
