### PR TITLE
fix(dex): ensure connector is reloaded on changes

### DIFF
--- a/internal/controller/organization/dex.go
+++ b/internal/controller/organization/dex.go
@@ -4,10 +4,12 @@
 package organization
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"slices"
+	"strconv"
 	"strings"
 
 	"github.com/dexidp/dex/connector/oidc"
@@ -22,6 +24,7 @@ import (
 	greenhousev1alpha1 "github.com/cloudoperators/greenhouse/api/v1alpha1"
 	"github.com/cloudoperators/greenhouse/internal/clientutil"
 	"github.com/cloudoperators/greenhouse/internal/common"
+	dexstore "github.com/cloudoperators/greenhouse/internal/dex"
 )
 
 const (
@@ -127,11 +130,16 @@ func (r *OrganizationReconciler) reconcileDexConnector(ctx context.Context, org 
 	oidcConnector, err := r.dex.GetConnector(ctx, org.Name)
 	if err != nil {
 		if errors.Is(err, storage.ErrNotFound) {
+			rv := ""
+			if r.DexStorageType == dexstore.Postgres {
+				rv = "0"
+			}
 			if err = r.dex.CreateConnector(ctx, storage.Connector{
-				ID:     org.Name,
-				Type:   dexConnectorTypeGreenhouse,
-				Name:   cases.Title(language.English).String(org.Name),
-				Config: configByte,
+				ID:              org.Name,
+				Type:            dexConnectorTypeGreenhouse,
+				Name:            cases.Title(language.English).String(org.Name),
+				ResourceVersion: rv,
+				Config:          configByte,
 			}); err != nil {
 				log.FromContext(ctx).Error(err, "failed to create dex connector", "name", org.Name)
 				return err
@@ -142,10 +150,15 @@ func (r *OrganizationReconciler) reconcileDexConnector(ctx context.Context, org 
 		log.FromContext(ctx).Error(err, "failed to get dex connector", "name", org.Name)
 		return err
 	}
+	if bytes.Equal(oidcConnector.Config, configByte) {
+		log.FromContext(ctx).Info("dex connector is up to date, no update needed", "name", org.Name)
+		return nil
+	}
 	if err = r.dex.UpdateConnector(ctx, oidcConnector.ID, func(c storage.Connector) (storage.Connector, error) {
 		c.ID = org.Name
 		c.Type = dexConnectorTypeGreenhouse
 		c.Name = cases.Title(language.English).String(org.Name)
+		c.ResourceVersion = incrementResourceVersion(r.DexStorageType, c.ResourceVersion)
 		c.Config = configByte
 		return c, nil
 	}); err != nil {
@@ -246,6 +259,22 @@ func getRedirects(orgName string, redirectURIs []string) []string {
 
 func getRedirectForOrg(orgName string) string {
 	return fmt.Sprintf("https://%s.dashboard.%s", orgName, common.DNSDomain)
+}
+
+// incrementResourceVersion increments the resource version by 1.
+// This is necessary for the SQL storage backend where the resource version
+// is not automatically incremented on updates. Without this, the dex server's
+// in-memory connector cache never detects changes because the cached and stored
+// resource versions always match.
+func incrementResourceVersion(storageType, resourceVersion string) string {
+	if storageType != dexstore.Postgres {
+		return resourceVersion
+	}
+	v, err := strconv.ParseInt(resourceVersion, 10, 64)
+	if err != nil {
+		return "1"
+	}
+	return strconv.FormatInt(v+1, 10)
 }
 
 // appendRedirects - appends newRedirects to the redirects slice if it does not exist

--- a/internal/controller/organization/dex_test.go
+++ b/internal/controller/organization/dex_test.go
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package organization_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/cloudoperators/greenhouse/internal/controller/organization"
+	dexstore "github.com/cloudoperators/greenhouse/internal/dex"
+)
+
+var _ = Describe("incrementResourceVersion", func() {
+	DescribeTable("should correctly increment the resource version for postgres storage",
+		func(input, expected string) {
+			Expect(organization.ExportIncrementResourceVersion(dexstore.Postgres, input)).To(Equal(expected))
+		},
+		Entry("empty string defaults to 1", "", "1"),
+		Entry("zero increments to 1", "0", "1"),
+		Entry("1 increments to 2", "1", "2"),
+		Entry("42 increments to 43", "42", "43"),
+		Entry("non-numeric defaults to 1", "abc", "1"),
+	)
+	DescribeTable("should return the same resource version for non-postgres storage",
+		func(input, expected string) {
+			Expect(organization.ExportIncrementResourceVersion(dexstore.K8s, input)).To(Equal(expected))
+		},
+		Entry("empty string remains empty", "", ""),
+		Entry("numeric string remains unchanged", "42", "42"),
+		Entry("non-numeric string remains unchanged", "abc", "abc"),
+	)
+})

--- a/internal/controller/organization/organization_exports_test.go
+++ b/internal/controller/organization/organization_exports_test.go
@@ -4,5 +4,6 @@
 package organization
 
 var (
-	ExportDefaultTeamRoles = defaultTeamRoles
+	ExportDefaultTeamRoles         = defaultTeamRoles
+	ExportIncrementResourceVersion = incrementResourceVersion
 )


### PR DESCRIPTION
the resource version is not set by default in the SQL storage
kubernetes storage uses the CRs resourceVersion

this resourceversion is used by dex to detect changes to the
connectors and reload if necessary

https://github.com/dexidp/dex/blob/1e65dda440cf2f7a5b190e4822b5408923972b5e/server/server.go#L812-L820

<!--
Please ensure the PR title follows the conventional commit format:
<type>(<scope>): description

For a list of accepted types and scopes see the workflow documentation: https://github.com/cloudoperators/greenhouse/blob/main/.github/workflows/ci-pr-title.yaml

-->

## Description
<!--
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 

- Related Issue # (issue)
- Closes # (issue)
- Fixes # (issue)

-->

## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [ ] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
