### PR TITLE
fix(docs): correct broken relative links across documentation

### DIFF
--- a/docs/architecture/high-level.md
+++ b/docs/architecture/high-level.md
@@ -99,7 +99,7 @@ When talking about clusters in the context of Greenhouse, we are referring to tw
 ## Organizations & Authentication
 
 The Greenhouse platform is designed to support multiple organizations, each with its own set of users and permissions. Each organization can have multiple teams, and each team can have its own set of roles and permissions. The Greenhouse API provides a way to manage these organizations, teams, and roles.
-The Organization is a cluster-scoped resource for which a namespace with the same name will be created. When creating an Organization an identity provider (IdP) needs to be specified. All users in this IdP have read access to the resources in the Organization's namespace. Greenhouse will automatically provision a set of RBAC roles, view [RBAC within the Organization namespace](./../../../reference/components/organization/#role-based-access-control-within-the-organization-namespace) for details.
+The Organization is a cluster-scoped resource for which a namespace with the same name will be created. When creating an Organization an identity provider (IdP) needs to be specified. All users in this IdP have read access to the resources in the Organization's namespace. Greenhouse will automatically provision a set of RBAC roles, view [RBAC within the Organization namespace](./../../reference/components/organization/#role-based-access-control-within-the-organization-namespace) for details.
 
 In order to make the Kubernetes API available for multiple organizations, Greenhouse provides an idproxy build on-top of [Dex](https://dexidp.io/), which allows to handle different identity providers (IdP) when authenticating users against the Kubernetes API.
 

--- a/docs/operations/playbooks/cluster/cluster-kubernetes-version-out-of-maintenance.md
+++ b/docs/operations/playbooks/cluster/cluster-kubernetes-version-out-of-maintenance.md
@@ -43,6 +43,6 @@ kubectl --kubeconfig=<target-cluster-kubeconfig> version --short
 
 ## Additional Resources
 
-- [Greenhouse Cluster Documentation](../../../reference/api/cluster.md)
+- [Greenhouse Cluster Documentation](../../../../reference/components/cluster)
 - [Kubernetes Version Skew Policy](https://kubernetes.io/releases/version-skew-policy/)
 - [Kubernetes Release Information](https://kubernetes.io/releases/)

--- a/docs/operations/playbooks/cluster/cluster-not-ready.md
+++ b/docs/operations/playbooks/cluster/cluster-not-ready.md
@@ -60,5 +60,5 @@ Or access your logs sink for Greenhouse logs.
 
 ## Additional Resources
 
-- [Greenhouse Cluster Documentation](../../reference/api/cluster.md)
+- [Greenhouse Cluster Documentation](../../../../reference/components/cluster)
 - [Kubernetes Cluster Troubleshooting](https://kubernetes.io/docs/tasks/debug/)

--- a/docs/operations/playbooks/cluster/cluster-token-expiry.md
+++ b/docs/operations/playbooks/cluster/cluster-token-expiry.md
@@ -15,8 +15,8 @@ This alert fires when the kubeconfig token for a cluster will expire in less tha
 
 Greenhouse has two ways of authenticating to Clusters:
 
-- [OIDC trust](../../user-guides/cluster/oidc_connectivity.md) - Preferred method, credential-less authentication
-- [Initial kubeconfig](../../user-guides/cluster/onboarding.md) - Traditional method using kubeconfig credentials
+- [OIDC trust](../../../../user-guides/cluster/oidc_connectivity) - Preferred method, credential-less authentication
+- [Initial kubeconfig](../../../../user-guides/cluster/onboarding) - Traditional method using kubeconfig credentials
 
 This alert only fires when initially a kubeconfig was provided. Greenhouse will create a Service Account on the target Cluster and keep a kubeconfig with a token scoped to this SA on the Greenhouse Cluster. These tokens have a limited validity period and are auto-rotated by the Greenhouse controller. When a token is about to expire, this alert fires. Since Greenhouse auto-rotates these tokens, this alert indicates that Greenhouse cannot (or could not) interact properly with the Cluster.
 
@@ -111,6 +111,6 @@ Look for messages about token refresh operations or authentication issues.
 
 ## Additional Resources
 
-- [Greenhouse Cluster Documentation](../../../reference/api/cluster.md)
-- [Cluster Onboarding](../../../user-guides/cluster/onboarding.md)
-- [Cluster OIDC connectivity](../../../user-guides/cluster/oidc_connectivity.md)
+- [Greenhouse Cluster Documentation](../../../../reference/components/cluster)
+- [Cluster Onboarding](../../../../user-guides/cluster/onboarding)
+- [Cluster OIDC connectivity](../../../../user-guides/cluster/oidc_connectivity)

--- a/docs/operations/playbooks/operator/operator-reconcile-duration-higher-10min.md
+++ b/docs/operations/playbooks/operator/operator-reconcile-duration-higher-10min.md
@@ -96,5 +96,5 @@ kubectl get organizations -o json | jq -r '.items[] | select(.status.statusCondi
 
 ## Additional Resources
 
-- [Greenhouse Architecture](../../../architecture/components.md)
+- [Greenhouse Architecture](../../../../architecture/high-level)
 - [Controller Runtime Metrics](https://book.kubebuilder.io/reference/metrics-reference.html)

--- a/docs/operations/playbooks/operator/operator-reconcile-errors-high.md
+++ b/docs/operations/playbooks/operator/operator-reconcile-errors-high.md
@@ -88,5 +88,5 @@ kubectl get --raw /readyz
 
 ## Additional Resources
 
-- [Greenhouse Architecture](../../../architecture/components.md)
+- [Greenhouse Architecture](../../../../architecture/high-level)
 - [Controller Runtime Metrics](https://book.kubebuilder.io/reference/metrics-reference.html)

--- a/docs/operations/playbooks/operator/operator-workqueue-not-drained.md
+++ b/docs/operations/playbooks/operator/operator-workqueue-not-drained.md
@@ -18,7 +18,7 @@ Each controller uses a workqueue to process reconciliation requests. When the wo
 This could be due to:
 
 - High rate of resource changes overwhelming the controller
-- Slow reconciliation operations (see also [OperatorReconcileDurationHigher10Min](operator-reconcile-duration-higher-10min.md))
+- Slow reconciliation operations (see also [OperatorReconcileDurationHigher10Min](../operator-reconcile-duration-higher-10min))
 - Controller pod being resource-constrained
 - Deadlocks or stuck reconciliation loops
 - External systems being slow or unavailable
@@ -102,6 +102,6 @@ kubectl get organizations -o json | jq -r '.items[] | select(.status.statusCondi
 
 ## Additional Resources
 
-- [Greenhouse Architecture](../../../architecture/components.md)
+- [Greenhouse Architecture](../../../../architecture/high-level)
 - [Controller Runtime Metrics](https://book.kubebuilder.io/reference/metrics-reference.html)
 - [Workqueue Metrics](https://book.kubebuilder.io/reference/metrics-reference.html#workqueue-metrics)

--- a/docs/operations/playbooks/operator/webhook-errors-high.md
+++ b/docs/operations/playbooks/operator/webhook-errors-high.md
@@ -103,6 +103,6 @@ kubectl describe pod -n greenhouse -l app=greenhouse,app.kubernetes.io/component
 
 ## Additional Resources
 
-- [Greenhouse Architecture](../../../architecture/components.md)
+- [Greenhouse Architecture](../../../../architecture/high-level)
 - [Kubernetes Admission Webhooks](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/)
 - [Controller Runtime Metrics](https://book.kubebuilder.io/reference/metrics-reference.html)

--- a/docs/operations/playbooks/operator/webhook-latency-high.md
+++ b/docs/operations/playbooks/operator/webhook-latency-high.md
@@ -101,6 +101,6 @@ kubectl describe pod -n greenhouse -l app=greenhouse,app.kubernetes.io/component
 
 ## Additional Resources
 
-- [Greenhouse Architecture](../../../architecture/components.md)
+- [Greenhouse Architecture](../../../../architecture/high-level)
 - [Kubernetes Admission Webhooks](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/)
 - [Controller Runtime Metrics](https://book.kubebuilder.io/reference/metrics-reference.html)

--- a/docs/operations/playbooks/organization/organization-not-ready.md
+++ b/docs/operations/playbooks/organization/organization-not-ready.md
@@ -63,5 +63,5 @@ Or access your logs sink for Greenhouse logs.
 
 ## Additional Resources
 
-- [Greenhouse Organization Documentation](../../../reference/components/organization.md)
-- [Getting Started with Organizations](../../../getting-started/core-concepts/organizations.md)
+- [Greenhouse Organization Documentation](../../../../reference/components/organization)
+- [Getting Started with Organizations](../../../../getting-started/core-concepts/organizations)

--- a/docs/operations/playbooks/organization/scim-access-not-ready.md
+++ b/docs/operations/playbooks/organization/scim-access-not-ready.md
@@ -77,4 +77,4 @@ Or access your logs sink for Greenhouse logs.
 
 ## Additional Resources
 
-- [Greenhouse Organization Documentation](../../../reference/components/organization.md)
+- [Greenhouse Organization Documentation](../../../../reference/components/organization)

--- a/docs/operations/playbooks/plugin/plugin-constantly-failing.md
+++ b/docs/operations/playbooks/plugin/plugin-constantly-failing.md
@@ -59,7 +59,7 @@ Common failure reasons to look for:
 - **PluginOptionValueInvalid**: Option values could not be converted to Helm values
 - **FluxHelmReleaseConfigInvalid**: The generated Flux HelmRelease manifest is invalid and could not be applied
 - **FluxHelmReleaseStalled**: The Flux HelmRelease is stalled, typically because install/upgrade retries have been exhausted
-- **ClusterAccessFailed**: The controller cannot access the target cluster — check target [Cluster status](../cluster/cluster-not-ready.md)
+- **ClusterAccessFailed**: The controller cannot access the target cluster — check target [Cluster status](../../cluster/cluster-not-ready)
 - **HelmUninstallFailed**: The Helm release could not be uninstalled (relevant during Plugin deletion)
 
 ### Check for Specific Issues
@@ -104,5 +104,5 @@ kubectl describe helmrelease <plugin-name> -n <namespace>
 
 ## Additional Resources
 
-- [Greenhouse Plugin Documentation](../../../reference/components/plugin.md)
-- [Plugin Configuration Guide](../../../user-guides/plugin/configure.md)
+- [Greenhouse Plugin Documentation](../../../../reference/components/plugin)
+- [Plugin Configuration Guide](../../../../user-guides/plugin/plugin-deployment)

--- a/docs/operations/playbooks/plugin/plugin-not-ready.md
+++ b/docs/operations/playbooks/plugin/plugin-not-ready.md
@@ -50,7 +50,7 @@ Look at the `status.statusConditions` section in the plugin resource. Pay specia
   - `OptionValueResolutionFailed` — option values could not be resolved (e.g. a referenced secret is missing)
   - `PluginOptionValueInvalid` — option values could not be converted to Helm values
   - `FluxHelmReleaseConfigInvalid` — the generated Flux HelmRelease manifest is invalid
-  - `ClusterAccessFailed` — the controller cannot access the target cluster; check target [Cluster status](../cluster/cluster-not-ready.md)
+  - `ClusterAccessFailed` — the controller cannot access the target cluster; check target [Cluster status](../../cluster/cluster-not-ready)
 - **HelmReleaseDeployed**: Mirrors the Flux HelmRelease `Ready` condition and reflects whether the Helm release has been successfully deployed on the target cluster. Common reasons for `false`:
   - `FluxHelmReleaseStalled` — install/upgrade retries have been exhausted
   - `HelmUninstallFailed` — uninstalling a previous Helm release revision failed
@@ -70,6 +70,6 @@ kubectl describe helmrelease <plugin-name> -n <namespace>
 
 ## Additional Resources
 
-- [Greenhouse Plugin Documentation](../../../reference/components/plugin.md)
-- [Plugin Configuration Guide](../../../user-guides/plugin/configure.md)
+- [Greenhouse Plugin Documentation](../../../../reference/components/plugin)
+- [Plugin Configuration Guide](../../../../user-guides/plugin/plugin-deployment)
 - [Flux HelmRelease Documentation](https://fluxcd.io/flux/components/helm/helmreleases/)

--- a/docs/operations/playbooks/proxy/idproxy-errors-high.md
+++ b/docs/operations/playbooks/proxy/idproxy-errors-high.md
@@ -107,5 +107,5 @@ kubectl logs -n greenhouse -l app.kubernetes.io/name=idproxy --tail=500 | grep -
 
 ## Additional Resources
 
-- [Greenhouse Architecture](../../../architecture/components.md)
-- [Authentication Configuration](../../../user-guides/organization/authentication.md)
+- [Greenhouse Architecture](../../../../architecture/high-level)
+- [Authentication Configuration](../../../../user-guides/organization/creation)

--- a/docs/operations/playbooks/proxy/proxy-request-duration-high.md
+++ b/docs/operations/playbooks/proxy/proxy-request-duration-high.md
@@ -98,5 +98,5 @@ kubectl describe pod -n greenhouse -l app.kubernetes.io/name=<proxy-name>
 
 ## Additional Resources
 
-- [Greenhouse Architecture](../../../architecture/components.md)
-- [Service Proxy Documentation](../../../user-guides/plugin/plugin-deployment.md#urls-for-exposed-services-and-ingresses)
+- [Greenhouse Architecture](../../../../architecture/high-level)
+- [Service Proxy Documentation](../../../../user-guides/plugin/plugin-deployment#urls-for-exposed-services-and-ingresses)

--- a/docs/operations/playbooks/proxy/proxy-request-errors-high.md
+++ b/docs/operations/playbooks/proxy/proxy-request-errors-high.md
@@ -105,5 +105,5 @@ kubectl describe pod -n greenhouse -l app=<service-name>
 
 ## Additional Resources
 
-- [Greenhouse Architecture](../../../architecture/components.md)
-- [Service Proxy Documentation](../../../user-guides/plugin/plugin-deployment.md#urls-for-exposed-services-and-ingresses)
+- [Greenhouse Architecture](../../../../architecture/high-level)
+- [Service Proxy Documentation](../../../../user-guides/plugin/plugin-deployment#urls-for-exposed-services-and-ingresses)

--- a/docs/operations/playbooks/resource/resource-owned-by-label-missing.md
+++ b/docs/operations/playbooks/resource/resource-owned-by-label-missing.md
@@ -94,5 +94,5 @@ Ensure that:
 
 ## Additional Resources
 
-- [Greenhouse Team Documentation](../../../getting-started/core-concepts/teams.md)
-- [Resource Ownership](../../../getting-started/operations/ownership.md)
+- [Greenhouse Team Documentation](../../../../getting-started/core-concepts/teams)
+- [Resource Ownership](../../../../getting-started/operations/ownership)

--- a/docs/operations/playbooks/team/team-membership-count-drop.md
+++ b/docs/operations/playbooks/team/team-membership-count-drop.md
@@ -67,5 +67,5 @@ Or access your logs sink for Greenhouse logs.
 
 ## Additional Resources
 
-- [Greenhouse Team Documentation](../../../getting-started/core-concepts/teams.md)
-- [Greenhouse Organization Documentation](../../../reference/components/organization)
+- [Greenhouse Team Documentation](../../../../getting-started/core-concepts/teams)
+- [Greenhouse Organization Documentation](../../../../reference/components/organization)

--- a/docs/operations/playbooks/team/team-role-binding-not-ready.md
+++ b/docs/operations/playbooks/team/team-role-binding-not-ready.md
@@ -85,7 +85,7 @@ If the issue is cluster connectivity, check the target cluster status:
 kubectl get cluster <cluster-name> -n <namespace>
 ```
 
-See the [ClusterNotReady playbook](../cluster/cluster-not-ready.md) for cluster troubleshooting.
+See the [ClusterNotReady playbook](../../cluster/cluster-not-ready) for cluster troubleshooting.
 
 ### Check Controller Logs
 
@@ -99,5 +99,5 @@ Or access your logs sink for Greenhouse logs.
 
 ## Additional Resources
 
-- [Greenhouse Team(RoleBinding) Documentation](../../../reference/components/team.md#teamrolebinding)
-- [Greenhouse Team RBAC User Guide](../../../user-guides/team/rbac.md)
+- [Greenhouse Team(RoleBinding) Documentation](../../../../user-guides/team/rbac)
+- [Greenhouse Team RBAC User Guide](../../../../user-guides/team/rbac)

--- a/docs/reference/components/catalog.md
+++ b/docs/reference/components/catalog.md
@@ -432,4 +432,4 @@ In case of permissions issues, you will see errors in the Kustomization status c
 
 ## Next Steps
 
-- [Catalog API Reference](./../../api/)
+- [Catalog API Reference](./../../../reference/api/)

--- a/docs/reference/components/cluster.md
+++ b/docs/reference/components/cluster.md
@@ -35,6 +35,6 @@ kubectl label cluster example-cluster \
 
 ## Next Steps
 
-- [Cluster Onboarding](./../../user-guides/cluster/onboarding)
-- [Cluster Offboarding](./../../user-guides/cluster/offboarding)
-- [Using Metadata Labels and Expressions](./../../user-guides/plugin/metadata-expressions)
+- [Cluster Onboarding](./../../../user-guides/cluster/onboarding)
+- [Cluster Offboarding](./../../../user-guides/cluster/offboarding)
+- [Using Metadata Labels and Expressions](./../../../user-guides/plugin/metadata-expressions)

--- a/docs/reference/components/plugin.md
+++ b/docs/reference/components/plugin.md
@@ -60,7 +60,7 @@ spec:
 
 | :information_source: A defaulting webhook automatically merges the OptionValues with the defaults set in the PluginDefinition. The defaulting does not update OptionValues when the defaults change and does not remove values when they are removed from the PluginDefinition. |
 
-`.spec.optionValues[].expression` is an optional field that allows you to define dynamic values using [CEL (Common Expression Language)](https://github.com/google/cel-spec) expressions. Expressions use `${...}` placeholders that reference `global.greenhouse.*` variables such as `global.greenhouse.clusterName` or [Cluster Metadata](./../cluster#setting-metadata-labels) via `global.greenhouse.metadata.*`. For available CEL string functions, see the [CEL string extension documentation](https://github.com/google/cel-go/tree/master/ext#strings). See [Using Metadata Labels and Expressions](./../../user-guides/plugin/metadata-expressions) for detailed examples.
+`.spec.optionValues[].expression` is an optional field that allows you to define dynamic values using [CEL (Common Expression Language)](https://github.com/google/cel-spec) expressions. Expressions use `${...}` placeholders that reference `global.greenhouse.*` variables such as `global.greenhouse.clusterName` or [Cluster Metadata](./../cluster#setting-metadata-labels) via `global.greenhouse.metadata.*`. For available CEL string functions, see the [CEL string extension documentation](https://github.com/google/cel-go/tree/master/ext#strings). See [Using Metadata Labels and Expressions](./../../../user-guides/plugin/metadata-expressions) for detailed examples.
 
 ```yaml
   optionValues:
@@ -110,4 +110,4 @@ The annotation `greenhouse.sap/reconcile` can be added to a Plugin resource to t
 - [Cluster reference](./../cluster)
 - [PluginPreset reference](./../pluginpreset)
 - [PluginDefinition reference](./../plugindefinition)
-- [Using Metadata Labels and Expressions](./../../user-guides/plugin/metadata-expressions)
+- [Using Metadata Labels and Expressions](./../../../user-guides/plugin/metadata-expressions)


### PR DESCRIPTION
## Description

Hugo renders each markdown file as a directory so relative links resolve one level deeper than the filesystem path suggests. Many links were missing one `../` level, causing 404s on the rendered site. Links to removed pages (`architecture/components.md`, `reference/api/cluster.md`, `user-guides/plugin/configure.md`) have been redirected to the closest equivalent pages.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [x] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

N/A

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Verified by running the Hugo docs site locally and confirming all previously broken links resolve to HTTP 200. 

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [x] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
