### PR TITLE
feat(plugins): include CRDs in helm template when in dry run mode

### DIFF
--- a/internal/helm/helm.go
+++ b/internal/helm/helm.go
@@ -225,6 +225,10 @@ func newHelmInstallAction(restClientGetter genericclioptions.RESTClientGetter, r
 	installAction.ClientOnly = isDryRun
 	installAction.Description = pluginDefinitionVersion
 
+	if isDryRun {
+		installAction.IncludeCRDs = true
+	}
+
 	return installAction, cfg.Capabilities, nil
 }
 


### PR DESCRIPTION
## Description

include CRDs in helm template when in dry run mode...

Image mirroring in plugin controller will not contain images specified in CRDs

Example: 

Prometheus CRDs upgrade Job - https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/charts/crds/templates/upgrade/job.yaml

In scenarios where a Cluster has gatekeeper / kyverno with image registry policies, the helm release would fail as helm template in image mirroring does not render CRDs.

closes https://github.com/cloudoperators/greenhouse/issues/1853


## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

- Fixes # (issue)

## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [ ] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
