### PR TITLE
docs(catalogs): add options override documentation

### DIFF
--- a/docs/reference/components/catalog.md
+++ b/docs/reference/components/catalog.md
@@ -242,8 +242,8 @@ spec:
 **NOTE:**
 
 - The `optionsOverride[].name` must match an existing option name in the PluginDefinition's `.spec.options[]`
-- The `value` type must match the option's type (string, bool, int, list, map)
-- This only overrides the **default value** of the option, not its required/optional status
+- The `value` type must match the option's type.
+- This only overrides the **default value** of the option.
 - If the option doesn't exist in the PluginDefinition, the override will be ignored
 
 ### Suspending the Catalog's reconciliation


### PR DESCRIPTION
## Description

documenting optionsOverride feature in catalog

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [x] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

- Related Issue #998 

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)


## Added to documentation?

- [ ] 📜 README.md
- [x] 🤝 Documentation pages updated
- [ ] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
