### PR TITLE
fix(catalogs): removes excluded field in spec

### DIFF
--- a/api/v1alpha1/catalog_types.go
+++ b/api/v1alpha1/catalog_types.go
@@ -32,11 +32,6 @@ type CatalogSource struct {
 	// glob patterns are supported, e.g. ["plugins/*.yaml", "more-plugins/**/plugindefinition.yaml"]
 	Resources []string `json:"resources"`
 
-	// Excludes contains a list of path patterns to exclude from the Catalog
-	// e.g. ["**/test/**", "**/example*/**"]
-	// +Optional
-	Excludes []string `json:"excludes,omitempty"`
-
 	// Ref is the git reference (branch, tag, or SHA) to resolve PluginDefinitions from
 	// precedence: SHA > Tag > Branch
 	// if not specified, defaults to the branch "main"

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -120,11 +120,6 @@ func (in *CatalogSource) DeepCopyInto(out *CatalogSource) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
-	if in.Excludes != nil {
-		in, out := &in.Excludes, &out.Excludes
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	}
 	if in.Ref != nil {
 		in, out := &in.Ref, &out.Ref
 		*out = new(GitRef)

--- a/charts/manager/crds/greenhouse.sap_catalogs.yaml
+++ b/charts/manager/crds/greenhouse.sap_catalogs.yaml
@@ -53,13 +53,6 @@ spec:
                   resolve PluginDefinitions / ClusterPluginDefinitions from
                 items:
                   properties:
-                    excludes:
-                      description: |-
-                        Excludes contains a list of path patterns to exclude from the Catalog
-                        e.g. ["**/test/**", "**/example*/**"]
-                      items:
-                        type: string
-                      type: array
                     overrides:
                       description: Overrides are the PluginDefinition overrides to
                         be applied

--- a/docs/reference/api/index.html
+++ b/docs/reference/api/index.html
@@ -230,18 +230,6 @@ glob patterns are supported, e.g. [&ldquo;plugins/*.yaml&rdquo;, &ldquo;more-plu
 </tr>
 <tr>
 <td>
-<code>excludes</code><br>
-<em>
-[]string
-</em>
-</td>
-<td>
-<p>Excludes contains a list of path patterns to exclude from the Catalog
-e.g. [&rdquo;<strong>/test/</strong>&rdquo;, &ldquo;<strong>/example*/</strong>&rdquo;]</p>
-</td>
-</tr>
-<tr>
-<td>
 <code>ref</code><br>
 <em>
 <a href="#greenhouse.sap/v1alpha1.GitRef">

--- a/docs/reference/api/openapi.yaml
+++ b/docs/reference/api/openapi.yaml
@@ -37,13 +37,6 @@ components:
               description: Sources contains the list of Git Repository source to resolve PluginDefinitions / ClusterPluginDefinitions from
               items:
                 properties:
-                  excludes:
-                    description: |-
-                      Excludes contains a list of path patterns to exclude from the Catalog
-                      e.g. ["**/test/**", "**/example*/**"]
-                    items:
-                      type: string
-                    type: array
                   overrides:
                     description: Overrides are the PluginDefinition overrides to be applied
                     items:

--- a/types/typescript/schema.d.ts
+++ b/types/typescript/schema.d.ts
@@ -53,11 +53,6 @@ export interface components {
             spec?: {
                 /** @description Sources contains the list of Git Repository source to resolve PluginDefinitions / ClusterPluginDefinitions from */
                 sources: {
-                    /**
-                     * @description Excludes contains a list of path patterns to exclude from the Catalog
-                     *     e.g. ["**\/test/**", "**\/example*\/**"]
-                     */
-                    excludes?: string[];
                     /** @description Overrides are the PluginDefinition overrides to be applied */
                     overrides?: {
                         /**


### PR DESCRIPTION
## Description

The excluded field is not used and in the current spec it is not possible to introduce exclusions.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [x] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [x] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
