### PR TITLE
release(version): backport feat(plugins): rename PluginDefinition label to ClusterPluginDefinition label #1356

### DIFF
--- a/api/well_known.go
+++ b/api/well_known.go
@@ -39,6 +39,9 @@ const (
 	// LabelKeyPluginDefinition is used to identify corresponding PluginDefinition for the resource.
 	LabelKeyPluginDefinition = "greenhouse.sap/plugindefinition"
 
+	// LabelKeyClusterPluginDefinition is used to identify the corresponding ClusterPluginDefinition for the resource.
+	LabelKeyClusterPluginDefinition = "greenhouse.sap/clusterplugindefinition"
+
 	// LabelKeyCluster is used to identify corresponding Cluster for the resource.
 	LabelKeyCluster = "greenhouse.sap/cluster"
 

--- a/internal/controller/plugin/plugin_controller.go
+++ b/internal/controller/plugin/plugin_controller.go
@@ -413,7 +413,7 @@ func (r *PluginReconciler) enqueueAllPluginsForPluginDefinition(ctx context.Cont
 	return ListPluginsAsReconcileRequests(
 		ctx,
 		r.Client,
-		client.MatchingLabels{greenhouseapis.LabelKeyPluginDefinition: o.GetName()},
+		client.MatchingLabels{greenhouseapis.LabelKeyClusterPluginDefinition: o.GetName()},
 	)
 }
 

--- a/internal/webhook/v1alpha1/plugin_webhook.go
+++ b/internal/webhook/v1alpha1/plugin_webhook.go
@@ -66,7 +66,12 @@ func DefaultPlugin(ctx context.Context, c client.Client, obj runtime.Object) err
 	}
 	// The label is used to help identifying Plugins, e.g. if a PluginDefinition changes.
 	delete(plugin.Labels, greenhouseapis.LabelKeyPlugin)
-	plugin.Labels[greenhouseapis.LabelKeyPluginDefinition] = plugin.Spec.PluginDefinition
+
+	// TODO: remove this once migration to CPD is done
+	delete(plugin.Labels, greenhouseapis.LabelKeyPluginDefinition)
+
+	// TODO: Once namespaced PluginDefinitions are supported, we need a logic here to handle the correct label
+	plugin.Labels[greenhouseapis.LabelKeyClusterPluginDefinition] = plugin.Spec.PluginDefinition
 	plugin.Labels[greenhouseapis.LabelKeyCluster] = plugin.Spec.ClusterName
 
 	// Default the displayName to a normalized version of metadata.name.

--- a/internal/webhook/v1alpha1/plugin_webhook_test.go
+++ b/internal/webhook/v1alpha1/plugin_webhook_test.go
@@ -376,6 +376,68 @@ var _ = Describe("Validate plugin spec fields", Ordered, func() {
 	})
 })
 
+var _ = Describe("Validate ClusterPluginDefinition label on Defaulting", Ordered, func() {
+	var (
+		setup *test.TestSetup
+
+		team                        *greenhousev1alpha1.Team
+		testCluster                 *greenhousev1alpha1.Cluster
+		testPlugin                  *greenhousev1alpha1.Plugin
+		testPluginDefinition        *greenhousev1alpha1.ClusterPluginDefinition
+		testCentralPluginDefinition *greenhousev1alpha1.ClusterPluginDefinition
+	)
+
+	BeforeAll(func() {
+		setup = test.NewTestSetup(test.Ctx, test.K8sClient, "plugin-webhook")
+		team = setup.CreateTeam(test.Ctx, "test-team", test.WithTeamLabel(greenhouseapis.LabelKeySupportGroup, "true"))
+		testCluster = setup.CreateCluster(test.Ctx, "test-cluster", test.WithClusterLabel(greenhouseapis.LabelKeyOwnedBy, team.Name))
+		testPluginDefinition = setup.CreateClusterPluginDefinition(test.Ctx, "test-plugindefinition")
+		testCentralPluginDefinition = setup.CreateClusterPluginDefinition(test.Ctx, "central-plugin")
+		pluginsAllowedInCentralCluster = append(pluginsAllowedInCentralCluster, testCentralPluginDefinition.Name)
+	})
+
+	AfterEach(func() {
+		test.EventuallyDeleted(test.Ctx, test.K8sClient, testPlugin)
+	})
+
+	AfterAll(func() {
+		test.EventuallyDeleted(test.Ctx, test.K8sClient, testCluster)
+		test.EventuallyDeleted(test.Ctx, test.K8sClient, team)
+		test.EventuallyDeleted(test.Ctx, test.K8sClient, testPluginDefinition)
+		test.EventuallyDeleted(test.Ctx, test.K8sClient, testCentralPluginDefinition)
+	})
+
+	It("should accept a plugin for a remote cluster where releaseNamespace and Plugin Namespace do not match and the PluginDefinition is allowed on the central cluster", func() {
+		tempPluginsAllowedInCentralCluster := pluginsAllowedInCentralCluster
+		defer func() {
+			pluginsAllowedInCentralCluster = tempPluginsAllowedInCentralCluster
+		}()
+		pluginsAllowedInCentralCluster = []string{testPluginDefinition.Name}
+		testPlugin = test.NewPlugin(test.Ctx, "test-plugin", setup.Namespace(),
+			test.WithPluginDefinition(testPluginDefinition.Name),
+			test.WithCluster(testCluster.Name),
+			test.WithReleaseNamespace("test-namespace"),
+			test.WithReleaseName("test-release"),
+			test.WithPluginLabel(greenhouseapis.LabelKeyOwnedBy, team.Name),
+			test.WithPluginLabel(greenhouseapis.LabelKeyPluginDefinition, testPluginDefinition.Name),
+		)
+		err := test.K8sClient.Create(test.Ctx, testPlugin)
+		Expect(err).ToNot(HaveOccurred(), "there should be no error creating the plugin")
+
+		By("checking the label on the plugin")
+		Eventually(func(g Gomega) {
+			err = test.K8sClient.Get(test.Ctx, types.NamespacedName{Name: testPlugin.Name, Namespace: testPlugin.Namespace}, testPlugin)
+			Expect(err).ToNot(HaveOccurred(), "there should be no error getting the plugin")
+			labels := testPlugin.GetLabels()
+			g.Expect(labels).To(HaveKeyWithValue(greenhouseapis.LabelKeyClusterPluginDefinition, testPluginDefinition.Name),
+				"the plugin should have the clusterplugindefinition label set to the pluginDefinition name")
+			g.Expect(labels).ToNot(HaveKeyWithValue(greenhouseapis.LabelKeyPluginDefinition, testPluginDefinition.Name),
+				"the plugin should not have the plugindefinition label set to the pluginDefinition name")
+		}).Should(Succeed(), " the plugin should have only clusterpluginDefinition label set")
+
+	})
+})
+
 func expectClusterNotFoundError(err error) {
 	GinkgoHelper()
 	Expect(err).To(HaveOccurred(), "there should be an error updating the plugin")

--- a/internal/webhook/v1alpha1/plugindefinition_webhook.go
+++ b/internal/webhook/v1alpha1/plugindefinition_webhook.go
@@ -113,7 +113,7 @@ func ValidateDeletePluginDefinition(ctx context.Context, c client.Client, o runt
 	if !ok {
 		return nil, nil
 	}
-	return validateDelete(ctx, c, pluginDefinition.GetName())
+	return validateDelete(ctx, c, greenhouseapis.LabelKeyPluginDefinition, pluginDefinition.GetName())
 }
 
 func ValidateDeleteClusterPluginDefinition(ctx context.Context, c client.Client, o runtime.Object) (admission.Warnings, error) {
@@ -121,12 +121,12 @@ func ValidateDeleteClusterPluginDefinition(ctx context.Context, c client.Client,
 	if !ok {
 		return nil, nil
 	}
-	return validateDelete(ctx, c, pluginDefinition.GetName())
+	return validateDelete(ctx, c, greenhouseapis.LabelKeyClusterPluginDefinition, pluginDefinition.GetName())
 }
 
-func validateDelete(ctx context.Context, c client.Client, name string) (admission.Warnings, error) {
+func validateDelete(ctx context.Context, c client.Client, labelKey, name string) (admission.Warnings, error) {
 	list := &greenhousev1alpha1.PluginList{}
-	opt := client.MatchingLabels{greenhouseapis.LabelKeyPluginDefinition: name}
+	opt := client.MatchingLabels{labelKey: name}
 	if err := c.List(ctx, list, opt); err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil, nil

--- a/internal/webhook/v1alpha1/plugindefinition_webhook_test.go
+++ b/internal/webhook/v1alpha1/plugindefinition_webhook_test.go
@@ -179,7 +179,7 @@ var _ = Describe("Validate PluginDefinition Deletion", func() {
 						Name:      "test-plugin",
 						Namespace: "default",
 						Labels: map[string]string{
-							greenhouseapis.LabelKeyPluginDefinition: "test",
+							greenhouseapis.LabelKeyClusterPluginDefinition: "test",
 						},
 					},
 				},


### PR DESCRIPTION
(chore): change enqueue request labels to cpd label

(chore): remove guard around delete


(cherry picked from commit 5a9a0bc426cf51dd424c13e4d2ec6c8035371152)

<!--
Please ensure the PR title follows the conventional commit format:
<type>(<scope>): description

For a list of accepted types and scopes see the workflow documentation: https://github.com/cloudoperators/greenhouse/blob/main/.github/workflows/ci-pr-title.yaml

-->

## Description
<!--
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 

- Related Issue # (issue)
- Closes # (issue)
- Fixes # (issue)

-->

## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [ ] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
