### PR TITLE
fix(webhook): skip immutability check on ReleaseNamespace for UI-only plugins

### DIFF
--- a/internal/webhook/v1alpha1/plugin_webhook_test.go
+++ b/internal/webhook/v1alpha1/plugin_webhook_test.go
@@ -204,12 +204,13 @@ var _ = Describe("Validate plugin spec fields", Ordered, func() {
 	var (
 		setup *test.TestSetup
 
-		team                        *greenhousev1alpha1.Team
-		testCluster                 *greenhousev1alpha1.Cluster
-		testPlugin                  *greenhousev1alpha1.Plugin
-		testClusterPluginDefinition *greenhousev1alpha1.ClusterPluginDefinition
-		testCentralPluginDefinition *greenhousev1alpha1.ClusterPluginDefinition
-		testPluginDefinition        *greenhousev1alpha1.PluginDefinition
+		team                             *greenhousev1alpha1.Team
+		testCluster                      *greenhousev1alpha1.Cluster
+		testPlugin                       *greenhousev1alpha1.Plugin
+		testClusterPluginDefinition      *greenhousev1alpha1.ClusterPluginDefinition
+		testCentralPluginDefinition      *greenhousev1alpha1.ClusterPluginDefinition
+		testUIAppClusterPluginDefinition *greenhousev1alpha1.ClusterPluginDefinition
+		testPluginDefinition             *greenhousev1alpha1.PluginDefinition
 	)
 
 	BeforeAll(func() {
@@ -218,6 +219,14 @@ var _ = Describe("Validate plugin spec fields", Ordered, func() {
 		testCluster = setup.CreateCluster(test.Ctx, "test-cluster", test.WithClusterLabel(greenhouseapis.LabelKeyOwnedBy, team.Name))
 		testClusterPluginDefinition = setup.CreateClusterPluginDefinition(test.Ctx, "test-plugindefinition")
 		testCentralPluginDefinition = setup.CreateClusterPluginDefinition(test.Ctx, "central-plugin")
+		testUIAppClusterPluginDefinition = setup.CreateClusterPluginDefinition(test.Ctx, "uiapp-plugindefinition",
+			test.WithVersion("1.0.0"),
+			test.WithoutHelmChart(),
+			test.WithUIApplication(&greenhousev1alpha1.UIApplicationReference{
+				Name:    "test-ui-app",
+				Version: "0.0.1",
+			}),
+		)
 		testPluginDefinition = setup.CreatePluginDefinition(test.Ctx, "pd-namespaced")
 		pluginsAllowedInCentralCluster = append(pluginsAllowedInCentralCluster, testCentralPluginDefinition.Name)
 	})
@@ -231,6 +240,7 @@ var _ = Describe("Validate plugin spec fields", Ordered, func() {
 		test.EventuallyDeleted(test.Ctx, test.K8sClient, team)
 		test.EventuallyDeleted(test.Ctx, test.K8sClient, testClusterPluginDefinition)
 		test.EventuallyDeleted(test.Ctx, test.K8sClient, testCentralPluginDefinition)
+		test.EventuallyDeleted(test.Ctx, test.K8sClient, testUIAppClusterPluginDefinition)
 		test.EventuallyDeleted(test.Ctx, test.K8sClient, testPluginDefinition)
 	})
 
@@ -402,6 +412,18 @@ var _ = Describe("Validate plugin spec fields", Ordered, func() {
 		err := test.K8sClient.Update(test.Ctx, testPlugin)
 		Expect(err).To(HaveOccurred(), "there should be an error changing the plugin's releaseNamespace")
 		Expect(err.Error()).To(ContainSubstring(validation.FieldImmutableErrorMsg))
+	})
+
+	It("should accept to update a UI-only plugin when ReleaseNamespace is changed", func() {
+		testPlugin = setup.CreatePlugin(test.Ctx, "test-plugin",
+			test.WithClusterPluginDefinition(testUIAppClusterPluginDefinition.Name),
+			test.WithCluster(testCluster.Name),
+			test.WithReleaseNamespace("test-namespace"),
+			test.WithReleaseName("test-release"),
+			test.WithPluginLabel(greenhouseapis.LabelKeyOwnedBy, team.Name))
+		testPlugin.Spec.ReleaseNamespace = ""
+		err := test.K8sClient.Update(test.Ctx, testPlugin)
+		Expect(err).ToNot(HaveOccurred(), "there should be no error changing the UI-only plugin's releaseNamespace")
 	})
 
 	It("should reject to update a plugin when the pluginDefinition reference name changes", func() {


### PR DESCRIPTION
On-behalf-of: @SAP krzysztof.zagorski@sap.com

<!--
Please ensure the PR title follows the conventional commit format:
<type>(<scope>): description

For a list of accepted types and scopes see the workflow documentation: https://github.com/cloudoperators/greenhouse/blob/main/.github/workflows/ci-pr-title.yaml

-->

## Description
<!--
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
Skip immutability check on ReleaseNamespace for UI-only plugins.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 

- Related Issue # (issue)
- Closes # (issue)
- Fixes # (issue)

-->
- Closes #1456 

## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [x] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
