### PR TITLE
release(version): backport (chore): propagate label even after cluster creation (#1405)

### DIFF
--- a/internal/test/setup.go
+++ b/internal/test/setup.go
@@ -221,6 +221,24 @@ func (t *TestSetup) CreateSecret(ctx context.Context, name string, opts ...func(
 	return secret
 }
 
+// UpdateSecret updates a Secret object. Opts can be used to set the desired state of the Secret.
+func (t *TestSetup) UpdateSecret(ctx context.Context, name string, opts ...func(*corev1.Secret)) *corev1.Secret {
+	GinkgoHelper()
+	secret := &corev1.Secret{}
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		err := t.Get(ctx, client.ObjectKey{Name: name, Namespace: t.Namespace()}, secret)
+		if err != nil {
+			return err
+		}
+		for _, opt := range opts {
+			opt(secret)
+		}
+		return t.Update(ctx, secret)
+	})
+	Expect(err).NotTo(HaveOccurred(), "there should be no error updating the Secret")
+	return secret
+}
+
 // CreateConfigMap returns a ConfigMap object. Opts can be used to set the desired state of the ConfigMap.
 func (t *TestSetup) CreateConfigMap(ctx context.Context, name string, opts ...func(*corev1.ConfigMap)) *corev1.ConfigMap {
 	GinkgoHelper()


### PR DESCRIPTION
(chore): fix lint errors

<!--
Please ensure the PR title follows the conventional commit format:
<type>(<scope>): description

For a list of accepted types and scopes see the workflow documentation: https://github.com/cloudoperators/greenhouse/blob/main/.github/workflows/ci-pr-title.yaml

-->

## Description
<!--
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 

- Related Issue # (issue)
- Closes # (issue)
- Fixes # (issue)

-->

## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [ ] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
