### PR TITLE
feat(utils): add typed cel evaluation

### DIFF
--- a/internal/cel/evaluator_test.go
+++ b/internal/cel/evaluator_test.go
@@ -126,6 +126,25 @@ var _ = Describe("CEL Evaluator", func() {
 			Expect(err.Error()).To(ContainSubstring("no such key"))
 			Expect(result).To(BeNil())
 		})
+
+		It("should evaluate into typed fields", func() {
+			result, err := cel.EvaluateTyped[*fixtures.DummySpec]("object.spec", dummy)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).ToNot(BeNil())
+			Expect(result).To(BeAssignableToTypeOf(&fixtures.DummySpec{}))
+
+			ptrStr, err := cel.EvaluateTyped[*string]("object.metadata.name", dummy)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ptrStr).ToNot(BeNil())
+			Expect(ptrStr).To(BeAssignableToTypeOf(new(string)))
+			Expect(*ptrStr).To(Equal("test-dummy"))
+
+			labels, err := cel.EvaluateTyped[map[string]string]("object.metadata.labels", dummy)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(labels).ToNot(BeNil())
+			Expect(labels).To(BeAssignableToTypeOf(map[string]string{}))
+			Expect(labels["app"]).To(Equal("test-app"))
+		})
 	})
 
 	Describe("EvaluateList", func() {


### PR DESCRIPTION
## Description

Typed CEL Evaluation 

For #1426 we need the value of CEL that is evaluated to be type safe

Current CEL will evaluate it into any, which might result into undesired helm values.

Consider the scenario where a plugin has the following ingress hosts -

```yaml
apiVersion: greenhouse.sap/v1alpha1
kind: Plugin
metadata:
  name: plugin-a
  namespace: demo
spec:
...
  optionValues:
...
    - name: ingress.hosts
      value:
        - ingress-a.example.com
        - ingress-plugin-a.example.com
...
```

plugin-b needs to extract the hosts from plugin-a

```yaml
apiVersion: greenhouse.sap/v1alpha1
kind: Plugin
metadata:
  name: plugin-b
  namespace: demo
spec:
...
  optionValues:
...
    - name: ingress.hosts
      valueRef:
          apiVersion: greenhouse.sap/v1alpha1
          kind: Plugin
          name: plugin-a
          expression: "<CEL-EXPR>"
...
```

the expression - `object.spec.optionValues.filter(o, o.name == 'ingress.hosts')[0].value[0]` returns the first element in the array.

the expression - `object.spec.optionValues.filter(o, o.name == 'ingress.hosts')[0].value` returns the array as is.

typed evaluation usage -  `value, err := cel.EvaluateTyped[[]string](expr, object)`

The first expression will return error as the evaluation is a `string` and not an `[]string`

The second expression will succeed as the evaluated value is indeed an `[]string`

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

- Related Issue #1426 

## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

validating type evaluation result

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [x] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
