### PR TITLE
fix(plugins): handle plugin definition ref name immutability bug

### DIFF
--- a/api/v1alpha1/types.go
+++ b/api/v1alpha1/types.go
@@ -10,7 +10,8 @@ import (
 // PluginDefinitionReference defines the reference to the PluginDefinition or ClusterPluginDefinition.
 type PluginDefinitionReference struct {
 	// Name of the referenced PluginDefinition or ClusterPluginDefinition resource.
-	Name string `json:"name"`
+	// +Optional
+	Name string `json:"name,omitempty"`
 	// Kind of the referent. Supported values: PluginDefinition, ClusterPluginDefinition.
 	// +kubebuilder:default=PluginDefinition
 	// +kubebuilder:validation:Enum=PluginDefinition;ClusterPluginDefinition

--- a/charts/manager/crds/greenhouse.sap_pluginpresets.yaml
+++ b/charts/manager/crds/greenhouse.sap_pluginpresets.yaml
@@ -228,8 +228,6 @@ spec:
                         description: Name of the referenced PluginDefinition or ClusterPluginDefinition
                           resource.
                         type: string
-                    required:
-                    - name
                     type: object
                   releaseName:
                     description: |-

--- a/charts/manager/crds/greenhouse.sap_plugins.yaml
+++ b/charts/manager/crds/greenhouse.sap_plugins.yaml
@@ -138,8 +138,6 @@ spec:
                     description: Name of the referenced PluginDefinition or ClusterPluginDefinition
                       resource.
                     type: string
-                required:
-                - name
                 type: object
               releaseName:
                 description: |-

--- a/docs/reference/api/openapi.yaml
+++ b/docs/reference/api/openapi.yaml
@@ -1132,8 +1132,6 @@ components:
                     name:
                       description: Name of the referenced PluginDefinition or ClusterPluginDefinition resource.
                       type: string
-                  required:
-                    - name
                   type: object
                 releaseName:
                   description: |-
@@ -1330,8 +1328,6 @@ components:
                 name:
                   description: Name of the referenced PluginDefinition or ClusterPluginDefinition resource.
                   type: string
-              required:
-                - name
               type: object
             releaseName:
               description: |-

--- a/internal/webhook/v1alpha1/plugin_webhook.go
+++ b/internal/webhook/v1alpha1/plugin_webhook.go
@@ -217,7 +217,10 @@ func ValidateUpdatePlugin(ctx context.Context, c client.Client, old, obj runtime
 	}
 
 	pluginDefinitionRefNamePath := field.NewPath("spec", "pluginDefinitionRef", "name")
-	allErrs = append(allErrs, validation.ValidateImmutableField(oldPlugin.Spec.PluginDefinitionRef.Name, plugin.Spec.PluginDefinitionRef.Name, pluginDefinitionRefNamePath)...)
+
+	if oldPlugin.Spec.PluginDefinitionRef.Name != "" {
+		allErrs = append(allErrs, validation.ValidateImmutableField(oldPlugin.Spec.PluginDefinitionRef.Name, plugin.Spec.PluginDefinitionRef.Name, pluginDefinitionRefNamePath)...)
+	}
 
 	allErrs = append(allErrs, validation.ValidateImmutableField(oldPlugin.Spec.ClusterName, plugin.Spec.ClusterName,
 		field.NewPath("spec", "clusterName"))...)


### PR DESCRIPTION
## Description

Existing plugins without a `PluginDefinitionRef` will always have the referent `PluginDefinitionRef.Name` empty and we should avoid immutability check in such situation as the `MutatingWebhook` will ensure the required defaults for `PluginDefinitionRef` fields.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

- Fixes #1441 

## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)


## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [ ] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
