### PR TITLE
fix(plugins): sort mirrored images to avoid controllerutil diff

### DIFF
--- a/internal/controller/plugin/image_mirror.go
+++ b/internal/controller/plugin/image_mirror.go
@@ -6,6 +6,7 @@ package plugin
 import (
 	"fmt"
 	"regexp"
+	"slices"
 	"strings"
 
 	helmv2 "github.com/fluxcd/helm-controller/api/v2"
@@ -90,6 +91,7 @@ func extractUniqueImages(manifests string) []string {
 	for img := range seen {
 		images = append(images, img)
 	}
+	slices.Sort(images)
 	return images
 }
 

--- a/internal/controller/plugin/plugin_controller_flux.go
+++ b/internal/controller/plugin/plugin_controller_flux.go
@@ -156,7 +156,7 @@ func (r *PluginReconciler) ensureHelmRelease(
 		return fmt.Errorf("failed to generate HelmRelease values for Plugin %s: %w", plugin.Name, err)
 	}
 
-	result, err := ctrl.CreateOrUpdate(ctx, r.Client, release, func() error {
+	result, err := controllerutil.CreateOrPatch(ctx, r.Client, release, func() error {
 		builder := flux.NewHelmReleaseSpecBuilder().
 			WithChart(helmv2.HelmChartTemplateSpec{
 				Chart:    pluginDefinitionSpec.HelmChart.Name,


### PR DESCRIPTION
## Description

Sort mirrored images in post renderer to avoid diff in `controllerutil.CreateOrPatch`

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [x] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
