### PR TITLE
feat(greenhouse): ensure suspended conditions in lifecycle

### DIFF
--- a/api/meta/v1alpha1/conditions_constants.go
+++ b/api/meta/v1alpha1/conditions_constants.go
@@ -22,4 +22,11 @@ const (
 	OwnerLabelSetToNotExistingTeamReason ConditionReason = "OwnerLabelNotExistingTeam"
 	// OwnerLabelSetToNonSupportGroupTeamReason is set when the resource has the owned-by label set to a non-support-group Team.
 	OwnerLabelSetToNonSupportGroupTeamReason ConditionReason = "OwnerLabelSetToNonSupportGroupTeam"
+
+	// SuspendedCondition reflects that the resource is suspended.
+	SuspendedCondition ConditionType = "Suspended"
+	// ResourceSuspendedReason is set when the resource is successfully suspended.
+	ResourceSuspendedReason ConditionReason = "ResourceSuspended"
+	// ResourceSuspensionFailedReason is set when the resource suspension failed.
+	ResourceSuspensionFailedReason ConditionReason = "ResourceSuspensionFailed"
 )

--- a/api/v1alpha1/catalog_types.go
+++ b/api/v1alpha1/catalog_types.go
@@ -258,6 +258,16 @@ func (c *Catalog) SetTrueCondition(conditionType greenhousemetav1alpha1.Conditio
 	c.SetCondition(greenhousemetav1alpha1.TrueCondition(conditionType, reason, message))
 }
 
+func (c *Catalog) RemoveCondition(conditionType greenhousemetav1alpha1.ConditionType) {
+	c.Status.Conditions = slices.DeleteFunc(c.Status.Conditions, func(cond greenhousemetav1alpha1.Condition) bool {
+		return cond.Type == conditionType
+	})
+}
+
+func (c *Catalog) CanBeSuspended() bool {
+	return true
+}
+
 func init() {
 	SchemeBuilder.Register(&Catalog{}, &CatalogList{})
 }

--- a/api/v1alpha1/cluster_types.go
+++ b/api/v1alpha1/cluster_types.go
@@ -4,6 +4,8 @@
 package v1alpha1
 
 import (
+	"slices"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	greenhousemetav1alpha1 "github.com/cloudoperators/greenhouse/api/meta/v1alpha1"
@@ -113,6 +115,16 @@ func (c *Cluster) GetConditions() greenhousemetav1alpha1.StatusConditions {
 
 func (c *Cluster) SetCondition(condition greenhousemetav1alpha1.Condition) {
 	c.Status.SetConditions(condition)
+}
+
+func (c *Cluster) RemoveCondition(conditionType greenhousemetav1alpha1.ConditionType) {
+	c.Status.Conditions = slices.DeleteFunc(c.Status.Conditions, func(cond greenhousemetav1alpha1.Condition) bool {
+		return cond.Type == conditionType
+	})
+}
+
+func (c *Cluster) CanBeSuspended() bool {
+	return false
 }
 
 // GetSecretName returns the Kubernetes secret containing sensitive data for this cluster.

--- a/api/v1alpha1/clusterplugindefinition_types.go
+++ b/api/v1alpha1/clusterplugindefinition_types.go
@@ -4,6 +4,8 @@
 package v1alpha1
 
 import (
+	"slices"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	greenhousemetav1alpha1 "github.com/cloudoperators/greenhouse/api/meta/v1alpha1"
@@ -53,6 +55,16 @@ func (c *ClusterPluginDefinition) GetConditions() greenhousemetav1alpha1.StatusC
 
 func (c *ClusterPluginDefinition) SetCondition(condition greenhousemetav1alpha1.Condition) {
 	c.Status.SetConditions(condition)
+}
+
+func (c *ClusterPluginDefinition) RemoveCondition(conditionType greenhousemetav1alpha1.ConditionType) {
+	c.Status.Conditions = slices.DeleteFunc(c.Status.Conditions, func(cond greenhousemetav1alpha1.Condition) bool {
+		return cond.Type == conditionType
+	})
+}
+
+func (c *ClusterPluginDefinition) CanBeSuspended() bool {
+	return false
 }
 
 func init() {

--- a/api/v1alpha1/organization_types.go
+++ b/api/v1alpha1/organization_types.go
@@ -4,6 +4,8 @@
 package v1alpha1
 
 import (
+	"slices"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	greenhousemetav1alpha1 "github.com/cloudoperators/greenhouse/api/meta/v1alpha1"
@@ -146,6 +148,16 @@ func (o *Organization) GetConditions() greenhousemetav1alpha1.StatusConditions {
 
 func (o *Organization) SetCondition(condition greenhousemetav1alpha1.Condition) {
 	o.Status.SetConditions(condition)
+}
+
+func (o *Organization) RemoveCondition(conditionType greenhousemetav1alpha1.ConditionType) {
+	o.Status.Conditions = slices.DeleteFunc(o.Status.Conditions, func(cond greenhousemetav1alpha1.Condition) bool {
+		return cond.Type == conditionType
+	})
+}
+
+func (o *Organization) CanBeSuspended() bool {
+	return false
 }
 
 func (o *OrganizationSpec) GetSCIMConfig() *SCIMConfig {

--- a/api/v1alpha1/plugin_types.go
+++ b/api/v1alpha1/plugin_types.go
@@ -4,6 +4,8 @@
 package v1alpha1
 
 import (
+	"slices"
+
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -298,4 +300,14 @@ func (o *Plugin) GetReleaseName() string {
 		return o.Spec.ReleaseName
 	}
 	return o.Name
+}
+
+func (o *Plugin) RemoveCondition(conditionType greenhousemetav1alpha1.ConditionType) {
+	o.Status.Conditions = slices.DeleteFunc(o.Status.Conditions, func(cond greenhousemetav1alpha1.Condition) bool {
+		return cond.Type == conditionType
+	})
+}
+
+func (o *Plugin) CanBeSuspended() bool {
+	return true
 }

--- a/api/v1alpha1/plugindefinition_types.go
+++ b/api/v1alpha1/plugindefinition_types.go
@@ -6,6 +6,7 @@ package v1alpha1
 import (
 	"encoding/json"
 	"fmt"
+	"slices"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -247,6 +248,16 @@ func (p *PluginDefinition) GetConditions() greenhousemetav1alpha1.StatusConditio
 
 func (p *PluginDefinition) SetCondition(condition greenhousemetav1alpha1.Condition) {
 	p.Status.SetConditions(condition)
+}
+
+func (p *PluginDefinition) RemoveCondition(conditionType greenhousemetav1alpha1.ConditionType) {
+	p.Status.Conditions = slices.DeleteFunc(p.Status.Conditions, func(cond greenhousemetav1alpha1.Condition) bool {
+		return cond.Type == conditionType
+	})
+}
+
+func (p *PluginDefinition) CanBeSuspended() bool {
+	return false
 }
 
 func init() {

--- a/api/v1alpha1/pluginpreset_types.go
+++ b/api/v1alpha1/pluginpreset_types.go
@@ -4,6 +4,8 @@
 package v1alpha1
 
 import (
+	"slices"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	greenhousemetav1alpha1 "github.com/cloudoperators/greenhouse/api/meta/v1alpha1"
@@ -104,6 +106,16 @@ func (c *PluginPreset) GetConditions() greenhousemetav1alpha1.StatusConditions {
 
 func (c *PluginPreset) SetCondition(condition greenhousemetav1alpha1.Condition) {
 	c.Status.SetConditions(condition)
+}
+
+func (c *PluginPreset) RemoveCondition(conditionType greenhousemetav1alpha1.ConditionType) {
+	c.Status.Conditions = slices.DeleteFunc(c.Status.Conditions, func(cond greenhousemetav1alpha1.Condition) bool {
+		return cond.Type == conditionType
+	})
+}
+
+func (c *PluginPreset) CanBeSuspended() bool {
+	return false
 }
 
 //+kubebuilder:object:root=true

--- a/api/v1alpha1/team_types.go
+++ b/api/v1alpha1/team_types.go
@@ -4,6 +4,8 @@
 package v1alpha1
 
 import (
+	"slices"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	greenhousemetav1alpha1 "github.com/cloudoperators/greenhouse/api/meta/v1alpha1"
@@ -81,4 +83,14 @@ func (o *Team) GetConditions() greenhousemetav1alpha1.StatusConditions {
 
 func (o *Team) SetCondition(condition greenhousemetav1alpha1.Condition) {
 	o.Status.StatusConditions.SetConditions(condition)
+}
+
+func (o *Team) RemoveCondition(conditionType greenhousemetav1alpha1.ConditionType) {
+	o.Status.StatusConditions.Conditions = slices.DeleteFunc(o.Status.StatusConditions.Conditions, func(cond greenhousemetav1alpha1.Condition) bool {
+		return cond.Type == conditionType
+	})
+}
+
+func (o *Team) CanBeSuspended() bool {
+	return false
 }

--- a/api/v1alpha2/teamrolebinding_types.go
+++ b/api/v1alpha2/teamrolebinding_types.go
@@ -87,6 +87,16 @@ func (trb *TeamRoleBinding) SetCondition(condition greenhousemetav1alpha1.Condit
 	trb.Status.SetConditions(condition)
 }
 
+func (trb *TeamRoleBinding) RemoveCondition(conditionType greenhousemetav1alpha1.ConditionType) {
+	trb.Status.Conditions = slices.DeleteFunc(trb.Status.Conditions, func(cond greenhousemetav1alpha1.Condition) bool {
+		return cond.Type == conditionType
+	})
+}
+
+func (trb *TeamRoleBinding) CanBeSuspended() bool {
+	return false
+}
+
 // SetPropagationStatus updates the TeamRoleBinding's PropagationStatus for the Cluster
 func (trb *TeamRoleBinding) SetPropagationStatus(cluster string, rbacReady metav1.ConditionStatus, reason greenhousemetav1alpha1.ConditionReason, message string) {
 	condition := greenhousemetav1alpha1.NewCondition(RBACReady, rbacReady, reason, message)

--- a/internal/controller/fixtures/dummy_types.go
+++ b/internal/controller/fixtures/dummy_types.go
@@ -4,6 +4,8 @@
 package fixtures
 
 import (
+	"slices"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
@@ -153,4 +155,14 @@ func (in *Dummy) GetConditions() greenhousemetav1alpha1.StatusConditions {
 
 func (in *Dummy) SetCondition(condition greenhousemetav1alpha1.Condition) {
 	in.Status.SetConditions(condition)
+}
+
+func (in *Dummy) RemoveCondition(conditionType greenhousemetav1alpha1.ConditionType) {
+	in.Status.Conditions = slices.DeleteFunc(in.Status.Conditions, func(cond greenhousemetav1alpha1.Condition) bool {
+		return cond.Type == conditionType
+	})
+}
+
+func (in *Dummy) CanBeSuspended() bool {
+	return true
 }


### PR DESCRIPTION
## Description

Certain resources can be suspended by annotating the resource with `greenhouse.sap/suspend: "true"`

When annotated `Suspended` condition is set.
It is removed once it enters the regular reconciliation of `EnsureCreated`

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

`lifecycle.Reconcile` tests updated

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [ ] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
