### PR TITLE
refactor(e2e): remove duplicate import

### DIFF
--- a/e2e/shared/cluster.go
+++ b/e2e/shared/cluster.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"time"
 
-	"k8s.io/apimachinery/pkg/api/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/util/retry"
 
@@ -74,11 +73,11 @@ func OffBoardRemoteCluster(ctx context.Context, adminClient, remoteClient client
 	By("checking the cluster resource is eventually deleted")
 	Eventually(func(g Gomega) {
 		err := adminClient.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, cluster)
-		g.Expect(errors.IsNotFound(err)).To(BeTrue(), "cluster resource should be deleted")
+		g.Expect(apierrors.IsNotFound(err)).To(BeTrue(), "cluster resource should be deleted")
 		secret := &corev1.Secret{}
 		err = adminClient.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, secret)
 		GinkgoWriter.Printf("secret err: %v\n", err)
-		g.Expect(errors.IsNotFound(err)).To(BeTrue(), "cluster secret should be deleted")
+		g.Expect(apierrors.IsNotFound(err)).To(BeTrue(), "cluster secret should be deleted")
 	}).Should(Succeed(), "cluster resource & secret should be deleted")
 
 	By("verifying that the remote cluster managed service account and cluster role binding is deleted")
@@ -86,11 +85,11 @@ func OffBoardRemoteCluster(ctx context.Context, adminClient, remoteClient client
 		crb := &rbacv1.ClusterRoleBinding{}
 		err := remoteClient.Get(ctx, client.ObjectKey{Name: ManagedResourceName}, crb)
 		GinkgoWriter.Printf("crb err: %v\n", err)
-		g.Expect(errors.IsNotFound(err)).To(BeTrue(), "cluster role binding should be deleted")
+		g.Expect(apierrors.IsNotFound(err)).To(BeTrue(), "cluster role binding should be deleted")
 		managedSA := &corev1.ServiceAccount{}
 		err = remoteClient.Get(ctx, client.ObjectKey{Name: ManagedResourceName, Namespace: namespace}, managedSA)
 		GinkgoWriter.Printf("sa err: %v\n", err)
-		g.Expect(errors.IsNotFound(err)).To(BeTrue(), "managed service account should be deleted")
+		g.Expect(apierrors.IsNotFound(err)).To(BeTrue(), "managed service account should be deleted")
 	}).Should(Succeed(), "RBAC on remote cluster should be deleted")
 }
 


### PR DESCRIPTION
<!--
Please ensure the PR title follows the conventional commit format:
<type>(<scope>): description

For a list of accepted types and scopes see the workflow documentation: https://github.com/cloudoperators/greenhouse/blob/main/.github/workflows/ci-pr-title.yaml

-->

## Description
<!--
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 

- Related Issue # (issue)
- Closes # (issue)
- Fixes # (issue)

-->

## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [ ] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
