### PR TITLE
feat(catalogs): catalog propagate owned-by label to (Cluster)PluginDefinitions

### DIFF
--- a/e2e/catalog/scenarios/catalog_option_overrides.go
+++ b/e2e/catalog/scenarios/catalog_option_overrides.go
@@ -88,7 +88,7 @@ func (s *scenario) createCatalogAndVerifySuccess(ctx context.Context, catalog *g
 	s.catalog = catalog
 	s.catalog.Spec.Sources = append(s.catalog.Spec.Sources, source)
 	Expect(s.createCatalogIfNotExists(ctx)).ToNot(HaveOccurred(), "there should be no error creating the initial Catalog")
-	s.verifySuccess(ctx)
+	s.verifySuccess(ctx, nil)
 	groupKey, err := getSourceGroupHash(source, catalog.Name)
 	Expect(err).ToNot(HaveOccurred(), "there should be no error getting the source group hash for initial catalog")
 	kustomization := s.getKustomizationObject(groupKey)

--- a/internal/controller/catalog/source.go
+++ b/internal/controller/catalog/source.go
@@ -136,6 +136,12 @@ func (r *CatalogReconciler) newCatalogSource(catalogSource greenhousev1alpha1.Ca
 	if lastReconciledAt, ok := lifecycle.ReconcileAnnotationValue(catalog); ok {
 		s.lastReconciledAt = lastReconciledAt
 	}
+
+	// Add owned-by label from Catalog to commonLabels
+	if ownedBy, exists := catalog.Labels[greenhouseapis.LabelKeyOwnedBy]; exists {
+		s.commonLabels[greenhouseapis.LabelKeyOwnedBy] = ownedBy
+	}
+
 	return s, nil
 }
 


### PR DESCRIPTION
## Description

Propagate `owned-by` label to CPD / PD if it exists


## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

- Closes #1719 

## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

unit tests and e2e tests to confirm label propagation from `Catalog` to PD / CPD

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [ ] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
