### PR TITLE
fix(core): rewrite Host header for Envoy compatibility

### DIFF
--- a/cmd/cors-proxy/main.go
+++ b/cmd/cors-proxy/main.go
@@ -108,12 +108,7 @@ func doRun(targetURL string) error {
 		return nil
 	}
 
-	reverseProxy := &httputil.ReverseProxy{
-		Rewrite: func(r *httputil.ProxyRequest) {
-			r.SetURL(target)
-			r.SetXForwarded()
-		},
-	}
+	reverseProxy := newReverseProxy(target)
 
 	tlsConfig := &tls.Config{MinVersion: tls.VersionTLS12}
 	if targetCAFile != "" {
@@ -174,6 +169,15 @@ func doRun(targetURL string) error {
 	})
 
 	return g.Run()
+}
+
+func newReverseProxy(target *url.URL) *httputil.ReverseProxy {
+	return &httputil.ReverseProxy{
+		Rewrite: func(r *httputil.ProxyRequest) {
+			r.SetURL(target)
+			r.Out.Host = target.Host
+		},
+	}
 }
 
 func printHeader() {

--- a/cmd/cors-proxy/main_test.go
+++ b/cmd/cors-proxy/main_test.go
@@ -6,7 +6,6 @@ package main
 import (
 	"net/http"
 	"net/http/httptest"
-	"net/http/httputil"
 	"net/url"
 	"testing"
 
@@ -14,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestRewriteSetsHostHeader(t *testing.T) {
+func TestReverseProxyRewritesHostToTarget(t *testing.T) {
 	var receivedHost string
 	targetServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		receivedHost = r.Host
@@ -25,12 +24,7 @@ func TestRewriteSetsHostHeader(t *testing.T) {
 	target, err := url.Parse(targetServer.URL)
 	require.NoError(t, err)
 
-	reverseProxy := &httputil.ReverseProxy{
-		Rewrite: func(r *httputil.ProxyRequest) {
-			r.SetURL(target)
-			r.SetXForwarded()
-		},
-	}
+	reverseProxy := newReverseProxy(target)
 
 	proxy := httptest.NewServer(reverseProxy)
 	defer proxy.Close()


### PR DESCRIPTION
## Description
Use `ReverseProxy.Rewrite` with `SetURL` to rewrite Host header to target URL. `NewSingleHostReverseProxy` preserves original Host header which causes 404 errors with Envoy-based loadbalancers in Gardener.
Rewrite replaces the deprecated `Director` approach and handles Host rewriting automatically via `SetURL`.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

- Fixes https://github.com/cloudoperators/greenhouse/issues/1654

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [x] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
