### PR TITLE
feat(plugins): add cluster metadata labels to global.greenhouse

### DIFF
--- a/api/well_known.go
+++ b/api/well_known.go
@@ -60,6 +60,9 @@ const (
 
 	// LabelKeyOwnedBy is used to identify the owning support-group team of a resource.
 	LabelKeyOwnedBy = "greenhouse.sap/owned-by"
+
+	// LabelKeyMetadataPrefix is the prefix for cluster metadata labels that are transferred to Plugin template data.
+	LabelKeyMetadataPrefix = "metadata.greenhouse.sap/"
 )
 
 // TeamRole and TeamRoleBinding constants

--- a/internal/controller/plugin/plugin_controller_flux.go
+++ b/internal/controller/plugin/plugin_controller_flux.go
@@ -145,7 +145,7 @@ func addValuesToHelmRelease(ctx context.Context, c client.Client, plugin *greenh
 		return nil, err
 	}
 
-	optionValues, err = helm.ResolveTemplatedValues(ctx, c, plugin, optionValues)
+	optionValues, err = helm.ResolveTemplatedValues(ctx, optionValues)
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve templated values: %w", err)
 	}

--- a/internal/helm/template_test.go
+++ b/internal/helm/template_test.go
@@ -10,131 +10,30 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/kubectl/pkg/scheme"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	greenhousev1alpha1 "github.com/cloudoperators/greenhouse/api/v1alpha1"
+	"github.com/cloudoperators/greenhouse/internal/test"
 )
 
 var _ = Describe("Template Processing", func() {
 	var (
-		ctx    context.Context
-		c      client.Client
-		plugin *greenhousev1alpha1.Plugin
+		ctx context.Context
 	)
 
 	BeforeEach(func() {
 		ctx = context.Background()
-
-		c = fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(
-			&greenhousev1alpha1.Cluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "obs-eu-de-1",
-					Namespace: "test-org",
-					Labels: map[string]string{
-						"metadata.greenhouse.sap/region":      "eu-de-1",
-						"metadata.greenhouse.sap/environment": "production",
-						"other-label":                         "should-be-ignored",
-					},
-				},
-			},
-			&greenhousev1alpha1.Cluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "obs-eu-de-2",
-					Namespace: "test-org",
-				},
-			},
-			// Test team
-			&greenhousev1alpha1.Team{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-team",
-					Namespace: "test-org",
-				},
-			},
-		).Build()
-
-		plugin = &greenhousev1alpha1.Plugin{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-plugin",
-				Namespace: "test-org",
-			},
-			Spec: greenhousev1alpha1.PluginSpec{
-				ClusterName:      "obs-eu-de-1",
-				ReleaseNamespace: "test-org",
-				PluginDefinition: "disco",
-			},
-		}
-	})
-
-	Describe("Template Data Building", func() {
-		It("should build template data with all greenhouse values including cluster metadata", func() {
-			templateData, err := buildTemplateData(ctx, c, plugin)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(templateData).ToNot(BeNil())
-
-			global, exists := templateData["global"].(map[string]interface{})
-			Expect(exists).To(BeTrue())
-			greenhouse, exists := global["greenhouse"].(map[string]interface{})
-			Expect(exists).To(BeTrue())
-
-			Expect(greenhouse["clusterName"]).To(Equal("obs-eu-de-1"))
-			Expect(greenhouse["organizationName"]).To(Equal("test-org"))
-			Expect(greenhouse["clusterNames"]).To(ContainElements("obs-eu-de-1", "obs-eu-de-2"))
-			Expect(greenhouse["teamNames"]).To(ContainElement("test-team"))
-			Expect(greenhouse["baseDomain"]).To(Equal(""))
-
-			metadata, exists := greenhouse["metadata"].(map[string]interface{})
-			Expect(exists).To(BeTrue())
-
-			Expect(metadata["region"]).To(Equal("eu-de-1"))
-			Expect(metadata["environment"]).To(Equal("production"))
-
-			// Should not include non-metadata labels.
-			_, exists = metadata["other-label"]
-			Expect(exists).To(BeFalse())
-		})
-
-		It("should handle plugins without cluster name gracefully", func() {
-			pluginWithoutCluster := &greenhousev1alpha1.Plugin{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-plugin-no-cluster",
-					Namespace: "test-org",
-				},
-				Spec: greenhousev1alpha1.PluginSpec{
-					ReleaseNamespace: "test-org",
-					PluginDefinition: "disco",
-				},
-			}
-
-			templateData, err := buildTemplateData(ctx, c, pluginWithoutCluster)
-			Expect(err).ToNot(HaveOccurred())
-
-			global, exists := templateData["global"].(map[string]interface{})
-			Expect(exists).To(BeTrue())
-			greenhouse, exists := global["greenhouse"].(map[string]interface{})
-			Expect(exists).To(BeTrue())
-
-			// Should not have metadata when no cluster is specified.
-			_, exists = greenhouse["metadata"]
-			Expect(exists).To(BeFalse())
-			_, exists = greenhouse["clusterName"]
-			Expect(exists).To(BeFalse())
-		})
 	})
 
 	Describe("Template Resolution", func() {
 		DescribeTable("resolving templates with various Sprig functions",
-			func(template string, expectedResult string, expectError bool) {
-				optionValues := []greenhousev1alpha1.PluginOptionValue{
-					{
-						Name:     "testOption",
-						Template: &template,
-					},
-				}
+			func(template string, expectedResult string, expectError bool, greenhouseValues []greenhousev1alpha1.PluginOptionValue) {
+				// Combine the greenhouse values with the test template.
+				optionValues := append(greenhouseValues, greenhousev1alpha1.PluginOptionValue{
+					Name:     "testOption",
+					Template: &template,
+				})
 
-				resolvedValues, err := ResolveTemplatedValues(ctx, c, plugin, optionValues)
+				resolvedValues, err := ResolveTemplatedValues(ctx, optionValues)
 
 				if expectError {
 					Expect(err).To(HaveOccurred())
@@ -142,110 +41,178 @@ var _ = Describe("Template Processing", func() {
 				}
 
 				Expect(err).ToNot(HaveOccurred())
-				Expect(resolvedValues).To(HaveLen(1))
-				Expect(resolvedValues[0].Name).To(Equal("testOption"))
-				Expect(resolvedValues[0].Template).To(BeNil())
-				Expect(resolvedValues[0].Value).ToNot(BeNil())
+				Expect(resolvedValues).ToNot(BeEmpty())
+
+				// Find the testOption in the resolved values.
+				var testOptionValue *greenhousev1alpha1.PluginOptionValue
+				for i := range resolvedValues {
+					if resolvedValues[i].Name == "testOption" {
+						testOptionValue = &resolvedValues[i]
+						break
+					}
+				}
+				Expect(testOptionValue).ToNot(BeNil(), "testOption should be found in resolved values")
+				Expect(testOptionValue.Template).To(BeNil())
+				Expect(testOptionValue.Value).ToNot(BeNil())
 
 				var resolvedValue string
-				err = json.Unmarshal(resolvedValues[0].Value.Raw, &resolvedValue)
+				err = json.Unmarshal(testOptionValue.Value.Raw, &resolvedValue)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(resolvedValue).To(Equal(expectedResult))
 			},
 			Entry("simple cluster name",
 				"{{ .global.greenhouse.clusterName }}",
-				"obs-eu-de-1", false),
+				"obs-eu-de-1", false,
+				[]greenhousev1alpha1.PluginOptionValue{
+					{Name: "global.greenhouse.clusterName", Value: test.MustReturnJSONFor("obs-eu-de-1")},
+				}),
 			Entry("simple organization name",
 				"{{ .global.greenhouse.organizationName }}",
-				"test-org", false),
-
+				"test-org", false,
+				[]greenhousev1alpha1.PluginOptionValue{
+					{Name: "global.greenhouse.organizationName", Value: test.MustReturnJSONFor("test-org")},
+				}),
 			Entry("upper case transformation",
 				"{{ upper .global.greenhouse.clusterName }}",
-				"OBS-EU-DE-1", false),
+				"OBS-EU-DE-1", false,
+				[]greenhousev1alpha1.PluginOptionValue{
+					{Name: "global.greenhouse.clusterName", Value: test.MustReturnJSONFor("obs-eu-de-1")},
+				}),
 			Entry("lower case transformation",
 				"{{ lower .global.greenhouse.clusterName }}",
-				"obs-eu-de-1", false),
+				"obs-eu-de-1", false,
+				[]greenhousev1alpha1.PluginOptionValue{
+					{Name: "global.greenhouse.clusterName", Value: test.MustReturnJSONFor("obs-eu-de-1")},
+				}),
 			Entry("title case transformation",
 				"{{ title .global.greenhouse.organizationName }}",
-				"Test-Org", false),
-
+				"Test-Org", false,
+				[]greenhousev1alpha1.PluginOptionValue{
+					{Name: "global.greenhouse.organizationName", Value: test.MustReturnJSONFor("test-org")},
+				}),
 			Entry("regex split and join",
 				`ingress.{{ regexSplit "-" .global.greenhouse.clusterName 2 | join "." }}.my.cloud.`,
-				"ingress.obs.eu-de-1.my.cloud.", false),
-
+				"ingress.obs.eu-de-1.my.cloud.", false,
+				[]greenhousev1alpha1.PluginOptionValue{
+					{Name: "global.greenhouse.clusterName", Value: test.MustReturnJSONFor("obs-eu-de-1")},
+				}),
 			Entry("regex split all parts",
 				`{{ regexSplit "-" .global.greenhouse.clusterName -1 | join "_" }}`,
-				"obs_eu_de_1", false),
+				"obs_eu_de_1", false,
+				[]greenhousev1alpha1.PluginOptionValue{
+					{Name: "global.greenhouse.clusterName", Value: test.MustReturnJSONFor("obs-eu-de-1")},
+				}),
 			Entry("regex split first 3 parts",
 				`{{ regexSplit "-" .global.greenhouse.clusterName 3 | join "-" }}`,
-				"obs-eu-de-1", false),
-
+				"obs-eu-de-1", false,
+				[]greenhousev1alpha1.PluginOptionValue{
+					{Name: "global.greenhouse.clusterName", Value: test.MustReturnJSONFor("obs-eu-de-1")},
+				}),
 			Entry("https URL construction",
 				"https://{{ .global.greenhouse.clusterName }}.example.com",
-				"https://obs-eu-de-1.example.com", false),
-
+				"https://obs-eu-de-1.example.com", false,
+				[]greenhousev1alpha1.PluginOptionValue{
+					{Name: "global.greenhouse.clusterName", Value: test.MustReturnJSONFor("obs-eu-de-1")},
+				}),
 			Entry("conditional with if-else",
 				`{{ if eq .global.greenhouse.clusterName "obs-eu-de-1" }}production{{ else }}staging{{ end }}`,
-				"production", false),
+				"production", false,
+				[]greenhousev1alpha1.PluginOptionValue{
+					{Name: "global.greenhouse.clusterName", Value: test.MustReturnJSONFor("obs-eu-de-1")},
+				}),
 			Entry("conditional with contains",
 				`{{ if contains "eu" .global.greenhouse.clusterName }}europe{{ else }}other{{ end }}`,
-				"europe", false),
-
+				"europe", false,
+				[]greenhousev1alpha1.PluginOptionValue{
+					{Name: "global.greenhouse.clusterName", Value: test.MustReturnJSONFor("obs-eu-de-1")},
+				}),
 			Entry("join cluster names",
 				`{{ join "," .global.greenhouse.clusterNames }}`,
-				"obs-eu-de-1,obs-eu-de-2", false),
+				"obs-eu-de-1,obs-eu-de-2", false,
+				[]greenhousev1alpha1.PluginOptionValue{
+					{Name: "global.greenhouse.clusterNames", Value: test.MustReturnJSONFor([]string{"obs-eu-de-1", "obs-eu-de-2"})},
+				}),
 			Entry("first cluster name",
 				`{{ index .global.greenhouse.clusterNames 0 }}`,
-				"obs-eu-de-1", false),
-
+				"obs-eu-de-1", false,
+				[]greenhousev1alpha1.PluginOptionValue{
+					{Name: "global.greenhouse.clusterNames", Value: test.MustReturnJSONFor([]string{"obs-eu-de-1", "obs-eu-de-2"})},
+				}),
 			Entry("trim and replace",
 				`{{ trim "  test-value  " | replace "test" "demo" }}`,
-				"demo-value", false),
+				"demo-value", false,
+				[]greenhousev1alpha1.PluginOptionValue{}),
 			Entry("hasPrefix check",
 				`{{ if hasPrefix "obs" .global.greenhouse.clusterName }}yes{{ else }}no{{ end }}`,
-				"yes", false),
-
+				"yes", false,
+				[]greenhousev1alpha1.PluginOptionValue{
+					{Name: "global.greenhouse.clusterName", Value: test.MustReturnJSONFor("obs-eu-de-1")},
+				}),
 			Entry("string length",
 				`{{ len .global.greenhouse.clusterName }}`,
-				"11", false),
-
+				"11", false,
+				[]greenhousev1alpha1.PluginOptionValue{
+					{Name: "global.greenhouse.clusterName", Value: test.MustReturnJSONFor("obs-eu-de-1")},
+				}),
 			// Cluster metadata tests.
 			Entry("cluster metadata region",
 				"{{ .global.greenhouse.metadata.region }}",
-				"eu-de-1", false),
+				"eu-de-1", false,
+				[]greenhousev1alpha1.PluginOptionValue{
+					{Name: "global.greenhouse.metadata.region", Value: test.MustReturnJSONFor("eu-de-1")},
+				}),
 			Entry("cluster metadata environment",
 				"{{ .global.greenhouse.metadata.environment }}",
-				"production", false),
+				"production", false,
+				[]greenhousev1alpha1.PluginOptionValue{
+					{Name: "global.greenhouse.metadata.environment", Value: test.MustReturnJSONFor("production")},
+				}),
 			Entry("metadata-based URL construction",
 				"https://api.{{ .global.greenhouse.metadata.region }}.example.com",
-				"https://api.eu-de-1.example.com", false),
+				"https://api.eu-de-1.example.com", false,
+				[]greenhousev1alpha1.PluginOptionValue{
+					{Name: "global.greenhouse.metadata.region", Value: test.MustReturnJSONFor("eu-de-1")},
+				}),
 			Entry("conditional with metadata environment",
 				`{{ if eq .global.greenhouse.metadata.environment "production" }}prod-config{{ else }}dev-config{{ end }}`,
-				"prod-config", false),
-
+				"prod-config", false,
+				[]greenhousev1alpha1.PluginOptionValue{
+					{Name: "global.greenhouse.metadata.environment", Value: test.MustReturnJSONFor("production")},
+				}),
 			Entry("database connection string",
 				`postgres://user:pass@{{ .global.greenhouse.clusterName }}.db.example.com:5432/myapp`,
-				"postgres://user:pass@obs-eu-de-1.db.example.com:5432/myapp", false),
+				"postgres://user:pass@obs-eu-de-1.db.example.com:5432/myapp", false,
+				[]greenhousev1alpha1.PluginOptionValue{
+					{Name: "global.greenhouse.clusterName", Value: test.MustReturnJSONFor("obs-eu-de-1")},
+				}),
 			Entry("kubernetes service name",
 				`{{ .global.greenhouse.organizationName }}-{{ regexSplit "-" .global.greenhouse.clusterName 2 | join "-" }}-svc`,
-				"test-org-obs-eu-de-1-svc", false),
-
+				"test-org-obs-eu-de-1-svc", false,
+				[]greenhousev1alpha1.PluginOptionValue{
+					{Name: "global.greenhouse.organizationName", Value: test.MustReturnJSONFor("test-org")},
+					{Name: "global.greenhouse.clusterName", Value: test.MustReturnJSONFor("obs-eu-de-1")},
+				}),
 			Entry("invalid template syntax",
 				"{{ invalid template }}",
-				"", true),
+				"", true,
+				[]greenhousev1alpha1.PluginOptionValue{}),
 			Entry("nonexistent field",
 				"{{ .nonexistent.field }}",
-				"<no value>", false),
+				"<no value>", false,
+				[]greenhousev1alpha1.PluginOptionValue{}),
 			Entry("invalid sprig function",
 				"{{ invalidFunction .global.greenhouse.clusterName }}",
-				"", true),
+				"", true,
+				[]greenhousev1alpha1.PluginOptionValue{
+					{Name: "global.greenhouse.clusterName", Value: test.MustReturnJSONFor("obs-eu-de-1")},
+				}),
 		)
 	})
 
 	Describe("Edge Cases", func() {
 		It("should handle empty template list", func() {
 			optionValues := []greenhousev1alpha1.PluginOptionValue{}
-			resolvedValues, err := ResolveTemplatedValues(ctx, c, plugin, optionValues)
+			resolvedValues, err := ResolveTemplatedValues(ctx, optionValues)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(resolvedValues).To(BeEmpty())
 		})
@@ -258,7 +225,7 @@ var _ = Describe("Template Processing", func() {
 					Value:    &apiextensionsv1.JSON{Raw: []byte(`"fallback"`)},
 				},
 			}
-			resolvedValues, err := ResolveTemplatedValues(ctx, c, plugin, optionValues)
+			resolvedValues, err := ResolveTemplatedValues(ctx, optionValues)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(resolvedValues).To(HaveLen(1))
 			Expect(resolvedValues[0].Template).To(BeNil())


### PR DESCRIPTION
## Description
This PR enhances string templating for `PluginOptionValues` to support cluster-specific metadata. Cluster labels following the `metadata.greenhouse.sap/*` pattern are now automatically available in Plugin templates as `global.greenhouse.metadata.*` values. For example, a cluster labeled with `metadata.greenhouse.sap/region: eu-de-1` makes `{{ .global.greenhouse.metadata.region }}` available in Plugin templates, resolving to `eu-de-1`.

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

- Closes https://github.com/cloudoperators/greenhouse/issues/1361

## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [x] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

Documentation will be added under different issue.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
