### PR TITLE
fix(catalogs): update reconcile ordering and preserve validation failed conditions

### DIFF
--- a/internal/controller/catalog/catalog_controller_test.go
+++ b/internal/controller/catalog/catalog_controller_test.go
@@ -133,7 +133,7 @@ var _ = Describe("Catalog controller", Ordered, func() {
 				catalogReady := catalog.Status.GetConditionByType(greenhousemetav1alpha1.ReadyCondition)
 				g.Expect(catalogReady).ToNot(BeNil(), "the Catalog should have a Ready condition")
 				g.Expect(catalogReady.Status).To(Equal(metav1.ConditionFalse), "the Ready condition status should be False")
-				g.Expect(catalogReady.Reason).To(Equal(greenhousev1alpha1.CatalogNotReadyReason), "the Ready condition reason should be CatalogNotReady")
+				g.Expect(catalogReady.Reason).To(Equal(greenhousev1alpha1.CatalogEmptySources), "the Ready condition reason should be CatalogNotReady")
 			}).Should(Succeed(), "catalog status should be not ready when no sources are defined")
 		})
 


### PR DESCRIPTION
## Description

- sources check (if no sources then initiate orphan resource deletion) early exit
- validate sources (early exit)
- initiate orphan resource deletion (if any) (exit on error)

This PR ensures that the above reconciling functionalities should preserve their errors, messages and reasons when encountered and not be replaced by the generic _"not all catalog objects are ready"_

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [x] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
