### PR TITLE
feat(e2e): replace bitnamicharts nginx with podinfo chart in e2e

### DIFF
--- a/e2e/plugin/e2e_test.go
+++ b/e2e/plugin/e2e_test.go
@@ -82,12 +82,12 @@ var _ = Describe("Plugin E2E", Ordered, func() {
 		shared.ClusterIsReady(ctx, adminClient, remoteClusterName, env.TestNamespace)
 	})
 
-	It("should deploy the nginx plugin", func() {
-		scenarios.PluginControllerNginxByPlugin(ctx, adminClient, remoteClient, env, remoteClusterName, team.Name)
+	It("should deploy the PodInfo plugin", func() {
+		scenarios.PluginControllerPodInfoByPlugin(ctx, adminClient, remoteClient, env, remoteClusterName, team.Name)
 	})
 
-	It("should deploy the plugin by the plugin preset", func() {
-		scenarios.PluginControllerNginxByPreset(ctx, adminClient, remoteClient, env, remoteClusterName, team.Name)
+	It("should deploy the PodInfo plugin by the plugin preset", func() {
+		scenarios.PluginControllerPodInfoByPreset(ctx, adminClient, remoteClient, env, remoteClusterName, team.Name)
 	})
 
 	It("should rollback the first helm release on failed deployment", func() {

--- a/e2e/plugin/fixtures/fixtures.go
+++ b/e2e/plugin/fixtures/fixtures.go
@@ -6,8 +6,6 @@ package fixtures
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-
 	greenhousev1alpha1 "github.com/cloudoperators/greenhouse/api/v1alpha1"
 	"github.com/cloudoperators/greenhouse/internal/test"
 )
@@ -29,55 +27,6 @@ func PreparePluginDefinition(name, namespace string, opts ...func(definition *gr
 	}
 
 	return pd
-}
-
-func PrepareNginxPluginDefinition(namespace string) *greenhousev1alpha1.ClusterPluginDefinition {
-	return PreparePluginDefinition("nginx-22.3.3", namespace,
-		test.WithVersion("22.3.3"),
-		test.WithHelmChart(
-			&greenhousev1alpha1.HelmChartReference{
-				Name:       "bitnamicharts/nginx",
-				Repository: "oci://registry-1.docker.io",
-				Version:    "22.3.3",
-			},
-		),
-		test.AppendPluginOption(greenhousev1alpha1.PluginOption{
-			Default:     &apiextensionsv1.JSON{Raw: []byte("false")},
-			Description: "autoscaling.enabled",
-			Name:        "autoscaling.enabled",
-			Type:        "bool",
-		}),
-		test.AppendPluginOption(greenhousev1alpha1.PluginOption{
-			Default:     &apiextensionsv1.JSON{Raw: []byte("\"\"")},
-			Description: "autoscaling.maxReplicas",
-			Name:        "autoscaling.maxReplicas",
-			Type:        "string",
-		}),
-		test.AppendPluginOption(greenhousev1alpha1.PluginOption{
-			Default:     &apiextensionsv1.JSON{Raw: []byte("\"\"")},
-			Description: "autoscaling.minReplicas",
-			Name:        "autoscaling.minReplicas",
-			Type:        "string",
-		}),
-		test.AppendPluginOption(greenhousev1alpha1.PluginOption{
-			Default:     &apiextensionsv1.JSON{Raw: []byte("true")},
-			Description: "containerSecurityContext.enabled",
-			Name:        "containerSecurityContext.enabled",
-			Type:        "bool",
-		}),
-		test.AppendPluginOption(greenhousev1alpha1.PluginOption{
-			Default:     &apiextensionsv1.JSON{Raw: []byte("1")},
-			Description: "replicaCount",
-			Name:        "replicaCount",
-			Type:        "int",
-		}),
-		test.AppendPluginOption(greenhousev1alpha1.PluginOption{
-			Default:     &apiextensionsv1.JSON{Raw: []byte("true")},
-			Description: "podSecurityContext.enabled",
-			Name:        "podSecurityContext.enabled",
-			Type:        "bool",
-		}),
-	)
 }
 
 func PrepareCertManagerPluginDefinition(namespace string) *greenhousev1alpha1.ClusterPluginDefinition {

--- a/e2e/plugin/scenarios/plugin_controller_rollback.go
+++ b/e2e/plugin/scenarios/plugin_controller_rollback.go
@@ -37,14 +37,14 @@ func PluginControllerHelmRollback(ctx context.Context, adminClient, remoteClient
 	By("Setting the HELM_RELEASE_TIMEOUT to 5 seconds")
 	Expect(os.Setenv("HELM_RELEASE_TIMEOUT", "5")).To(Succeed(), "there should be no error setting HELM_RELEASE_TIMEOUT env")
 
-	By("Preparing the plugin")
-	// Creating plugin with release name
+	By("Preparing the plugin with release name")
 	plugin := fixtures.PreparePlugin(certManagerPluginTest, env.TestNamespace,
 		test.WithClusterPluginDefinition(pluginDefinition.Name),
 		test.WithCluster(remoteClusterName),
 		test.WithReleaseNamespace(env.TestNamespace),
 		test.WithReleaseName(certManagerPluginTest),
 		test.WithPluginLabel(greenhouseapis.LabelKeyOwnedBy, teamName),
+		test.WithPluginLabel(greenhouseapis.GreenhouseHelmDeliveryToolLabel, "helm"),
 	)
 
 	By("Installing release manually on the remote cluster")


### PR DESCRIPTION
<!--
Please ensure the PR title follows the conventional commit format:
<type>(<scope>): description

For a list of accepted types and scopes see the workflow documentation: https://github.com/cloudoperators/greenhouse/blob/main/.github/workflows/ci-pr-title.yaml

-->

## Description
<!--
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
This PR replaces bitnamicharts/nginx with podinfo chart for e2e tests. It sets the delivery tool label in plugins to "helm" for e2e tests regarding the helm plugin controller.

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 

- Related Issue # (issue)
- Closes # (issue)
- Fixes # (issue)

-->
- Closes #1761 

## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [x] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
