### PR TITLE
fix(catalogs): use eventually scoped gomega

### DIFF
--- a/e2e/catalog/scenarios/scenario.go
+++ b/e2e/catalog/scenarios/scenario.go
@@ -208,7 +208,7 @@ func (s *scenario) expectKustomizationReady(ctx context.Context, groupKey string
 		g.Expect(readyCond).ToNot(BeNil(), "the Kustomization should have a Ready condition")
 		g.Expect(readyCond.Status).To(Equal(metav1.ConditionTrue), "the Kustomization Ready condition status should be True - "+kustomization.Name)
 		inventory = kustomization.Status.Inventory
-		Expect(inventory).ToNot(BeNil(), "the Kustomization status inventory should not be nil")
+		g.Expect(inventory).ToNot(BeNil(), "the Kustomization status inventory should not be nil")
 	}).Should(Succeed(), "flux Kustomization should be created for the Catalog source")
 	s.verifyPluginDefinitions(ctx, inventory, overrides)
 }


### PR DESCRIPTION
<!--
Please ensure the PR title follows the conventional commit format:
<type>(<scope>): description

For a list of accepted types and scopes see the workflow documentation: https://github.com/cloudoperators/greenhouse/blob/main/.github/workflows/ci-pr-title.yaml

-->

## Description

e2e was flaky with incomplete kustomization inventory. This ensures the eventually-scoped gomega variable is used for test verifications.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 

- Related Issue # (issue)
- Closes # (issue)
- Fixes # (issue)

-->

## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [ ] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
