### PR TITLE
feat(catalogs): implement Role and RoleBinding for catalog SA

### DIFF
--- a/api/well_known.go
+++ b/api/well_known.go
@@ -90,6 +90,8 @@ const (
 
 	// KindClusterPluginDefinitionPlural is the plural form of ClusterPluginDefinition kind.
 	KindClusterPluginDefinitionPlural = "clusterplugindefinitions"
+	// KindPluginDefinitionPlural is the plural form of PluginDefinition kind.
+	KindPluginDefinitionPlural = "plugindefinitions"
 )
 
 // Deletion Policies

--- a/internal/controller/organization/organization_controller.go
+++ b/internal/controller/organization/organization_controller.go
@@ -387,18 +387,28 @@ func (r *OrganizationReconciler) enqueueOrganizationsForReferencedConfigMap(ctx 
 
 // reconcileCatalogServiceAccount creates a ServiceAccount and associated RBAC for PluginDefinitionCatalog operations.
 func (r *OrganizationReconciler) reconcileCatalogPermissions(ctx context.Context, org *greenhousev1alpha1.Organization) error {
-	clusterResources := []string{greenhouseapis.KindClusterPluginDefinitionPlural}
 	if err := r.reconcileCatalogServiceAccount(ctx, org); err != nil {
 		return err
 	}
 
 	if org.Name == defaultGreenhouseConnectorID {
+		clusterResources := []string{greenhouseapis.KindClusterPluginDefinitionPlural, greenhouseapis.KindPluginDefinitionPlural}
 		if err := r.reconcileCatalogClusterRole(ctx, org, clusterResources); err != nil {
 			return err
 		}
 		if err := r.reconcileCatalogClusterRoleBinding(ctx, org); err != nil {
 			return err
 		}
+
+		return nil
+	}
+
+	namespaceResources := []string{greenhouseapis.KindPluginDefinitionPlural}
+	if err := r.reconcileCatalogRole(ctx, org, namespaceResources); err != nil {
+		return err
+	}
+	if err := r.reconcileCatalogRoleBinding(ctx, org); err != nil {
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
## Description

Implement RBAC permissions for Catalog `ServiceAccount` to manage `PluginDefinitions`.

**Regular organizations:**
- `Role` + `RoleBinding` for `PluginDefinitions` in their own namespace only

**Greenhouse organization:**
- `ClusterRole` + `ClusterRoleBinding` for both `PluginDefinitions` (cluster-wide) and `ClusterPluginDefinitions`


## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

- Closes https://github.com/cloudoperators/greenhouse/issues/1458

## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [x] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
