### PR TITLE
fix(flux): handle HelmRelease max retries exhausted

### DIFF
--- a/api/v1alpha1/plugin_types.go
+++ b/api/v1alpha1/plugin_types.go
@@ -158,6 +158,9 @@ const (
 	// WaitingForDependenciesCondition reflects if HelmRelease is waiting for other releases to be ready.
 	WaitingForDependenciesCondition greenhousemetav1alpha1.ConditionType = "WaitingForDependencies"
 
+	// RetriesExhaustedCondition reflects if the HelmRelease has exhausted all retries.
+	RetriesExhaustedCondition greenhousemetav1alpha1.ConditionType = "RetriesExhausted"
+
 	// PluginDefinitionNotFoundReason is set when the pluginDefinition is not found.
 	PluginDefinitionNotFoundReason greenhousemetav1alpha1.ConditionReason = "PluginDefinitionNotFound"
 

--- a/internal/controller/plugin/util.go
+++ b/internal/controller/plugin/util.go
@@ -42,6 +42,7 @@ var exposedConditions = []greenhousemetav1alpha1.ConditionType{
 	greenhousev1alpha1.WorkloadReadyCondition,
 	greenhousemetav1alpha1.OwnerLabelSetCondition,
 	greenhousev1alpha1.WaitingForDependenciesCondition,
+	greenhousev1alpha1.RetriesExhaustedCondition,
 }
 
 type reconcileResult struct {


### PR DESCRIPTION
## Description
Add `RetriesExhausted` condition to Plugin status to indicate when a HelmRelease has exhausted all install/upgrade retries. The condition message shows the current failure counts and max retries configured.

Set `reconcile.fluxcd.io/resetAt` annotation alongside `requestedAt` when the `greenhouse.sap/reconcile` annotation is used. This ensures Flux resets the failure counters, allowing the HelmRelease to retry after fixing the underlying issue.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

- Fixes https://github.com/cloudoperators/greenhouse/issues/1622

## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [x] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
