### PR TITLE
fix(e2e): catalog tests use plugindefinitions

### DIFF
--- a/e2e/catalog/e2e_test.go
+++ b/e2e/catalog/e2e_test.go
@@ -59,7 +59,7 @@ var _ = AfterSuite(func() {
 
 var _ = Describe("Catalog E2E", Ordered, func() {
 	var catalog *greenhousev1alpha1.Catalog
-	var clusterPluginDefinitions *greenhousev1alpha1.ClusterPluginDefinitionList
+	var pluginDefinitions *greenhousev1alpha1.PluginDefinitionList
 	It("should successfully create a Catalog resource", func() {
 		source := test.NewCatalogSource(
 			test.WithRepositoryBranch("main"),
@@ -75,9 +75,9 @@ var _ = Describe("Catalog E2E", Ordered, func() {
 		)
 		Expect(adminClient.Create(ctx, catalog)).To(Succeed(), "there should be no error creating the Catalog resource")
 		expect.CatalogReady(ctx, adminClient, env.TestNamespace, catalog.Name)
-		clusterPluginDefinitions = &greenhousev1alpha1.ClusterPluginDefinitionList{}
-		Expect(adminClient.List(ctx, clusterPluginDefinitions)).To(Succeed(), "there should be no error listing ClusterPluginDefinitions")
-		Expect(clusterPluginDefinitions.Items).ToNot(BeEmpty(), "there should be at least one ClusterPluginDefinition created from the Catalog")
-		Expect(clusterPluginDefinitions.Items).To(HaveLen(2), "there should be exactly two ClusterPluginDefinitions created from the Catalog")
+		pluginDefinitions = &greenhousev1alpha1.PluginDefinitionList{}
+		Expect(adminClient.List(ctx, pluginDefinitions)).To(Succeed(), "there should be no error listing pluginDefinitions")
+		Expect(pluginDefinitions.Items).ToNot(BeEmpty(), "there should be at least one pluginDefinition created from the Catalog")
+		Expect(pluginDefinitions.Items).To(HaveLen(2), "there should be exactly two pluginDefinitions created from the Catalog")
 	})
 })


### PR DESCRIPTION
<!--
Please ensure the PR title follows the conventional commit format:
<type>(<scope>): description

For a list of accepted types and scopes see the workflow documentation: https://github.com/cloudoperators/greenhouse/blob/main/.github/workflows/ci-pr-title.yaml

-->

## Description
<!--
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 

- Related Issue # (issue)
- Closes # (issue)
- Fixes # (issue)

-->

## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [ ] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
