### PR TITLE
fix(dev-env): write remote cluster structured auth to bin folder

### DIFF
--- a/.github/workflows/ci-pr-title.yaml
+++ b/.github/workflows/ci-pr-title.yaml
@@ -65,6 +65,7 @@ jobs:
             e2e
             greenhouse
             greenhousectl
+            dev-env
             actions
             template
             tests

--- a/dev-env/dev.config.yaml
+++ b/dev-env/dev.config.yaml
@@ -12,7 +12,8 @@ config:
         - command: kubectl --kubeconfig "${kubeconfig}" get cm kube-root-ca.crt -n default -o json | jq -r '.data."ca.crt"' | tee bin/greenhouse-admin-ca.crt
           vars:
             kubeconfig: kubeconfig
-        - command: yq eval --inplace '.jwt[0].issuer.certificateAuthority = load_str("./bin/greenhouse-admin-ca.crt")' ./dev-env/structured-auth.yaml
+        - command: cp ./dev-env/structured-auth.yaml ./bin/structured-auth.yaml
+        - command: yq eval --inplace '.jwt[0].issuer.certificateAuthority = load_str("./bin/greenhouse-admin-ca.crt")' ./bin/structured-auth.yaml
         - command: kubectl create clusterrolebinding ${clusterRoleBinding} --clusterrole=${clusterRole} --group=${group} --dry-run=client -o yaml | kubectl apply --kubeconfig "${kubeconfig}" -f -
           vars:
             kubeconfig: kubeconfig
@@ -34,5 +35,3 @@ config:
   - cluster:
       name: greenhouse-remote
       configPath: dev-env/greenhouse-remote-cluster.yaml
-      postSetup:
-        - command: yq eval --inplace '.jwt[0].issuer.certificateAuthority = "<placeholder>"' ./dev-env/structured-auth.yaml

--- a/dev-env/greenhouse-remote-cluster.yaml
+++ b/dev-env/greenhouse-remote-cluster.yaml
@@ -6,7 +6,7 @@ apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
   - role: control-plane
     extraMounts:
-      - hostPath: ./dev-env/structured-auth.yaml
+      - hostPath: ./bin/structured-auth.yaml
         containerPath: /etc/kubernetes/structured-auth.yaml
     kubeadmConfigPatches:
       - |


### PR DESCRIPTION
## Description

Currently for remote cluster structured authentication we have a placeholder for certificate (self-signed) for the issuer (Admin Cluster)

Dev env setup automation replaces the placeholder with the certificate, creates the kind clusters and then replaces the certificate with placeholder to avoid committing it to git.

But this cluster soon becomes unusable after a restart as the certificate is no longer present in the path when the docker daemon runs. 

To avoid recreating remote-clusters always, we can persist the structured auth config to the ignored bin folder.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [x] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
