### PR TITLE
feat(clusters): cluster shows PayloadSchedulable=False when all worker nodes are un-schedulable / NotReady

### DIFF
--- a/api/v1alpha1/cluster_types.go
+++ b/api/v1alpha1/cluster_types.go
@@ -40,6 +40,9 @@ const (
 	// AllNodesReady reflects the readiness status of all nodes of a cluster.
 	AllNodesReady greenhousemetav1alpha1.ConditionType = "AllNodesReady"
 
+	// PayloadSchedulable reflects whether workloads can be scheduled on the cluster.
+	PayloadSchedulable greenhousemetav1alpha1.ConditionType = "PayloadSchedulable"
+
 	// KubeConfigValid reflects the validity of the kubeconfig of a cluster.
 	KubeConfigValid greenhousemetav1alpha1.ConditionType = "KubeConfigValid"
 
@@ -74,9 +77,9 @@ type ClusterConditionType string
 // Nodes contains node count metrics and tracks non-ready nodes in a cluster.
 type Nodes struct {
 	// Total represent the number of all the nodes in the cluster.
-	Total int32 `json:"total,omitempty"`
+	Total int `json:"total,omitempty"`
 	// ReadyNodes represent the number of ready nodes in the cluster.
-	Ready int32 `json:"ready,omitempty"`
+	Ready int `json:"ready,omitempty"`
 	// NotReady is slice of non-ready nodes status details.
 	// +listType="map"
 	// +listMapKey=name

--- a/charts/manager/crds/greenhouse.sap_clusters.yaml
+++ b/charts/manager/crds/greenhouse.sap_clusters.yaml
@@ -119,12 +119,10 @@ spec:
                   ready:
                     description: ReadyNodes represent the number of ready nodes in
                       the cluster.
-                    format: int32
                     type: integer
                   total:
                     description: Total represent the number of all the nodes in the
                       cluster.
-                    format: int32
                     type: integer
                 type: object
               statusConditions:

--- a/cmd/greenhouse/controllers.go
+++ b/cmd/greenhouse/controllers.go
@@ -42,9 +42,9 @@ var knownControllers = map[string]func(controllerName string, mgr ctrl.Manager) 
 	"clusterPluginDefinition": (&plugindefinitioncontroller.ClusterPluginDefinitionReconciler{}).SetupWithManager,
 
 	// Cluster controllers
-	"bootStrap":         (&clustercontrollers.BootstrapReconciler{}).SetupWithManager,
-	"clusterReconciler": startClusterReconciler,
-	"kubeconfig":        (&clustercontrollers.KubeconfigReconciler{}).SetupWithManager,
+	"bootstrap":  (&clustercontrollers.BootstrapReconciler{}).SetupWithManager,
+	"cluster":    startClusterReconciler,
+	"kubeconfig": (&clustercontrollers.KubeconfigReconciler{}).SetupWithManager,
 }
 
 // knownControllers lists the name of known controllers.

--- a/docs/reference/api/index.html
+++ b/docs/reference/api/index.html
@@ -1879,7 +1879,7 @@ Kubernetes meta/v1.Time
 <td>
 <code>total</code><br>
 <em>
-int32
+int
 </em>
 </td>
 <td>
@@ -1890,7 +1890,7 @@ int32
 <td>
 <code>ready</code><br>
 <em>
-int32
+int
 </em>
 </td>
 <td>

--- a/docs/reference/api/openapi.yaml
+++ b/docs/reference/api/openapi.yaml
@@ -592,11 +592,9 @@ components:
                   x-kubernetes-list-type: map
                 ready:
                   description: ReadyNodes represent the number of ready nodes in the cluster.
-                  format: int32
                   type: integer
                 total:
                   description: Total represent the number of all the nodes in the cluster.
-                  format: int32
                   type: integer
               type: object
             statusConditions:

--- a/e2e/cluster/e2e_test.go
+++ b/e2e/cluster/e2e_test.go
@@ -33,6 +33,7 @@ import (
 const (
 	remoteClusterHName               = "remote-int-h-cluster"
 	remoteClusterFName               = "remote-int-f-cluster"
+	remoteClusterNodeName            = "remote-int-n-cluster"
 	remoteOIDCClusterHName           = "remote-int-oidc-h-cluster"
 	remoteOIDCClusterCName           = "remote-int-oidc-c-cluster"
 	remoteOIDCClusterFName           = "remote-int-oidc-f-cluster"
@@ -69,13 +70,14 @@ var _ = BeforeSuite(func() {
 	env = env.WithOrganization(ctx, adminClient, "./testdata/organization.yaml")
 	team = test.NewTeam(ctx, "test-cluster-e2e-team", env.TestNamespace, test.WithTeamLabel(greenhouseapis.LabelKeySupportGroup, "true"), test.WithMappedIDPGroup("SOME_IDP_GROUP_NAME"))
 	err = adminClient.Create(ctx, team)
-	Expect(err).ToNot(HaveOccurred(), "there should be no error creating a Team")
+	Expect(client.IgnoreAlreadyExists(err)).ToNot(HaveOccurred(), "there should be no error creating a Team")
 	testStartTime = time.Now().UTC()
 })
 
 var _ = AfterSuite(func() {
 	shared.OffBoardRemoteCluster(ctx, adminClient, remoteClient, testStartTime, remoteClusterHName, env.TestNamespace)
 	shared.OffBoardRemoteCluster(ctx, adminClient, remoteClient, testStartTime, remoteClusterFName, env.TestNamespace)
+	shared.OffBoardRemoteCluster(ctx, adminClient, remoteClient, testStartTime, remoteClusterNodeName, env.TestNamespace)
 	shared.OffBoardRemoteCluster(ctx, adminClient, remoteClient, testStartTime, remoteOIDCClusterHName, env.TestNamespace)
 	shared.OffBoardRemoteCluster(ctx, adminClient, remoteClient, testStartTime, remoteOIDCClusterFName, env.TestNamespace)
 	shared.OffBoardRemoteCluster(ctx, adminClient, remoteClient, testStartTime, remoteOIDCClusterCName, env.TestNamespace)
@@ -249,6 +251,38 @@ var _ = Describe("Cluster E2E", Ordered, func() {
 
 			By("verifying the cluster status is ready")
 			shared.ClusterIsReady(ctx, adminClient, remoteOIDCClusterCName, env.TestNamespace)
+		})
+	})
+
+	Context("Cluster Node Not Ready / Ready 😵 🤖", Ordered, func() {
+		It("should onboard remote cluster", func() {
+			By("onboarding remote cluster")
+			shared.OnboardRemoteCluster(ctx, adminClient, env.RemoteKubeConfigBytes, remoteClusterNodeName, env.TestNamespace, team.Name)
+		})
+		It("should have a cluster resource created", func() {
+			By("verifying if the cluster resource is created")
+			Eventually(func(g Gomega) bool {
+				err := adminClient.Get(ctx, client.ObjectKey{Name: remoteClusterNodeName, Namespace: env.TestNamespace}, &greenhousev1alpha1.Cluster{})
+				g.Expect(err).ToNot(HaveOccurred())
+				return true
+			}).Should(BeTrue(), "cluster resource should be created")
+
+			By("verifying the cluster status is ready")
+			shared.ClusterIsReady(ctx, adminClient, remoteClusterNodeName, env.TestNamespace)
+		})
+		It("should reach not ready state when all nodes are not ready", func() {
+			By("cordoning all nodes in the remote cluster")
+			expect.CordonRemoteNodes(ctx, remoteClient)
+
+			By("verifying the cluster payload is not schedulable")
+			expect.ReconcileAndWaitForPayloadSchedulable(ctx, adminClient, remoteClusterNodeName, env.TestNamespace, false)
+		})
+		It("should reach ready state when nodes are ready again", func() {
+			By("un-cordoning all nodes in the remote cluster")
+			expect.UnCordonRemoteNodes(ctx, remoteClient)
+
+			By("verifying the cluster payload is schedulable again")
+			expect.ReconcileAndWaitForPayloadSchedulable(ctx, adminClient, remoteClusterNodeName, env.TestNamespace, true)
 		})
 	})
 })

--- a/e2e/cluster/expect/expect.go
+++ b/e2e/cluster/expect/expect.go
@@ -6,7 +6,6 @@ package expect
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"time"
 
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -123,19 +122,73 @@ func RevokingRemoteClusterAccess(ctx context.Context, adminClient, remoteClient 
 func ReconcileReadyNotReady(ctx context.Context, adminClient client.Client, clusterName, namespace string, readyStatus bool) {
 	err := shared.WaitUntilResourceReadyOrNotReady(ctx, adminClient, &greenhousev1alpha1.Cluster{}, clusterName, namespace, func(resource lifecycle.RuntimeObject) error {
 		By("triggering a reconcile of the cluster resource")
-		resourceLabels := resource.GetLabels()
-		if resourceLabels == nil {
-			resourceLabels = make(map[string]string)
+		resourceAnnotations := resource.GetAnnotations()
+		if resourceAnnotations == nil {
+			resourceAnnotations = make(map[string]string)
 		}
-		resourceLabels["greenhouse.sap/last-apply"] = strconv.FormatInt(time.Now().Unix(), 10)
-		resource.SetLabels(resourceLabels)
+		resourceAnnotations[lifecycle.ReconcileAnnotation] = metav1.Now().Format(time.DateTime)
+		resource.SetAnnotations(resourceAnnotations)
 		return adminClient.Update(ctx, resource)
 	}, readyStatus)
 	Expect(err).NotTo(HaveOccurred(), "cluster should be in desired status")
+}
+
+func ReconcileAndWaitForPayloadSchedulable(ctx context.Context, adminClient client.Client, clusterName, namespace string, schedulable bool) {
+	Eventually(func(g Gomega) {
+		cluster := &greenhousev1alpha1.Cluster{}
+		g.Expect(adminClient.Get(ctx, client.ObjectKey{Name: clusterName, Namespace: namespace}, cluster)).To(Succeed())
+		By("triggering a reconcile of the cluster resource")
+		resourceAnnotations := cluster.GetAnnotations()
+		if resourceAnnotations == nil {
+			resourceAnnotations = make(map[string]string)
+		}
+		resourceAnnotations[lifecycle.ReconcileAnnotation] = metav1.Now().Format(time.DateTime)
+		cluster.SetAnnotations(resourceAnnotations)
+		g.Expect(adminClient.Update(ctx, cluster)).To(Succeed())
+		g.Expect(adminClient.Get(ctx, client.ObjectKey{Name: clusterName, Namespace: namespace}, cluster)).To(Succeed())
+		conditions := cluster.GetConditions()
+		payloadCondition := conditions.GetConditionByType(greenhousev1alpha1.PayloadSchedulable)
+		g.Expect(payloadCondition).ToNot(BeNil(), "cluster should have PayloadSchedulable condition")
+		g.Expect(payloadCondition.IsTrue()).To(Equal(schedulable), "PayloadSchedulable should be %v", schedulable)
+	}).Should(Succeed(), "PayloadSchedulable condition should reach desired state")
 }
 
 func GetRestConfig(restClientGetter *clientutil.RestClientGetter) *rest.Config {
 	restConfig, err := restClientGetter.ToRESTConfig()
 	Expect(err).NotTo(HaveOccurred(), "there should be no error creating the remote REST config")
 	return restConfig
+}
+
+func CordonRemoteNodes(ctx context.Context, remoteClient client.Client) {
+	nodes := &corev1.NodeList{}
+	err := remoteClient.List(ctx, nodes)
+	Expect(err).NotTo(HaveOccurred(), "there should be no error while listing nodes")
+	for _, node := range nodes.Items {
+		if _, ok := node.Labels["node-role.kubernetes.io/control-plane"]; ok {
+			By("skipping cordoning control plane node: " + node.Name)
+			continue
+		}
+		if node.Spec.Unschedulable {
+			continue
+		}
+		base := node.DeepCopy()
+		node.Spec.Unschedulable = true
+		err = remoteClient.Patch(ctx, &node, client.MergeFrom(base))
+		Expect(err).NotTo(HaveOccurred(), "there should be no error while patching node")
+	}
+}
+
+func UnCordonRemoteNodes(ctx context.Context, remoteClient client.Client) {
+	nodes := &corev1.NodeList{}
+	err := remoteClient.List(ctx, nodes)
+	Expect(err).NotTo(HaveOccurred(), "there should be no error while listing nodes")
+	for _, node := range nodes.Items {
+		if !node.Spec.Unschedulable {
+			continue
+		}
+		base := node.DeepCopy()
+		node.Spec.Unschedulable = false
+		err = remoteClient.Patch(ctx, &node, client.MergeFrom(base))
+		Expect(err).NotTo(HaveOccurred(), "there should be no error while patching node")
+	}
 }

--- a/e2e/shared/cluster.go
+++ b/e2e/shared/cluster.go
@@ -82,7 +82,9 @@ func OffBoardRemoteCluster(ctx context.Context, adminClient, remoteClient client
 	Eventually(func(g Gomega) {
 		crb := &rbacv1.ClusterRoleBinding{}
 		err := remoteClient.Get(ctx, client.ObjectKey{Name: ManagedResourceName}, crb)
-		GinkgoWriter.Printf("crb err: %v\n", err)
+		if err != nil {
+			GinkgoWriter.Printf("crb err: %v\n", err)
+		}
 		g.Expect(apierrors.IsNotFound(err)).To(BeTrue(), "cluster role binding should be deleted")
 		managedSA := &corev1.ServiceAccount{}
 		err = remoteClient.Get(ctx, client.ObjectKey{Name: ManagedResourceName, Namespace: namespace}, managedSA)

--- a/internal/controller/cluster/cluster_status.go
+++ b/internal/controller/cluster/cluster_status.go
@@ -30,7 +30,10 @@ import (
 	"github.com/cloudoperators/greenhouse/pkg/lifecycle"
 )
 
-const clusterK8sVersionUnknown = "unknown"
+const (
+	clusterK8sVersionUnknown = "unknown"
+	controlPlaneNodeLabel    = "node-role.kubernetes.io/control-plane"
+)
 
 func (r *RemoteClusterReconciler) setConditions() lifecycle.Conditioner {
 	return func(ctx context.Context, resource lifecycle.RuntimeObject) {
@@ -51,10 +54,12 @@ func (r *RemoteClusterReconciler) setConditions() lifecycle.Conditioner {
 			kubeConfigValidCondition, k8sVersion = r.reconcileKubeConfigValid(restClientGetter)
 		}
 
-		var allNodesReadyCondition, clusterAccessibleCondition, resourcesDeployedCondition greenhousemetav1alpha1.Condition
+		var allNodesReadyCondition, clusterAccessibleCondition, resourcesDeployedCondition, payloadSchedulable greenhousemetav1alpha1.Condition
+		payloadSchedulable = greenhousemetav1alpha1.TrueCondition(greenhousev1alpha1.PayloadSchedulable, "", "")
 		var nodes *greenhousev1alpha1.Nodes
 		// Can only reconcile detailed status if kubeconfig is valid.
 		if kubeConfigValidCondition.IsFalse() {
+			payloadSchedulable = greenhousemetav1alpha1.FalseCondition(greenhousev1alpha1.PayloadSchedulable, "", "kubeconfig not valid - payloads cannot be scheduled")
 			allNodesReadyCondition = greenhousemetav1alpha1.UnknownCondition(greenhousev1alpha1.AllNodesReady, "", "kubeconfig not valid - cannot know node status")
 			clusterAccessibleCondition = greenhousemetav1alpha1.UnknownCondition(greenhousev1alpha1.PermissionsVerified, "", "kubeconfig not valid - cannot validate cluster access")
 			resourcesDeployedCondition = greenhousemetav1alpha1.UnknownCondition(greenhousev1alpha1.ManagedResourcesDeployed, "", "kubeconfig not valid - cannot validate managed resources")
@@ -62,6 +67,9 @@ func (r *RemoteClusterReconciler) setConditions() lifecycle.Conditioner {
 			allNodesReadyCondition, nodes = r.reconcileNodeStatus(ctx, restClientGetter)
 			clusterAccessibleCondition = r.reconcilePermissions(ctx, restClientGetter)
 			resourcesDeployedCondition = r.reconcileBootstrapResources(ctx, restClientGetter, clusterSecret)
+			if nodes != nil && len(nodes.NotReady) == nodes.Total {
+				payloadSchedulable = greenhousemetav1alpha1.FalseCondition(greenhousev1alpha1.PayloadSchedulable, "", "all nodes are not ready")
+			}
 		}
 
 		readyCondition := r.reconcileReadyStatus(kubeConfigValidCondition, resourcesDeployedCondition)
@@ -76,6 +84,7 @@ func (r *RemoteClusterReconciler) setConditions() lifecycle.Conditioner {
 			ownerLabelCondition,
 			clusterAccessibleCondition,
 			resourcesDeployedCondition,
+			payloadSchedulable,
 		}
 		deletionCondition := r.checkDeletionSchedule(logger, cluster)
 		if !deletionCondition.IsUnknown() {
@@ -223,11 +232,14 @@ func (r *RemoteClusterReconciler) reconcileNodeStatus(
 		return greenhousemetav1alpha1.FalseCondition(greenhousev1alpha1.AllNodesReady, "", err.Error()), nil
 	}
 
-	notReadyNodes := []greenhousev1alpha1.NodeStatus{}
-	var totalNodes, readyNodes int32
+	var notReadyNodes []greenhousev1alpha1.NodeStatus
+	var totalNodes, readyNodes int
 	allNodesReadyCondition = greenhousemetav1alpha1.TrueCondition(greenhousev1alpha1.AllNodesReady, "", "")
 
 	for _, node := range nodeList.Items {
+		if _, ok := node.Labels[controlPlaneNodeLabel]; ok {
+			continue
+		}
 		totalNodes++
 
 		nodeStatus := getNodeStatusIfNodeNotReady(node)
@@ -251,6 +263,9 @@ func (r *RemoteClusterReconciler) reconcileNodeStatus(
 
 // getNodeStatusIfNodeNotReady returns a NodeStatus when the NodeReady condition is explicitly False; otherwise nil.
 func getNodeStatusIfNodeNotReady(node corev1.Node) *greenhousev1alpha1.NodeStatus {
+	if node.Spec.Unschedulable {
+		return &greenhousev1alpha1.NodeStatus{Name: node.Name, Message: "Node is unschedulable", LastTransitionTime: metav1.Now()}
+	}
 	var readyCondition *corev1.NodeCondition
 	for i := range node.Status.Conditions {
 		if node.Status.Conditions[i].Type == corev1.NodeReady {

--- a/internal/controller/cluster/status_test.go
+++ b/internal/controller/cluster/status_test.go
@@ -155,9 +155,9 @@ var _ = Describe("Cluster status", Ordered, func() {
 			g.Expect(validCluster.Status.GetConditionByType(greenhousev1alpha1.AllNodesReady).Status).To(Equal(metav1.ConditionFalse))
 			g.Expect(validCluster.Status.GetConditionByType(greenhousev1alpha1.AllNodesReady).Message).To(ContainSubstring("test-node not ready, test-node-3 not ready"))
 			// Validate the counts of total and ready nodes.
-			g.Expect(validCluster.Status.Nodes).ToNot((BeNil()))
-			g.Expect(validCluster.Status.Nodes.Total).To(Equal(int32(3)))
-			g.Expect(validCluster.Status.Nodes.Ready).To(Equal(int32(1)))
+			g.Expect(validCluster.Status.Nodes).ToNot(BeNil())
+			g.Expect(validCluster.Status.Nodes.Total).To(Equal(3))
+			g.Expect(validCluster.Status.Nodes.Ready).To(Equal(1))
 			g.Expect(validCluster.Status.Nodes.NotReady).To(HaveLen(2))
 		}).Should(Succeed())
 
@@ -220,9 +220,9 @@ var _ = Describe("Cluster status", Ordered, func() {
 			g.Expect(validCluster.Status.GetConditionByType(greenhousev1alpha1.AllNodesReady).Status).To(Equal(metav1.ConditionTrue), "The AllNodesReady condition should be true")
 			g.Expect(validCluster.Status.GetConditionByType(greenhousev1alpha1.AllNodesReady).Message).To(BeEmpty())
 			// Validate the counts of total and ready nodes.
-			g.Expect(validCluster.Status.Nodes).ToNot((BeNil()))
-			g.Expect(validCluster.Status.Nodes.Total).To(Equal(int32(3)))
-			g.Expect(validCluster.Status.Nodes.Ready).To(Equal(int32(3)))
+			g.Expect(validCluster.Status.Nodes).ToNot(BeNil())
+			g.Expect(validCluster.Status.Nodes.Total).To(Equal(3))
+			g.Expect(validCluster.Status.Nodes.Ready).To(Equal(3))
 			g.Expect(validCluster.Status.Nodes.NotReady).To(BeEmpty())
 		}).Should(Succeed())
 

--- a/internal/controller/teamrbac/teamrolebinding_controller_test.go
+++ b/internal/controller/teamrbac/teamrolebinding_controller_test.go
@@ -783,10 +783,12 @@ var _ = Describe("Validate ClusterRole & RoleBinding on Remote Cluster", Ordered
 			Expect(clusterAKubeClient.Update(test.Ctx, remoteClusterRoleBinding)).To(Succeed(), "there should be no error updating the ClusterRoleBinding on the remote cluster")
 
 			By("triggering the reconcile of the central cluster TeamRoleBinding with a noop update")
-			Expect(k8sClient.Get(test.Ctx, types.NamespacedName{Name: trb.Name, Namespace: trb.Namespace}, trb)).To(Succeed(), "there should be no error getting the TeamRoleBinding from the central cluster")
-			// changing the labels to trigger the reconciliation in this test.
-			trb.SetLabels(map[string]string{"foo": "bar"})
-			Expect(k8sClient.Update(test.Ctx, trb)).To(Succeed(), "there should be no error updating the TeamRoleBinding on the central cluster")
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(test.Ctx, types.NamespacedName{Name: trb.Name, Namespace: trb.Namespace}, trb)).To(Succeed(), "there should be no error getting the TeamRoleBinding from the central cluster")
+				// changing the labels to trigger the reconciliation in this test.
+				trb.SetLabels(map[string]string{"foo": "bar"})
+				g.Expect(k8sClient.Update(test.Ctx, trb)).To(Succeed(), "there should be no error updating the TeamRoleBinding on the central cluster")
+			}).Should(Succeed(), "there should be no error updating the TeamRoleBinding on the central cluster")
 
 			Eventually(func(g Gomega) bool {
 				g.Expect(clusterAKubeClient.Get(test.Ctx, remoteClusterRoleBindingName, remoteClusterRoleBinding)).To(Succeed(), "there should be no error getting the ClusterRoleBinding from the remote cluster")


### PR DESCRIPTION
## Description

Set Cluster Ready status to False when all remote cluster `Nodes` are `Unschedulable`

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

- Related Issue #1714 

## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

e2e test to verify cluster status when nodes are `Unschedulable`

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [x] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced PayloadSchedulable condition type for cluster status monitoring.
  * Control-plane nodes now excluded from readiness calculations.
  * Unschedulable nodes tracked separately in cluster status.

* **Refactor**
  * Improved cluster readiness evaluation logic for better status accuracy.
  * Updated controller naming for consistency.

* **Tests**
  * Added comprehensive end-to-end tests for cluster node readiness and state transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->