### PR TITLE
feat(pluginpresets): validate PluginDefinition existence in PluginPreset reconciler

### DIFF
--- a/api/v1alpha1/pluginpreset_types.go
+++ b/api/v1alpha1/pluginpreset_types.go
@@ -61,6 +61,10 @@ const (
 	PluginFailedCondition greenhousemetav1alpha1.ConditionType = "PluginFailed"
 	// AllPluginsReadyCondition is set when all Plugins managed by the PluginPreset are created and ready.
 	AllPluginsReadyCondition greenhousemetav1alpha1.ConditionType = "AllPluginsReady"
+	// PluginDefinitionNotExistsReason is the reason set on ReadyCondition when the referenced PluginDefinition does not exist.
+	PluginDefinitionNotExistsReason greenhousemetav1alpha1.ConditionReason = "PluginDefinitionNotExists"
+	// ClusterPluginDefinitionNotExistsReason is the reason set on ReadyCondition when the referenced ClusterPluginDefinition does not exist.
+	ClusterPluginDefinitionNotExistsReason greenhousemetav1alpha1.ConditionReason = "ClusterPluginDefinitionNotExists"
 )
 
 // PluginPresetStatus defines the observed state of PluginPreset

--- a/internal/controller/plugin/pluginpreset_controller.go
+++ b/internal/controller/plugin/pluginpreset_controller.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"slices"
 	"strings"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -105,6 +106,27 @@ func (r *PluginPresetReconciler) EnsureCreated(ctx context.Context, resource lif
 	_ = log.FromContext(ctx)
 
 	initPluginPresetStatus(pluginPreset)
+
+	// Check if the referenced PluginDefinition exists. If not, set ReadyCondition to false and return early.
+	pluginDefExists, err := r.pluginDefinitionExists(ctx, pluginPreset)
+	if err != nil {
+		return ctrl.Result{}, lifecycle.Failed, err
+	}
+	if !pluginDefExists {
+		reason := greenhousev1alpha1.PluginDefinitionNotExistsReason
+		if pluginPreset.Spec.Plugin.PluginDefinitionRef.Kind == greenhousev1alpha1.ClusterPluginDefinitionKind {
+			reason = greenhousev1alpha1.ClusterPluginDefinitionNotExistsReason
+		}
+		pluginPreset.SetCondition(greenhousemetav1alpha1.FalseCondition(greenhousemetav1alpha1.ReadyCondition, reason,
+			fmt.Sprintf("The referenced %s %q does not exist", pluginPreset.Spec.Plugin.PluginDefinitionRef.Kind, pluginPreset.Spec.Plugin.PluginDefinitionRef.Name)))
+		return ctrl.Result{RequeueAfter: 10 * time.Second}, lifecycle.Success, nil
+	}
+
+	// Clear any stale PluginDefinitionNotExists ReadyCondition since the definition now exists.
+	if rc := pluginPreset.Status.GetConditionByType(greenhousemetav1alpha1.ReadyCondition); rc != nil &&
+		(rc.Reason == greenhousev1alpha1.PluginDefinitionNotExistsReason || rc.Reason == greenhousev1alpha1.ClusterPluginDefinitionNotExistsReason) {
+		pluginPreset.SetCondition(greenhousemetav1alpha1.UnknownCondition(greenhousemetav1alpha1.ReadyCondition, "", ""))
+	}
 
 	clusters, err := r.listClusters(ctx, pluginPreset)
 	if err != nil {
@@ -368,12 +390,43 @@ func initPluginPresetStatus(p *greenhousev1alpha1.PluginPreset) {
 	}
 }
 
+// pluginDefinitionExists checks whether the referenced PluginDefinition or ClusterPluginDefinition exists.
+func (r *PluginPresetReconciler) pluginDefinitionExists(ctx context.Context, pluginPreset *greenhousev1alpha1.PluginPreset) (bool, error) {
+	ref := pluginPreset.Spec.Plugin.PluginDefinitionRef
+	switch ref.Kind {
+	case greenhousev1alpha1.PluginDefinitionKind:
+		pd := &greenhousev1alpha1.PluginDefinition{}
+		err := r.Get(ctx, client.ObjectKey{Namespace: pluginPreset.GetNamespace(), Name: ref.Name}, pd)
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return err == nil, err
+	case greenhousev1alpha1.ClusterPluginDefinitionKind:
+		cpd := &greenhousev1alpha1.ClusterPluginDefinition{}
+		err := r.Get(ctx, client.ObjectKey{Name: ref.Name}, cpd)
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return err == nil, err
+	default:
+		return false, fmt.Errorf("unsupported PluginDefinition kind: %s", ref.Kind)
+	}
+}
+
 // computeReadyCondition computes the ReadyCondition based on the PluginPreset's StatusConditions.
 func (r *PluginPresetReconciler) computeReadyCondition(
 	conditions greenhousemetav1alpha1.StatusConditions,
 ) (readyCondition greenhousemetav1alpha1.Condition) {
 
 	readyCondition = *conditions.GetConditionByType(greenhousemetav1alpha1.ReadyCondition)
+
+	// If the ReadyCondition was already set to False with a PluginDefinitionNotExists reason by EnsureCreated,
+	// preserve it and do not overwrite it.
+	if readyCondition.IsFalse() &&
+		(readyCondition.Reason == greenhousev1alpha1.PluginDefinitionNotExistsReason ||
+			readyCondition.Reason == greenhousev1alpha1.ClusterPluginDefinitionNotExistsReason) {
+		return readyCondition
+	}
 
 	if conditions.GetConditionByType(greenhousev1alpha1.PluginFailedCondition).IsTrue() {
 		readyCondition.Status = metav1.ConditionFalse

--- a/internal/controller/plugin/pluginpreset_controller_test.go
+++ b/internal/controller/plugin/pluginpreset_controller_test.go
@@ -412,6 +412,68 @@ var _ = Describe("PluginPreset Controller Lifecycle", Ordered, func() {
 		test.EventuallyDeleted(test.Ctx, test.K8sClient, pluginPreset)
 	})
 
+	It("should set ReadyCondition to false with ClusterPluginDefinitionNotExists reason when referenced ClusterPluginDefinition does not exist, and recover when it is created", func() {
+		const missingDefName = "non-existing-plugin-definition"
+		pluginPreset := test.NewPluginPreset("pd-not-found", test.TestNamespace,
+			test.WithPluginPresetLabel(greenhouseapis.LabelKeyOwnedBy, testTeam.Name),
+			test.WithPluginPresetPluginSpec(greenhousev1alpha1.PluginSpec{
+				PluginDefinitionRef: greenhousev1alpha1.PluginDefinitionReference{
+					Kind: greenhousev1alpha1.ClusterPluginDefinitionKind,
+					Name: missingDefName,
+				},
+				ReleaseName:      releaseName,
+				ReleaseNamespace: releaseNamespace,
+			}),
+			test.WithPluginPresetClusterSelector(metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"cluster": clusterA,
+				},
+			}))
+
+		Expect(test.K8sClient.Create(test.Ctx, pluginPreset)).Should(Succeed(), "failed to create test PluginPreset")
+
+		By("checking that ReadyCondition is false with ClusterPluginDefinitionNotExists reason")
+		Eventually(func(g Gomega) {
+			err := test.K8sClient.Get(test.Ctx, types.NamespacedName{Name: "pd-not-found", Namespace: pluginPreset.Namespace}, pluginPreset)
+			g.Expect(err).ShouldNot(HaveOccurred(), "unexpected error getting PluginPreset")
+			g.Expect(pluginPreset.Status.StatusConditions.Conditions).NotTo(BeNil(), "the PluginPreset should have StatusConditions")
+
+			readyCondition := pluginPreset.Status.GetConditionByType(greenhousemetav1alpha1.ReadyCondition)
+			g.Expect(readyCondition).NotTo(BeNil(), "ReadyCondition should be set")
+			g.Expect(readyCondition.IsFalse()).Should(BeTrue(), "ReadyCondition should be false when ClusterPluginDefinition is not found")
+			g.Expect(readyCondition.Reason).To(Equal(greenhousev1alpha1.ClusterPluginDefinitionNotExistsReason), "ReadyCondition reason should be ClusterPluginDefinitionNotExists")
+			g.Expect(readyCondition.Message).To(ContainSubstring(missingDefName), "condition message should contain the PluginDefinition name")
+		}).Should(Succeed(), "the PluginPreset should have ReadyCondition set to false with correct reason")
+
+		By("checking that no Plugins were created")
+		pluginList := &greenhousev1alpha1.PluginList{}
+		Expect(test.K8sClient.List(test.Ctx, pluginList, client.InNamespace(test.TestNamespace), client.MatchingLabels{greenhouseapis.LabelKeyPluginPreset: "pd-not-found"})).To(Succeed())
+		Expect(pluginList.Items).To(BeEmpty(), "no Plugins should be created when ClusterPluginDefinition does not exist")
+
+		By("creating the missing ClusterPluginDefinition to trigger recovery")
+		missingDef := test.NewClusterPluginDefinition(test.Ctx, missingDefName, test.WithHelmChart(
+			&greenhousev1alpha1.HelmChartReference{
+				Name:       "dummy",
+				Repository: "oci://greenhouse/helm-charts",
+				Version:    "1.0.0",
+			}))
+		Expect(test.K8sClient.Create(test.Ctx, missingDef)).To(Succeed(), "failed to create the ClusterPluginDefinition")
+		test.MockHelmChartReady(test.Ctx, test.K8sClient, missingDef, flux.HelmRepositoryDefaultNamespace)
+
+		By("checking that ReadyCondition recovers after ClusterPluginDefinition is created")
+		Eventually(func(g Gomega) {
+			err := test.K8sClient.Get(test.Ctx, types.NamespacedName{Name: "pd-not-found", Namespace: pluginPreset.Namespace}, pluginPreset)
+			g.Expect(err).ShouldNot(HaveOccurred(), "unexpected error getting PluginPreset")
+
+			readyCondition := pluginPreset.Status.GetConditionByType(greenhousemetav1alpha1.ReadyCondition)
+			g.Expect(readyCondition).NotTo(BeNil(), "ReadyCondition should be set")
+			g.Expect(string(readyCondition.Reason)).NotTo(Equal(string(greenhousev1alpha1.ClusterPluginDefinitionNotExistsReason)), "ReadyCondition reason should no longer be ClusterPluginDefinitionNotExists")
+		}).Should(Succeed(), "the PluginPreset should recover after the ClusterPluginDefinition is created")
+
+		test.EventuallyDeleted(test.Ctx, test.K8sClient, pluginPreset)
+		test.EventuallyDeleted(test.Ctx, test.K8sClient, missingDef)
+	})
+
 	It("should reconcile PluginStatuses for PluginPreset", func() {
 		By("creating a PluginPreset")
 		testPluginPreset := test.NewPluginPreset(pluginPresetName, test.TestNamespace,

--- a/internal/webhook/v1alpha1/pluginpreset_webhook.go
+++ b/internal/webhook/v1alpha1/pluginpreset_webhook.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -75,13 +74,19 @@ func ValidateCreatePluginPreset(ctx context.Context, c client.Client, pluginPres
 	}
 
 	// ensure PluginDefinition reference is set
-	pluginDefinitionRefNamePath := field.NewPath("spec", "plugin", "pluginDefinitionRef", "name")
 	pluginDefinitionRefKindPath := field.NewPath("spec", "plugin", "pluginDefinitionRef", "kind")
 	if pluginPreset.Spec.Plugin.PluginDefinitionRef.Name == "" {
-		allErrs = append(allErrs, field.Invalid(pluginDefinitionRefNamePath, pluginPreset.Spec.Plugin.PluginDefinitionRef.Name, "PluginDefinition name must be set"))
+		allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "plugin", "pluginDefinitionRef", "name"), pluginPreset.Spec.Plugin.PluginDefinitionRef.Name, "PluginDefinition name must be set"))
 	}
 	if pluginPreset.Spec.Plugin.PluginDefinitionRef.Kind == "" {
 		allErrs = append(allErrs, field.Invalid(pluginDefinitionRefKindPath, pluginPreset.Spec.Plugin.PluginDefinitionRef.Kind, "PluginDefinition kind must be set"))
+	}
+
+	// ensure the PluginDefinition kind is supported
+	if pluginPreset.Spec.Plugin.PluginDefinitionRef.Kind != "" &&
+		pluginPreset.Spec.Plugin.PluginDefinitionRef.Kind != greenhousev1alpha1.PluginDefinitionKind &&
+		pluginPreset.Spec.Plugin.PluginDefinitionRef.Kind != greenhousev1alpha1.ClusterPluginDefinitionKind {
+		allErrs = append(allErrs, field.Invalid(pluginDefinitionRefKindPath, pluginPreset.Spec.Plugin.PluginDefinitionRef.Kind, "unsupported PluginDefinition kind"))
 	}
 
 	// ensure ClusterSelector is set
@@ -103,53 +108,13 @@ func ValidateCreatePluginPreset(ctx context.Context, c client.Client, pluginPres
 		allErrs = append(allErrs, errList...)
 	}
 
+	// validate that each PluginOptionValue and ClusterOptionOverride is structurally valid
+	if errList := validatePluginOptionValuesForPreset(pluginPreset); len(errList) > 0 {
+		allErrs = append(allErrs, errList...)
+	}
+
 	if len(allErrs) > 0 {
 		return allWarns, apierrors.NewInvalid(pluginPreset.GroupVersionKind().GroupKind(), pluginPreset.Name, allErrs)
-	}
-
-	var pluginDefinitionSpec greenhousev1alpha1.PluginDefinitionSpec
-
-	// ensure (Cluster-)PluginDefinition exists and validate OptionValues defined by the Preset
-	switch pluginPreset.Spec.Plugin.PluginDefinitionRef.Kind {
-	case greenhousev1alpha1.PluginDefinitionKind:
-		pluginDefinition := &greenhousev1alpha1.PluginDefinition{}
-		err := c.Get(ctx, types.NamespacedName{
-			Namespace: pluginPreset.GetNamespace(),
-			Name:      pluginPreset.Spec.Plugin.PluginDefinitionRef.Name,
-		}, pluginDefinition)
-		switch {
-		case apierrors.IsNotFound(err):
-			return allWarns, field.Invalid(pluginDefinitionRefNamePath, pluginPreset.Spec.Plugin.PluginDefinitionRef.Name,
-				fmt.Sprintf("PluginDefinition %s does not exist in namespace %s", pluginPreset.Spec.Plugin.PluginDefinitionRef.Name, pluginPreset.GetNamespace()))
-		case err != nil:
-			return allWarns, field.Invalid(pluginDefinitionRefNamePath, pluginPreset.Spec.Plugin.PluginDefinitionRef.Name,
-				fmt.Sprintf("PluginDefinition %s could not be retrieved from namespace %s: %s", pluginPreset.Spec.Plugin.PluginDefinitionRef.Name, pluginPreset.GetNamespace(), err.Error()))
-		default:
-			pluginDefinitionSpec = pluginDefinition.Spec
-		}
-	case greenhousev1alpha1.ClusterPluginDefinitionKind:
-		clusterPluginDefinition := &greenhousev1alpha1.ClusterPluginDefinition{}
-		err := c.Get(ctx, types.NamespacedName{
-			Namespace: "",
-			Name:      pluginPreset.Spec.Plugin.PluginDefinitionRef.Name,
-		}, clusterPluginDefinition)
-		switch {
-		case apierrors.IsNotFound(err):
-			return allWarns, field.Invalid(pluginDefinitionRefNamePath, pluginPreset.Spec.Plugin.PluginDefinitionRef.Name,
-				fmt.Sprintf("ClusterPluginDefinition %s does not exist", pluginPreset.Spec.Plugin.PluginDefinitionRef.Name))
-		case err != nil:
-			return allWarns, field.Invalid(pluginDefinitionRefNamePath, pluginPreset.Spec.Plugin.PluginDefinitionRef.Name,
-				fmt.Sprintf("ClusterPluginDefinition %s could not be retrieved: %s", pluginPreset.Spec.Plugin.PluginDefinitionRef.Name, err.Error()))
-		default:
-			pluginDefinitionSpec = clusterPluginDefinition.Spec
-		}
-	default:
-		return allWarns, field.Invalid(pluginDefinitionRefKindPath, pluginPreset.Spec.Plugin.PluginDefinitionRef.Kind, "unsupported PluginDefinition kind")
-	}
-
-	// validate OptionValues defined by the Preset
-	if errList := validatePluginOptionValuesForPreset(pluginPreset, pluginPreset.Spec.Plugin.PluginDefinitionRef.Name, pluginDefinitionSpec); len(errList) > 0 {
-		return allWarns, apierrors.NewInvalid(pluginPreset.GroupVersionKind().GroupKind(), pluginPreset.Name, errList)
 	}
 
 	return allWarns, nil
@@ -178,6 +143,11 @@ func ValidateUpdatePluginPreset(ctx context.Context, c client.Client, oldPluginP
 		allErrs = append(allErrs, errList...)
 	}
 
+	// validate that each PluginOptionValue and ClusterOptionOverride is structurally valid
+	if errList := validatePluginOptionValuesForPreset(pluginPreset); len(errList) > 0 {
+		allErrs = append(allErrs, errList...)
+	}
+
 	if len(allErrs) > 0 {
 		return allWarns, apierrors.NewInvalid(pluginPreset.GroupVersionKind().GroupKind(), pluginPreset.Name, allErrs)
 	}
@@ -197,19 +167,51 @@ func ValidateDeletePluginPreset(_ context.Context, _ client.Client, pluginPreset
 	return nil, nil
 }
 
-// validatePluginOptionValuesForPreset validates plugin options and their values, but skips the check for required options.
-// Required options are checked at the Plugin creation level, because the preset can override options and we cannot predict what clusters will be a part of the PluginPreset later on.
-func validatePluginOptionValuesForPreset(pluginPreset *greenhousev1alpha1.PluginPreset, pluginDefinitionName string, pluginDefinitionSpec greenhousev1alpha1.PluginDefinitionSpec) field.ErrorList {
+// validatePluginOptionValuesForPreset validates that each PluginOptionValue and ClusterOptionOverride is structurally valid.
+// It checks that each option value has exactly one value source set (value, valueFrom, or expression),
+// and that secret references (valueFrom) have both name and key set.
+// It does NOT validate option types against the PluginDefinition, because the PluginDefinition may not exist yet at admission time.
+// Type validation is deferred to the controller / Plugin creation level.
+func validatePluginOptionValuesForPreset(pluginPreset *greenhousev1alpha1.PluginPreset) field.ErrorList {
 	var allErrs field.ErrorList
 
 	optionValuesPath := field.NewPath("spec").Child("plugin").Child("optionValues")
-	errors := validatePluginOptionValues(pluginPreset.Spec.Plugin.OptionValues, pluginDefinitionName, pluginDefinitionSpec, false, optionValuesPath)
-	allErrs = append(allErrs, errors...)
+	allErrs = append(allErrs, validateOptionValuesStructure(pluginPreset.Spec.Plugin.OptionValues, optionValuesPath)...)
 
 	for idx, overridesForSingleCluster := range pluginPreset.Spec.ClusterOptionOverrides {
 		optionOverridesPath := field.NewPath("spec").Child("clusterOptionOverrides").Index(idx).Child("overrides")
-		errors = validatePluginOptionValues(overridesForSingleCluster.Overrides, pluginDefinitionName, pluginDefinitionSpec, false, optionOverridesPath)
-		allErrs = append(allErrs, errors...)
+		allErrs = append(allErrs, validateOptionValuesStructure(overridesForSingleCluster.Overrides, optionOverridesPath)...)
+	}
+	return allErrs
+}
+
+// validateOptionValuesStructure validates that each option value has exactly one value source set,
+// and that valueFrom secret references have both name and key set.
+func validateOptionValuesStructure(optionValues []greenhousev1alpha1.PluginOptionValue, basePath *field.Path) field.ErrorList {
+	var allErrs field.ErrorList
+	for idx, val := range optionValues {
+		fieldPathWithIndex := basePath.Index(idx)
+
+		// Value, ValueFrom, and Expression are mutually exclusive, but exactly one must be provided.
+		if !hasExactlyOneValueSource(val) {
+			allErrs = append(allErrs, field.Required(
+				fieldPathWithIndex,
+				"must provide exactly one of value, valueFrom, or expression for option "+val.Name),
+			)
+			continue
+		}
+
+		// Validate that ValueFrom secret references are well-formed if a secret is referenced.
+		if val.ValueFrom != nil && val.ValueFrom.Secret != nil {
+			if val.ValueFrom.Secret.Name == "" {
+				allErrs = append(allErrs, field.Required(fieldPathWithIndex.Child("valueFrom").Child("secret").Child("name"),
+					fmt.Sprintf("optionValue %s must reference a secret by name", val.Name)))
+			}
+			if val.ValueFrom.Secret.Key == "" {
+				allErrs = append(allErrs, field.Required(fieldPathWithIndex.Child("valueFrom").Child("secret").Child("key"),
+					fmt.Sprintf("optionValue %s must reference a key in a secret", val.Name)))
+			}
+		}
 	}
 	return allErrs
 }

--- a/internal/webhook/v1alpha1/pluginpreset_webhook_test.go
+++ b/internal/webhook/v1alpha1/pluginpreset_webhook_test.go
@@ -108,30 +108,43 @@ var _ = Describe("PluginPreset Admission Tests", Ordered, func() {
 		Expect(err.Error()).To(ContainSubstring("ClusterSelector must be set"))
 	})
 
-	It("should reject PluginPreset with non-existing ClusterPluginDefinition", func() {
-		cut := &greenhousev1alpha1.PluginPreset{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      pluginPresetCreate,
-				Namespace: test.TestNamespace,
-			},
-			Spec: greenhousev1alpha1.PluginPresetSpec{
-				Plugin: greenhousev1alpha1.PluginSpec{
-					PluginDefinitionRef: greenhousev1alpha1.PluginDefinitionReference{
-						Name: "non-existing",
-						Kind: greenhousev1alpha1.ClusterPluginDefinitionKind,
-					},
+	It("should accept PluginPreset with non-existing ClusterPluginDefinition", func() {
+		cut := test.NewPluginPreset(pluginPresetCreate+"-nonexist-cpd", test.TestNamespace,
+			test.WithPluginPresetLabel(greenhouseapis.LabelKeyOwnedBy, teamWithSupportGroupName),
+			test.WithPluginPresetClusterSelector(metav1.LabelSelector{MatchLabels: map[string]string{"foo": "bar"}}),
+			test.WithPluginPresetPluginSpec(greenhousev1alpha1.PluginSpec{
+				PluginDefinitionRef: greenhousev1alpha1.PluginDefinitionReference{
+					Name: "non-existing",
+					Kind: greenhousev1alpha1.ClusterPluginDefinitionKind,
 				},
-				ClusterSelector:        metav1.LabelSelector{MatchLabels: map[string]string{"foo": "bar"}},
-				ClusterOptionOverrides: []greenhousev1alpha1.ClusterOptionOverride{},
-			},
-		}
+			}),
+		)
 
-		err := test.K8sClient.Create(test.Ctx, cut)
-		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("PluginDefinition non-existing does not exist"))
+		Expect(test.K8sClient.Create(test.Ctx, cut)).To(Succeed(), "PluginPreset with non-existing ClusterPluginDefinition should be accepted")
+		delete(cut.Annotations, greenhousev1alpha1.PreventDeletionAnnotation)
+		Expect(test.K8sClient.Update(test.Ctx, cut)).To(Succeed())
+		test.EventuallyDeleted(test.Ctx, test.K8sClient, cut)
 	})
 
-	It("should reject PluginPreset with non-existing PluginDefinition", func() {
+	It("should accept PluginPreset with non-existing PluginDefinition", func() {
+		cut := test.NewPluginPreset(pluginPresetCreate+"-nonexist-pd", test.TestNamespace,
+			test.WithPluginPresetLabel(greenhouseapis.LabelKeyOwnedBy, teamWithSupportGroupName),
+			test.WithPluginPresetClusterSelector(metav1.LabelSelector{MatchLabels: map[string]string{"foo": "bar"}}),
+			test.WithPluginPresetPluginSpec(greenhousev1alpha1.PluginSpec{
+				PluginDefinitionRef: greenhousev1alpha1.PluginDefinitionReference{
+					Name: "non-existing",
+					Kind: greenhousev1alpha1.PluginDefinitionKind,
+				},
+			}),
+		)
+
+		Expect(test.K8sClient.Create(test.Ctx, cut)).To(Succeed(), "PluginPreset with non-existing PluginDefinition should be accepted")
+		delete(cut.Annotations, greenhousev1alpha1.PreventDeletionAnnotation)
+		Expect(test.K8sClient.Update(test.Ctx, cut)).To(Succeed())
+		test.EventuallyDeleted(test.Ctx, test.K8sClient, cut)
+	})
+
+	It("should reject PluginPreset with unsupported PluginDefinition kind", func() {
 		cut := &greenhousev1alpha1.PluginPreset{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      pluginPresetCreate,
@@ -140,18 +153,17 @@ var _ = Describe("PluginPreset Admission Tests", Ordered, func() {
 			Spec: greenhousev1alpha1.PluginPresetSpec{
 				Plugin: greenhousev1alpha1.PluginSpec{
 					PluginDefinitionRef: greenhousev1alpha1.PluginDefinitionReference{
-						Name: "non-existing",
-						Kind: greenhousev1alpha1.PluginDefinitionKind,
+						Name: "some-definition",
+						Kind: "UnsupportedKind",
 					},
 				},
-				ClusterSelector:        metav1.LabelSelector{MatchLabels: map[string]string{"foo": "bar"}},
-				ClusterOptionOverrides: []greenhousev1alpha1.ClusterOptionOverride{},
+				ClusterSelector: metav1.LabelSelector{MatchLabels: map[string]string{"foo": "bar"}},
 			},
 		}
 
 		err := test.K8sClient.Create(test.Ctx, cut)
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("PluginDefinition non-existing does not exist"))
+		Expect(err.Error()).To(ContainSubstring("Unsupported value"))
 	})
 
 	It("should accept PluginPreset with namespaced PluginDefinition", func() {
@@ -296,7 +308,7 @@ var _ = Describe("PluginPreset Admission Tests", Ordered, func() {
 })
 
 var _ = Describe("Validate Plugin OptionValues for PluginPreset", func() {
-	DescribeTable("Validate OptionValues in .Spec.Plugin contain either Value or ValueFrom", func(value *apiextensionsv1.JSON, valueFrom *greenhousev1alpha1.PluginValueFromSource, expErr bool) {
+	DescribeTable("Validate OptionValues in .Spec.Plugin contain exactly one of Value, ValueFrom, or Expression", func(value *apiextensionsv1.JSON, valueFrom *greenhousev1alpha1.PluginValueFromSource, expErr bool) {
 		pluginPreset := &greenhousev1alpha1.PluginPreset{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "PluginPreset",
@@ -323,34 +335,7 @@ var _ = Describe("Validate Plugin OptionValues for PluginPreset", func() {
 			},
 		}
 
-		var defaultVal *apiextensionsv1.JSON
-		var optionType greenhousev1alpha1.PluginOptionType
-		switch {
-		case value != nil:
-			defaultVal = value
-			optionType = greenhousev1alpha1.PluginOptionTypeString
-		case valueFrom != nil:
-			defaultVal = test.MustReturnJSONFor(valueFrom.Secret.Name)
-			optionType = greenhousev1alpha1.PluginOptionTypeSecret
-		}
-
-		pluginDefinition := &greenhousev1alpha1.ClusterPluginDefinition{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "greenhouse",
-				Name:      "testPlugin",
-			},
-			Spec: greenhousev1alpha1.PluginDefinitionSpec{
-				Options: []greenhousev1alpha1.PluginOption{
-					{
-						Name:    "test",
-						Default: defaultVal,
-						Type:    optionType,
-					},
-				},
-			},
-		}
-
-		errList := validatePluginOptionValuesForPreset(pluginPreset, pluginDefinition.Name, pluginDefinition.Spec)
+		errList := validatePluginOptionValuesForPreset(pluginPreset)
 		switch expErr {
 		case true:
 			Expect(errList).ToNot(BeEmpty(), "expected an error, got nil")
@@ -359,12 +344,12 @@ var _ = Describe("Validate Plugin OptionValues for PluginPreset", func() {
 		}
 	},
 		Entry("Value and ValueFrom nil", nil, nil, true),
-		Entry("Value and ValueFrom not nil", test.MustReturnJSONFor("test"), &greenhousev1alpha1.PluginValueFromSource{Secret: &greenhousev1alpha1.SecretKeyReference{Name: "my-secret"}}, true),
+		Entry("Value and ValueFrom not nil", test.MustReturnJSONFor("test"), &greenhousev1alpha1.PluginValueFromSource{Secret: &greenhousev1alpha1.SecretKeyReference{Name: "my-secret", Key: "secret-key"}}, true),
 		Entry("Value not nil", test.MustReturnJSONFor("test"), nil, false),
 		Entry("ValueFrom not nil", nil, &greenhousev1alpha1.PluginValueFromSource{Secret: &greenhousev1alpha1.SecretKeyReference{Name: "my-secret", Key: "secret-key"}}, false),
 	)
 
-	DescribeTable("Validate OptionValues in .Spec.ClusterOptionOverrides contain either Value or ValueFrom", func(value *apiextensionsv1.JSON, valueFrom *greenhousev1alpha1.PluginValueFromSource, expErr bool) {
+	DescribeTable("Validate OptionValues in .Spec.ClusterOptionOverrides contain exactly one of Value, ValueFrom, or Expression", func(value *apiextensionsv1.JSON, valueFrom *greenhousev1alpha1.PluginValueFromSource, expErr bool) {
 		pluginPreset := &greenhousev1alpha1.PluginPreset{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "PluginPreset",
@@ -397,34 +382,7 @@ var _ = Describe("Validate Plugin OptionValues for PluginPreset", func() {
 			},
 		}
 
-		var defaultVal *apiextensionsv1.JSON
-		var optionType greenhousev1alpha1.PluginOptionType
-		switch {
-		case value != nil:
-			defaultVal = value
-			optionType = greenhousev1alpha1.PluginOptionTypeString
-		case valueFrom != nil:
-			defaultVal = test.MustReturnJSONFor(valueFrom.Secret.Name)
-			optionType = greenhousev1alpha1.PluginOptionTypeSecret
-		}
-
-		pluginDefinition := &greenhousev1alpha1.ClusterPluginDefinition{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "greenhouse",
-				Name:      "testPlugin",
-			},
-			Spec: greenhousev1alpha1.PluginDefinitionSpec{
-				Options: []greenhousev1alpha1.PluginOption{
-					{
-						Name:    "test",
-						Default: defaultVal,
-						Type:    optionType,
-					},
-				},
-			},
-		}
-
-		errList := validatePluginOptionValuesForPreset(pluginPreset, pluginDefinition.Name, pluginDefinition.Spec)
+		errList := validatePluginOptionValuesForPreset(pluginPreset)
 		switch expErr {
 		case true:
 			Expect(errList).ToNot(BeEmpty(), "expected an error, got nil")
@@ -433,163 +391,12 @@ var _ = Describe("Validate Plugin OptionValues for PluginPreset", func() {
 		}
 	},
 		Entry("Value and ValueFrom nil", nil, nil, true),
-		Entry("Value and ValueFrom not nil", test.MustReturnJSONFor("test"), &greenhousev1alpha1.PluginValueFromSource{Secret: &greenhousev1alpha1.SecretKeyReference{Name: "my-secret"}}, true),
+		Entry("Value and ValueFrom not nil", test.MustReturnJSONFor("test"), &greenhousev1alpha1.PluginValueFromSource{Secret: &greenhousev1alpha1.SecretKeyReference{Name: "my-secret", Key: "secret-key"}}, true),
 		Entry("Value not nil", test.MustReturnJSONFor("test"), nil, false),
 		Entry("ValueFrom not nil", nil, &greenhousev1alpha1.PluginValueFromSource{Secret: &greenhousev1alpha1.SecretKeyReference{Name: "my-secret", Key: "secret-key"}}, false),
 	)
 
-	DescribeTable("Validate OptionValues in .Spec.Plugin are consistent with PluginOption Type", func(defaultValue any, defaultType greenhousev1alpha1.PluginOptionType, actValue any, expErr bool) {
-		pluginDefinition := &greenhousev1alpha1.ClusterPluginDefinition{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "greenhouse",
-				Name:      "testPlugin",
-			},
-			Spec: greenhousev1alpha1.PluginDefinitionSpec{
-				Options: []greenhousev1alpha1.PluginOption{
-					{
-						Name:    "test",
-						Default: test.MustReturnJSONFor(defaultValue),
-						Type:    defaultType,
-					},
-				},
-			},
-		}
-
-		pluginPreset := &greenhousev1alpha1.PluginPreset{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       "PluginPreset",
-				APIVersion: greenhousev1alpha1.GroupVersion.String(),
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-plugin-preset",
-				Namespace: test.TestNamespace,
-			},
-			Spec: greenhousev1alpha1.PluginPresetSpec{
-				Plugin: greenhousev1alpha1.PluginSpec{
-					PluginDefinitionRef: greenhousev1alpha1.PluginDefinitionReference{
-						Name: "test",
-						Kind: greenhousev1alpha1.ClusterPluginDefinitionKind,
-					},
-					OptionValues: []greenhousev1alpha1.PluginOptionValue{
-						{
-							Name:  "test",
-							Value: test.MustReturnJSONFor(actValue),
-						},
-					},
-				},
-			},
-		}
-
-		errList := validatePluginOptionValuesForPreset(pluginPreset, pluginDefinition.Name, pluginDefinition.Spec)
-		switch expErr {
-		case true:
-			Expect(errList).ToNot(BeEmpty(), "expected an error, got nil")
-		default:
-			Expect(errList).To(BeEmpty(), "expected no error, got %v", errList)
-		}
-	},
-		Entry("PluginOption Value Consistent With PluginOption Type Bool", false, greenhousev1alpha1.PluginOptionTypeBool, true, false),
-		Entry("PluginOption Value Inconsistent With PluginOption Type Bool", true, greenhousev1alpha1.PluginOptionTypeBool, "notabool", true),
-		Entry("PluginOption Value Consistent With PluginOption Type String", "string", greenhousev1alpha1.PluginOptionTypeString, "mystring", false),
-		Entry("PluginOption Value Consistent With PluginOption Type String Escaped Integer", "1", greenhousev1alpha1.PluginOptionTypeString, "1", false),
-		Entry("PluginOption Value Inconsistent With PluginOption Type String", "string", greenhousev1alpha1.PluginOptionTypeString, 1, true),
-		Entry("PluginOption Value Consistent With PluginOption Type Int", 1, greenhousev1alpha1.PluginOptionTypeInt, 1, false),
-		Entry("PluginOption Value Inconsistent With PluginOption Type Int", 1, greenhousev1alpha1.PluginOptionTypeInt, "one", true),
-		Entry("PluginOption Value Consistent With PluginOption Type List", []string{"one", "two"}, greenhousev1alpha1.PluginOptionTypeList, []string{"one", "two", "three"}, false),
-		Entry("PluginOption Value Inconsistent With PluginOption Type List", []string{"one", "two"}, greenhousev1alpha1.PluginOptionTypeList, "one,two", true),
-		Entry("PluginOption Value Consistent With PluginOption Type Map", map[string]any{"key": "value"}, greenhousev1alpha1.PluginOptionTypeMap, map[string]any{"key": "custom"}, false),
-		Entry("PluginOption Value Inconsistent With PluginOption Type Map", map[string]any{"key": "value"}, greenhousev1alpha1.PluginOptionTypeMap, "one", true),
-		Entry("PluginOption Value Consistent With PluginOption Type Map Nested Map", map[string]any{"key": map[string]any{"nestedKey": "value"}}, greenhousev1alpha1.PluginOptionTypeMap, map[string]any{"key": map[string]any{"nestedKey": "custom"}}, false),
-		Entry("PluginOption Value not supported With PluginOption Type Secret", "", greenhousev1alpha1.PluginOptionTypeSecret, "string", true),
-	)
-
-	DescribeTable("Validate OptionValues in .Spec.ClusterOptionOverrides are consistent with PluginOption Type", func(defaultValue any, defaultType greenhousev1alpha1.PluginOptionType, actValue any, expErr bool) {
-		pluginDefinition := &greenhousev1alpha1.ClusterPluginDefinition{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "greenhouse",
-				Name:      "testPlugin",
-			},
-			Spec: greenhousev1alpha1.PluginDefinitionSpec{
-				Options: []greenhousev1alpha1.PluginOption{
-					{
-						Name:    "test",
-						Default: test.MustReturnJSONFor(defaultValue),
-						Type:    defaultType,
-					},
-				},
-			},
-		}
-
-		pluginPreset := &greenhousev1alpha1.PluginPreset{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       "PluginPreset",
-				APIVersion: greenhousev1alpha1.GroupVersion.String(),
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-plugin-preset",
-				Namespace: test.TestNamespace,
-			},
-			Spec: greenhousev1alpha1.PluginPresetSpec{
-				Plugin: greenhousev1alpha1.PluginSpec{
-					PluginDefinitionRef: greenhousev1alpha1.PluginDefinitionReference{
-						Name: "test",
-						Kind: greenhousev1alpha1.ClusterPluginDefinitionKind,
-					},
-					OptionValues: []greenhousev1alpha1.PluginOptionValue{},
-				},
-				ClusterOptionOverrides: []greenhousev1alpha1.ClusterOptionOverride{
-					{
-						ClusterName: "test-cluster",
-						Overrides: []greenhousev1alpha1.PluginOptionValue{
-							{
-								Name:  "test",
-								Value: test.MustReturnJSONFor(actValue),
-							},
-						},
-					},
-				},
-			},
-		}
-
-		errList := validatePluginOptionValuesForPreset(pluginPreset, pluginDefinition.Name, pluginDefinition.Spec)
-		switch expErr {
-		case true:
-			Expect(errList).ToNot(BeEmpty(), "expected an error, got nil")
-		default:
-			Expect(errList).To(BeEmpty(), "expected no error, got %v", errList)
-		}
-	},
-		Entry("PluginOption Value Consistent With PluginOption Type Bool", false, greenhousev1alpha1.PluginOptionTypeBool, true, false),
-		Entry("PluginOption Value Inconsistent With PluginOption Type Bool", true, greenhousev1alpha1.PluginOptionTypeBool, "notabool", true),
-		Entry("PluginOption Value Consistent With PluginOption Type String", "string", greenhousev1alpha1.PluginOptionTypeString, "mystring", false),
-		Entry("PluginOption Value Consistent With PluginOption Type String Escaped Integer", "1", greenhousev1alpha1.PluginOptionTypeString, "1", false),
-		Entry("PluginOption Value Inconsistent With PluginOption Type String", "string", greenhousev1alpha1.PluginOptionTypeString, 1, true),
-		Entry("PluginOption Value Consistent With PluginOption Type Int", 1, greenhousev1alpha1.PluginOptionTypeInt, 1, false),
-		Entry("PluginOption Value Inconsistent With PluginOption Type Int", 1, greenhousev1alpha1.PluginOptionTypeInt, "one", true),
-		Entry("PluginOption Value Consistent With PluginOption Type List", []string{"one", "two"}, greenhousev1alpha1.PluginOptionTypeList, []string{"one", "two", "three"}, false),
-		Entry("PluginOption Value Inconsistent With PluginOption Type List", []string{"one", "two"}, greenhousev1alpha1.PluginOptionTypeList, "one,two", true),
-		Entry("PluginOption Value Consistent With PluginOption Type Map", map[string]any{"key": "value"}, greenhousev1alpha1.PluginOptionTypeMap, map[string]any{"key": "custom"}, false),
-		Entry("PluginOption Value Inconsistent With PluginOption Type Map", map[string]any{"key": "value"}, greenhousev1alpha1.PluginOptionTypeMap, "one", true),
-		Entry("PluginOption Value Consistent With PluginOption Type Map Nested Map", map[string]any{"key": map[string]any{"nestedKey": "value"}}, greenhousev1alpha1.PluginOptionTypeMap, map[string]any{"key": map[string]any{"nestedKey": "custom"}}, false),
-		Entry("PluginOption Value not supported With PluginOption Type Secret", "", greenhousev1alpha1.PluginOptionTypeSecret, "string", true),
-	)
-
-	DescribeTable("Validate OptionValues in .Spec.Plugin reference a Secret", func(actValue *greenhousev1alpha1.PluginValueFromSource, expErr bool) {
-		pluginDefinition := &greenhousev1alpha1.ClusterPluginDefinition{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "greenhouse",
-				Name:      "testPlugin",
-			},
-			Spec: greenhousev1alpha1.PluginDefinitionSpec{
-				Options: []greenhousev1alpha1.PluginOption{
-					{
-						Name: "test",
-						Type: greenhousev1alpha1.PluginOptionTypeSecret,
-					},
-				},
-			},
-		}
-
+	DescribeTable("Validate OptionValues in .Spec.Plugin with ValueFrom reference a Secret", func(actValue *greenhousev1alpha1.PluginValueFromSource, expErr bool) {
 		pluginPreset := &greenhousev1alpha1.PluginPreset{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "PluginPreset",
@@ -615,7 +422,7 @@ var _ = Describe("Validate Plugin OptionValues for PluginPreset", func() {
 			},
 		}
 
-		errList := validatePluginOptionValuesForPreset(pluginPreset, pluginDefinition.Name, pluginDefinition.Spec)
+		errList := validatePluginOptionValuesForPreset(pluginPreset)
 		switch expErr {
 		case true:
 			Expect(errList).ToNot(BeEmpty(), "expected an error, got nil")
@@ -626,25 +433,10 @@ var _ = Describe("Validate Plugin OptionValues for PluginPreset", func() {
 		Entry("PluginOption ValueFrom has a valid SecretReference", &greenhousev1alpha1.PluginValueFromSource{Secret: &greenhousev1alpha1.SecretKeyReference{Name: "secret", Key: "key"}}, false),
 		Entry("PluginOption ValueFrom is missing SecretReference Name", &greenhousev1alpha1.PluginValueFromSource{Secret: &greenhousev1alpha1.SecretKeyReference{Key: "key"}}, true),
 		Entry("PluginOption ValueFrom is missing SecretReference Key", &greenhousev1alpha1.PluginValueFromSource{Secret: &greenhousev1alpha1.SecretKeyReference{Name: "secret"}}, true),
-		Entry("PluginOption ValueFrom does not contain a SecretReference", nil, true),
+		Entry("PluginOption ValueFrom without a SecretReference is valid", &greenhousev1alpha1.PluginValueFromSource{}, false),
 	)
 
-	DescribeTable("Validate OptionValues in .Spec.ClusterOptionOverrides reference a Secret", func(actValue *greenhousev1alpha1.PluginValueFromSource, expErr bool) {
-		pluginDefinition := &greenhousev1alpha1.ClusterPluginDefinition{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "greenhouse",
-				Name:      "testPlugin",
-			},
-			Spec: greenhousev1alpha1.PluginDefinitionSpec{
-				Options: []greenhousev1alpha1.PluginOption{
-					{
-						Name: "test",
-						Type: greenhousev1alpha1.PluginOptionTypeSecret,
-					},
-				},
-			},
-		}
-
+	DescribeTable("Validate OptionValues in .Spec.ClusterOptionOverrides with ValueFrom reference a Secret", func(actValue *greenhousev1alpha1.PluginValueFromSource, expErr bool) {
 		pluginPreset := &greenhousev1alpha1.PluginPreset{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "PluginPreset",
@@ -676,7 +468,7 @@ var _ = Describe("Validate Plugin OptionValues for PluginPreset", func() {
 			},
 		}
 
-		errList := validatePluginOptionValuesForPreset(pluginPreset, pluginDefinition.Name, pluginDefinition.Spec)
+		errList := validatePluginOptionValuesForPreset(pluginPreset)
 		switch expErr {
 		case true:
 			Expect(errList).ToNot(BeEmpty(), "expected an error, got nil")
@@ -687,26 +479,11 @@ var _ = Describe("Validate Plugin OptionValues for PluginPreset", func() {
 		Entry("PluginOption ValueFrom has a valid SecretReference", &greenhousev1alpha1.PluginValueFromSource{Secret: &greenhousev1alpha1.SecretKeyReference{Name: "secret", Key: "key"}}, false),
 		Entry("PluginOption ValueFrom is missing SecretReference Name", &greenhousev1alpha1.PluginValueFromSource{Secret: &greenhousev1alpha1.SecretKeyReference{Key: "key"}}, true),
 		Entry("PluginOption ValueFrom is missing SecretReference Key", &greenhousev1alpha1.PluginValueFromSource{Secret: &greenhousev1alpha1.SecretKeyReference{Name: "secret"}}, true),
-		Entry("PluginOption ValueFrom does not contain a SecretReference", nil, true),
+		Entry("PluginOption ValueFrom without a SecretReference is valid", &greenhousev1alpha1.PluginValueFromSource{}, false),
 	)
 
-	Describe("Validate PluginPreset does not have to specify required options", func() {
-		pluginDefinition := &greenhousev1alpha1.ClusterPluginDefinition{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "greenhouse",
-				Name:      "testPlugin",
-			},
-			Spec: greenhousev1alpha1.PluginDefinitionSpec{
-				Options: []greenhousev1alpha1.PluginOption{
-					{
-						Name:     "test",
-						Type:     greenhousev1alpha1.PluginOptionTypeString,
-						Required: true,
-					},
-				},
-			},
-		}
-		It("should accept a PluginPreset with missing required options", func() {
+	Describe("Validate PluginPreset accepts valid option values without PluginDefinition", func() {
+		It("should accept a PluginPreset with a value set", func() {
 			pluginPreset := &greenhousev1alpha1.PluginPreset{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "PluginPreset",
@@ -719,20 +496,19 @@ var _ = Describe("Validate Plugin OptionValues for PluginPreset", func() {
 				Spec: greenhousev1alpha1.PluginPresetSpec{
 					Plugin: greenhousev1alpha1.PluginSpec{
 						PluginDefinitionRef: greenhousev1alpha1.PluginDefinitionReference{
-							Name: "test",
+							Name: "non-existing-definition",
 							Kind: greenhousev1alpha1.ClusterPluginDefinitionKind,
 						},
-						OptionValues: []greenhousev1alpha1.PluginOptionValue{},
-					},
-					ClusterOptionOverrides: []greenhousev1alpha1.ClusterOptionOverride{
-						{
-							ClusterName: "test-cluster",
-							Overrides:   []greenhousev1alpha1.PluginOptionValue{},
+						OptionValues: []greenhousev1alpha1.PluginOptionValue{
+							{
+								Name:  "some-option",
+								Value: test.MustReturnJSONFor("some-value"),
+							},
 						},
 					},
 				},
 			}
-			errList := validatePluginOptionValuesForPreset(pluginPreset, pluginDefinition.Name, pluginDefinition.Spec)
+			errList := validatePluginOptionValuesForPreset(pluginPreset)
 			Expect(errList).To(BeEmpty(), "unexpected error")
 		})
 	})


### PR DESCRIPTION

<!--
Please ensure the PR title follows the conventional commit format:
<type>(<scope>): description

For a list of accepted types and scopes see the workflow documentation: https://github.com/cloudoperators/greenhouse/blob/main/.github/workflows/ci-pr-title.yaml

-->

## Description

Ensures e.g. changes bringing new PluginDefinition via Catalog does not break a HelmRelease if a PluginPreset using it comes with the same change

Removes strict existence validation of referenced (Cluster-)PluginDefinition and values in PluginPreset webhook. Webhook only does structural validation of PluginOptionValues & ClusterOptionOverrides.

Add early validation in PluginPreset reconciliation to check whether the
referenced PluginDefinition or ClusterPluginDefinition exists before
proceeding with plugin creation. When the definition is missing, the
ReadyCondition is set to false with an appropriate reason and the
reconciler requeues after 10 seconds.

- Add PluginDefinitionNotExistsReason and ClusterPluginDefinitionNotExistsReason constants
- Add pluginDefinitionExists helper method supporting both definition kinds
- Preserve the not-exists ReadyCondition in computeReadyCondition
- Clear stale not-exists condition once the definition becomes available


## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [x] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 

- Related Issue # (issue)
- Closes # (issue)
- Fixes # (issue)

-->

## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [ ] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
