### PR TITLE
fix(catalogs): retain catalog secret err in status

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -315,7 +315,7 @@ clean-e2e:
 
 .PHONY: e2e
 e2e:
-	GOMEGA_DEFAULT_EVENTUALLY_TIMEOUT="2m" \
+	GOMEGA_DEFAULT_EVENTUALLY_TIMEOUT="3m" \
 		go test -tags="$(SCENARIO)E2E" ${PWD}/e2e/$(SCENARIO) -mod=readonly -test.v -ginkgo.v --ginkgo.json-report=$(E2E_REPORT_PATH)
 
 .PHONY: e2e-local
@@ -325,7 +325,7 @@ e2e-local: prepare-e2e
     	GREENHOUSE_REMOTE_INT_KUBECONFIG="$(E2E_RESULT_DIR)/$(REMOTE_CLUSTER)-int.kubeconfig" \
     	CONTROLLER_LOGS_PATH="$(E2E_RESULT_DIR)/$(SCENARIO)-e2e-pod-logs.txt" \
     	EXECUTION_ENV=$(EXECUTION_ENV) \
-		GOMEGA_DEFAULT_EVENTUALLY_TIMEOUT="2m" \
+		GOMEGA_DEFAULT_EVENTUALLY_TIMEOUT="3m" \
 		go test -tags="$(SCENARIO)E2E" $(shell pwd)/e2e/$(SCENARIO) -test.v -ginkgo.v --ginkgo.json-report=$(E2E_REPORT_PATH)
 
 .PHONY: prepare-e2e

--- a/internal/controller/catalog/catalog_controller.go
+++ b/internal/controller/catalog/catalog_controller.go
@@ -32,6 +32,10 @@ import (
 	"github.com/cloudoperators/greenhouse/pkg/lifecycle"
 )
 
+const (
+	Source = "CatalogSource"
+)
+
 type CatalogReconciler struct {
 	client.Client
 	Scheme      *runtime.Scheme
@@ -69,7 +73,7 @@ func (r *CatalogReconciler) SetupWithManager(name string, mgr ctrl.Manager) erro
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 
 func (r *CatalogReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	return lifecycle.Reconcile(ctx, r.Client, req.NamespacedName, &greenhousev1alpha1.Catalog{}, r, r.setStatus())
+	return lifecycle.Reconcile(ctx, r.Client, req.NamespacedName, &greenhousev1alpha1.Catalog{}, r, func(_ context.Context, _ lifecycle.RuntimeObject) {})
 }
 
 func (r *CatalogReconciler) EnsureDeleted(_ context.Context, _ lifecycle.RuntimeObject) (ctrl.Result, lifecycle.ReconcileResult, error) {
@@ -238,44 +242,44 @@ func (r *CatalogReconciler) EnsureCreated(ctx context.Context, obj lifecycle.Run
 
 	catalog.SetProgressingReason()
 
-	var allErrors []error
+	var allErrors []catalogError
 	for _, s := range catalog.Spec.Sources {
 		sourcer, err := r.newCatalogSource(s, catalog)
 		if err != nil {
 			r.Log.Error(err, "failed to create source reconciler for catalog", "namespace", catalog.Namespace, "name", catalog.Name)
-			allErrors = append(allErrors, err)
+			allErrors = append(allErrors, catalogError{InventoryType: Source, Name: s.Repository + "-" + s.GetRefValue(), Error: err})
 			continue
 		}
 
 		if err = sourcer.reconcileGitRepository(ctx); err != nil {
 			r.Log.Error(err, "failed to reconcile git repository for catalog source", "namespace", catalog.Namespace, "name", sourcer.getGitRepoName())
-			allErrors = append(allErrors, err)
+			sourcer.setInventory(sourcev1.GitRepositoryKind, sourcer.getGitRepoName(), err.Error(), metav1.ConditionFalse)
+			allErrors = append(allErrors, catalogError{InventoryType: sourcev1.GitRepositoryKind, Name: sourcer.getGitRepoName(), Error: err})
 			continue
 		}
 
 		var externalArtifact *sourcev1.ExternalArtifact
 		if externalArtifact, err = sourcer.reconcileArtifactGeneration(ctx); err != nil {
 			r.Log.Error(err, "failed to reconcile artifact generation for catalog source", "namespace", catalog.Namespace, "name", sourcer.getArtifactName())
-			allErrors = append(allErrors, err)
+			allErrors = append(allErrors, catalogError{InventoryType: sourcev2.ArtifactGeneratorKind, Name: sourcer.getGeneratorName(), Error: err})
 			continue
 		}
 
-		ready, _ := sourcer.objectReadiness(ctx, externalArtifact)
+		ready, msg := sourcer.objectReadiness(ctx, externalArtifact)
 		if ready != metav1.ConditionTrue {
 			r.Log.Info("external artifact not ready yet, retry in next reconciliation loop", "namespace", catalog.Namespace, "name", sourcer.getArtifactName())
+			allErrors = append(allErrors, catalogError{InventoryType: sourcev1.ExternalArtifactKind, Name: sourcer.getArtifactName(), Error: errors.New(msg)})
 			continue
 		}
 
 		if err = sourcer.reconcileKustomization(ctx, externalArtifact); err != nil {
 			r.Log.Error(err, "failed to reconcile kustomization for catalog source", "namespace", catalog.Namespace, "name", sourcer.getKustomizationName())
-			allErrors = append(allErrors, err)
+			allErrors = append(allErrors, catalogError{InventoryType: kustomizev1.KustomizationKind, Name: sourcer.getKustomizationName(), Error: err})
 			continue
 		}
 	}
-	if len(allErrors) > 0 {
-		return ctrl.Result{}, lifecycle.Failed, utilerrors.NewAggregate(allErrors)
-	}
-	return ctrl.Result{}, lifecycle.Success, nil
+
+	return r.verifyStatus(ctx, catalog, allErrors)
 }
 
 // checkAndCleanInventory compares the current inventory in status with the desired inventory based on spec sources
@@ -371,71 +375,86 @@ func (r *CatalogReconciler) deleteOrphanedResource(ctx context.Context, obj clie
 	return nil
 }
 
-func (r *CatalogReconciler) setStatus() lifecycle.Conditioner {
-	return func(ctx context.Context, object lifecycle.RuntimeObject) {
-		catalog := object.(*greenhousev1alpha1.Catalog) //nolint:errcheck
-		existingNotReady := catalog.Status.GetConditionByType(greenhousemetav1alpha1.ReadyCondition)
-		if existingNotReady != nil && existingNotReady.Status == metav1.ConditionFalse {
-			if existingNotReady.Reason == greenhousev1alpha1.CatalogSourceValidationFail ||
-				existingNotReady.Reason == greenhousev1alpha1.OrphanedObjectCleanUpFail ||
-				existingNotReady.Reason == greenhousev1alpha1.CatalogEmptySources {
-				return
-			}
+func (r *CatalogReconciler) verifyStatus(ctx context.Context, catalog *greenhousev1alpha1.Catalog, allErrors []catalogError) (ctrl.Result, lifecycle.ReconcileResult, error) {
+	existingNotReady := catalog.Status.GetConditionByType(greenhousemetav1alpha1.ReadyCondition)
+	if existingNotReady != nil && existingNotReady.Status == metav1.ConditionFalse {
+		var err error
+		switch existingNotReady.Reason {
+		case greenhousev1alpha1.CatalogSourceValidationFail:
+			err = errors.New("catalog source validation failed")
+		case greenhousev1alpha1.OrphanedObjectCleanUpFail:
+			err = errors.New("orphaned object cleanup failed")
+		case greenhousev1alpha1.CatalogEmptySources:
+			err = errors.New("no sources specified for catalog")
 		}
-		var allInventoryReady []metav1.ConditionStatus
-		var srcErrs []error
-		for _, source := range catalog.Spec.Sources {
-			sourcer, srcErr := r.newCatalogSource(source, catalog)
-			if srcErr != nil {
-				srcErrs = append(srcErrs, srcErr)
-				continue
-			}
-			gitRepo := &sourcev1.GitRepository{}
-			gitRepo.SetName(sourcer.getGitRepoName())
-			gitRepo.SetNamespace(catalog.Namespace)
-			ready, msg := sourcer.objectReadiness(ctx, gitRepo)
-			allInventoryReady = append(allInventoryReady, ready)
-			sourcer.setInventory(sourcev1.GitRepositoryKind, gitRepo.Name, msg, ready)
-
-			artifactGen := &sourcev2.ArtifactGenerator{}
-			artifactGen.SetName(sourcer.getGeneratorName())
-			artifactGen.SetNamespace(catalog.Namespace)
-			ready, msg = sourcer.objectReadiness(ctx, artifactGen)
-			allInventoryReady = append(allInventoryReady, ready)
-			sourcer.setInventory(sourcev2.ArtifactGeneratorKind, artifactGen.Name, msg, ready)
-
-			extArtifact := &sourcev1.ExternalArtifact{}
-			extArtifact.SetName(sourcer.getArtifactName())
-			extArtifact.SetNamespace(catalog.Namespace)
-			ready, msg = sourcer.objectReadiness(ctx, extArtifact)
-			allInventoryReady = append(allInventoryReady, ready)
-			sourcer.setInventory(sourcev1.ExternalArtifactKind, extArtifact.Name, msg, ready)
-
-			kustomization := &kustomizev1.Kustomization{}
-			kustomization.SetName(sourcer.getKustomizationName())
-			kustomization.SetNamespace(catalog.Namespace)
-			ready, msg = sourcer.objectReadiness(ctx, kustomization)
-			allInventoryReady = append(allInventoryReady, ready)
-			sourcer.setInventory(kustomizev1.KustomizationKind, kustomization.Name, msg, ready)
+		if err != nil {
+			return ctrl.Result{}, lifecycle.Failed, err
 		}
-
-		if len(srcErrs) > 0 {
-			err := utilerrors.NewAggregate(srcErrs)
-			msg := "inventory readiness check incomplete: " + err.Error()
-			r.Log.Error(err, "inventory readiness check incomplete", "namespace", catalog.Namespace, "name", catalog.Name)
-			catalog.SetFalseCondition(greenhousemetav1alpha1.ReadyCondition, greenhousev1alpha1.CatalogNotReadyReason, msg)
-			return
-		}
-
-		notReady := slices.ContainsFunc(allInventoryReady, func(status metav1.ConditionStatus) bool {
-			return status != metav1.ConditionTrue // the status can contain Unknown as well
-		})
-		if notReady {
-			r.Log.Info("not all catalog objects are ready", "namespace", catalog.Namespace, "name", catalog.Name)
-			catalog.SetFalseCondition(greenhousemetav1alpha1.ReadyCondition, greenhousev1alpha1.CatalogNotReadyReason, "not all catalog objects are ready")
-			return
-		}
-		r.Log.Info("all catalog objects are ready", "namespace", catalog.Namespace, "name", catalog.Name)
-		catalog.SetTrueCondition(greenhousemetav1alpha1.ReadyCondition, greenhousev1alpha1.CatalogReadyReason, "all catalog objects are ready")
 	}
+
+	var allInventoryReady []metav1.ConditionStatus
+	for _, source := range catalog.Spec.Sources {
+		sourcer, srcErr := r.newCatalogSource(source, catalog)
+		if srcErr != nil {
+			allErrors = append(allErrors, catalogError{InventoryType: Source, Name: source.Repository + "-" + source.GetRefValue(), Error: srcErr})
+			continue
+		}
+		gitRepo := &sourcev1.GitRepository{}
+		gitRepo.SetName(sourcer.getGitRepoName())
+		gitRepo.SetNamespace(catalog.Namespace)
+		ready, msg := sourcer.objectReadiness(ctx, gitRepo)
+		allInventoryReady = append(allInventoryReady, ready)
+		sourcer.setInventory(sourcev1.GitRepositoryKind, gitRepo.Name, msg, ready)
+
+		artifactGen := &sourcev2.ArtifactGenerator{}
+		artifactGen.SetName(sourcer.getGeneratorName())
+		artifactGen.SetNamespace(catalog.Namespace)
+		ready, msg = sourcer.objectReadiness(ctx, artifactGen)
+		allInventoryReady = append(allInventoryReady, ready)
+		sourcer.setInventory(sourcev2.ArtifactGeneratorKind, artifactGen.Name, msg, ready)
+
+		extArtifact := &sourcev1.ExternalArtifact{}
+		extArtifact.SetName(sourcer.getArtifactName())
+		extArtifact.SetNamespace(catalog.Namespace)
+		ready, msg = sourcer.objectReadiness(ctx, extArtifact)
+		allInventoryReady = append(allInventoryReady, ready)
+		sourcer.setInventory(sourcev1.ExternalArtifactKind, extArtifact.Name, msg, ready)
+
+		kustomization := &kustomizev1.Kustomization{}
+		kustomization.SetName(sourcer.getKustomizationName())
+		kustomization.SetNamespace(catalog.Namespace)
+		ready, msg = sourcer.objectReadiness(ctx, kustomization)
+		allInventoryReady = append(allInventoryReady, ready)
+		sourcer.setInventory(kustomizev1.KustomizationKind, kustomization.Name, msg, ready)
+	}
+
+	notReady := slices.ContainsFunc(allInventoryReady, func(status metav1.ConditionStatus) bool {
+		return status != metav1.ConditionTrue
+	})
+
+	aggErr := formatCatalogErrors(allErrors)
+	if aggErr != nil || notReady {
+		errMsg := "not all catalog objects are ready"
+		if aggErr != nil {
+			errMsg = errMsg + ": " + aggErr.Error()
+		}
+		r.Log.Info(errMsg, "namespace", catalog.Namespace, "name", catalog.Name)
+		catalog.SetFalseCondition(greenhousemetav1alpha1.ReadyCondition, greenhousev1alpha1.CatalogNotReadyReason, errMsg)
+		return ctrl.Result{}, lifecycle.Failed, errors.New(errMsg)
+	}
+
+	r.Log.Info("all catalog objects are ready", "namespace", catalog.Namespace, "name", catalog.Name)
+	catalog.SetTrueCondition(greenhousemetav1alpha1.ReadyCondition, greenhousev1alpha1.CatalogReadyReason, "all catalog objects are ready")
+	return ctrl.Result{}, lifecycle.Success, nil
+}
+
+func formatCatalogErrors(allErrors []catalogError) error {
+	if len(allErrors) == 0 {
+		return nil
+	}
+	var errs []error
+	for _, err := range allErrors {
+		errs = append(errs, fmt.Errorf("%s/%s: %w", err.InventoryType, err.Name, err.Error))
+	}
+	return utilerrors.NewAggregate(errs)
 }

--- a/internal/controller/catalog/source.go
+++ b/internal/controller/catalog/source.go
@@ -53,6 +53,12 @@ const (
 	kustomizeArtifactPrefix = "kustomize"
 )
 
+type catalogError struct {
+	InventoryType string
+	Name          string
+	Error         error
+}
+
 type source struct {
 	client.Client
 	scheme                   *runtime.Scheme


### PR DESCRIPTION
## Description

Catalog should retain secret error while applying `GitRepository` resource.

If there is an error checking the existence of `.spec.sources[*].secretName` _Secret_ then it will be reflected in the Catalog StatusConditions.

> [!NOTE]
> In general, all error messages are aggregated and added to catalog ready condition message

```yaml
apiVersion: greenhouse.sap/v1alpha1
kind: Catalog
  name: greenhouse-extensions
  namespace: demo
spec:
  sources:
  - overrides:
    - alias: cert-manager-overridden
      name: cert-manager
    ref:
      branch: main
    repository: https://github.com/cloudoperators/greenhouse-extensions
    resources:
    - alerts/plugindefinition.yaml
    - cert-manager/plugindefinition.yaml
    - ingress-nginx/plugindefinition.yaml
    - kube-monitoring/plugindefinition.yaml
    secretName: github
  - overrides:
    - alias: perses-overridden
      name: perses
    ref:
      sha: ed3ff23bca21eef6cffc0956df338d8185340fc5
    repository: https://github.com/cloudoperators/greenhouse-extensions
    resources:
    - perses/plugindefinition.yaml
status:
  inventory:
   ....
  statusConditions:
    conditions:
    - lastTransitionTime: "2026-01-16T14:28:33Z"
      message: >-
        not all catalog objects are ready:
        GitRepository/repository-9689366613293914683: failed to get secret
        demo/github: Secret "github" not found
      reason: CatalogNotReady
      status: "False"
      type: Ready
```


## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [ ] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
