### PR TITLE
refactor(tests): remove redundant repository field from HelmChart references

### DIFF
--- a/internal/controller/plugin/pluginpreset_controller_test.go
+++ b/internal/controller/plugin/pluginpreset_controller_test.go
@@ -51,9 +51,8 @@ var (
 	testTeam               = test.NewTeam(test.Ctx, "test-pluginpreset-team", test.TestNamespace, test.WithTeamLabel(greenhouseapis.LabelKeySupportGroup, "true"))
 	pluginPresetDefinition = test.NewClusterPluginDefinition(test.Ctx, pluginPresetDefinitionName, test.WithHelmChart(
 		&greenhousev1alpha1.HelmChartReference{
-			Name:       "./../../test/fixtures/chartWithConfigMap",
-			Repository: "dummy",
-			Version:    "1.0.0",
+			Name:    "./../../test/fixtures/chartWithConfigMap",
+			Version: "1.0.0",
 		}),
 		test.AppendPluginOption(greenhousev1alpha1.PluginOption{
 			Name:        "myRequiredOption",

--- a/internal/controller/plugin/remote_cluster_test.go
+++ b/internal/controller/plugin/remote_cluster_test.go
@@ -96,9 +96,8 @@ var (
 		test.Ctx,
 		"test-plugindefinition-crd",
 		test.WithHelmChart(&greenhousev1alpha1.HelmChartReference{
-			Name:       "./../../test/fixtures/myChartWithCRDs",
-			Repository: "dummy",
-			Version:    "1.0.0",
+			Name:    "./../../test/fixtures/myChartWithCRDs",
+			Version: "1.0.0",
 		}),
 	)
 
@@ -106,9 +105,8 @@ var (
 		test.Ctx,
 		"test-plugindefinition-exposed",
 		test.WithHelmChart(&greenhousev1alpha1.HelmChartReference{
-			Name:       "./../../test/fixtures/chartWithExposedService",
-			Repository: "dummy",
-			Version:    "1.3.0",
+			Name:    "./../../test/fixtures/chartWithExposedService",
+			Version: "1.3.0",
 		}))
 
 	testCluster = test.NewCluster(test.Ctx, "test-cluster", test.TestNamespace,

--- a/internal/controller/plugin/suite_test.go
+++ b/internal/controller/plugin/suite_test.go
@@ -100,7 +100,6 @@ var _ = Describe("HelmControllerTest", Serial, func() {
 
 		Namespace               = "greenhouse"
 		ReleaseName             = "myplugin-release"
-		HelmRepo                = "dummy"
 		HelmChart               = "./../../test/fixtures/myChart"
 		HelmChartUpdated        = "./../../test/fixtures/myChartV2"
 		HelmChartWithAllOptions = "./../../test/fixtures/chartWithEveryOption"
@@ -137,9 +136,8 @@ var _ = Describe("HelmControllerTest", Serial, func() {
 		testPluginDefinition = test.NewClusterPluginDefinition(test.Ctx, PluginDefinitionName,
 			test.WithVersion(PluginDefinitionVersion),
 			test.WithHelmChart(&greenhousev1alpha1.HelmChartReference{
-				Name:       HelmChart,
-				Repository: HelmRepo,
-				Version:    PluginDefinitionChartVersion,
+				Name:    HelmChart,
+				Version: PluginDefinitionChartVersion,
 			}),
 			test.AppendPluginOption(greenhousev1alpha1.PluginOption{
 				Name:        PluginOptionRequired,
@@ -446,9 +444,8 @@ var _ = Describe("HelmControllerTest", Serial, func() {
 			complexPluginDefinition = test.NewClusterPluginDefinition(test.Ctx, pluginWithEveryOption,
 				test.WithVersion(PluginDefinitionVersion),
 				test.WithHelmChart(&greenhousev1alpha1.HelmChartReference{
-					Name:       HelmChartWithAllOptions,
-					Repository: HelmRepo,
-					Version:    PluginDefinitionChartVersion,
+					Name:    HelmChartWithAllOptions,
+					Version: PluginDefinitionChartVersion,
 				}),
 				test.AppendPluginOption(greenhousev1alpha1.PluginOption{
 					Name:        PluginOptionDefault,

--- a/internal/helm/diff_test.go
+++ b/internal/helm/diff_test.go
@@ -37,9 +37,8 @@ var _ = Describe("ensure helm diff against the release manifest works as expecte
 	BeforeEach(func() {
 		pluginDefinitionUT = test.NewClusterPluginDefinition(test.Ctx, "test-plugindefinition",
 			test.WithHelmChart(&greenhousev1alpha1.HelmChartReference{
-				Name:       "./../test/fixtures/myChart",
-				Repository: "dummy",
-				Version:    "1.0.0",
+				Name:    "./../test/fixtures/myChart",
+				Version: "1.0.0",
 			}),
 		)
 
@@ -171,9 +170,8 @@ var _ = Describe("ensure helm with hooks diff against the release manifest works
 	BeforeEach(func() {
 		pluginDefinitionUT = test.NewClusterPluginDefinition(test.Ctx, "test-plugindefinition",
 			test.WithHelmChart(&greenhousev1alpha1.HelmChartReference{
-				Name:       "./../test/fixtures/testHook",
-				Repository: "dummy",
-				Version:    "1.0.0",
+				Name:    "./../test/fixtures/testHook",
+				Version: "1.0.0",
 			}))
 		pluginUT = test.NewPlugin(test.Ctx, "test-plugin", namespace,
 			test.WithPluginLabel(greenhouseapis.LabelKeyOwnedBy, "test-team-1"),

--- a/internal/helm/suite_test.go
+++ b/internal/helm/suite_test.go
@@ -75,9 +75,8 @@ var (
 		Spec: greenhousev1alpha1.PluginDefinitionSpec{
 			Version: "1.0.0",
 			HelmChart: &greenhousev1alpha1.HelmChartReference{
-				Name:       "./../test/fixtures/myChart",
-				Repository: "dummy",
-				Version:    "1.0.0",
+				Name:    "./../test/fixtures/myChart",
+				Version: "1.0.0",
 			},
 			Options: []greenhousev1alpha1.PluginOption{
 				{
@@ -122,9 +121,8 @@ var (
 		Spec: greenhousev1alpha1.PluginDefinitionSpec{
 			Version: "1.0.0",
 			HelmChart: &greenhousev1alpha1.HelmChartReference{
-				Name:       "./../test/fixtures/myChartWithCRDs",
-				Repository: "dummy",
-				Version:    "1.0.0",
+				Name:    "./../test/fixtures/myChartWithCRDs",
+				Version: "1.0.0",
 			},
 			Options: []greenhousev1alpha1.PluginOption{
 				{

--- a/internal/test/resources.go
+++ b/internal/test/resources.go
@@ -190,9 +190,8 @@ func NewClusterPluginDefinition(ctx context.Context, name string, opts ...func(d
 			Description: "TestPluginDefinition",
 			Version:     "1.0.0",
 			HelmChart: &greenhousev1alpha1.HelmChartReference{
-				Name:       "./../../test/fixtures/myChart",
-				Repository: "dummy",
-				Version:    "1.0.0",
+				Name:    "./../../test/fixtures/myChart",
+				Version: "1.0.0",
 			},
 		},
 	}
@@ -248,9 +247,8 @@ func NewPluginDefinition(ctx context.Context, name, namespace string, opts ...fu
 			Description: "TestPluginDefinition",
 			Version:     "1.0.0",
 			HelmChart: &greenhousev1alpha1.HelmChartReference{
-				Name:       "./../../test/fixtures/myChart",
-				Repository: "dummy",
-				Version:    "1.0.0",
+				Name:    "./../../test/fixtures/myChart",
+				Version: "1.0.0",
 			},
 		},
 	}


### PR DESCRIPTION
<!--
Please ensure the PR title follows the conventional commit format:
<type>(<scope>): description

For a list of accepted types and scopes see the workflow documentation: https://github.com/cloudoperators/greenhouse/blob/main/.github/workflows/ci-pr-title.yaml

-->

## Description

Since Helm 3.19 there is a warning when the repo is ignored
because a local helm chart is used.
Since the tests added a dummy repo, this repo is now dropped.
This will remove excess log lines in the tests


## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [x] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 

- Related Issue # (issue)
- Closes # (issue)
- Fixes # (issue)

-->

## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [ ] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
