### PR TITLE
fix(idproxy): initialize signer algorithm in dex server

### DIFF
--- a/cmd/idproxy/main.go
+++ b/cmd/idproxy/main.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/dexidp/dex/server"
+	"github.com/dexidp/dex/server/signer"
 	"github.com/go-logr/logr"
 	"github.com/oklog/run"
 	"github.com/prometheus/client_golang/prometheus"
@@ -85,6 +86,12 @@ func main() {
 		log.Fatalf("Failed to setup refresh token policy: %s", err)
 	}
 
+	signerCfg := &signer.LocalConfig{KeysRotationPeriod: "3h"}
+	tokenSigner, err := signerCfg.Open(ctx, dexter, idTokenValidity, time.Now, logger.With("component", "signer"))
+	if err != nil {
+		log.Fatalf("failed to create token signer: %s", err)
+	}
+
 	registry := prometheus.NewRegistry()
 	registry.MustRegister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
 	registry.MustRegister(collectors.NewGoCollector())
@@ -94,6 +101,7 @@ func main() {
 		SkipApprovalScreen: true,
 		Logger:             logger.With("component", "server"),
 		Storage:            dexter,
+		Signer:             tokenSigner,
 		AllowedOrigins:     allowedOrigins,
 		IDTokensValidFor:   idTokenValidity,
 		RefreshTokenPolicy: refreshPolicy,


### PR DESCRIPTION
## Description

  Fixes a panic in `idproxy` introduced when the binary was built against dex v2.45.1 (#1857).                                                                                                      
                                                                                                                                                                                                               
- In dex v2.44.0, [`constructDiscovery()`](https://github.com/dexidp/dex/blob/7e2225c0e659/server/handlers.go#L108)                                                                                            
  determined the signing algorithm solely from the hardcoded `jose.RS256` value.  
- In v2.45.1, [`constructDiscovery(ctx)`](https://github.com/dexidp/dex/blob/11d2eeb52b42e1980e14cb91e69dd9e3faab2076/server/handlers.go#L108)                                                                             
  still sets `jose.RS256` as an initial default but then immediately overwrites it by calling                                                                                                                  
  [`s.signer.Algorithm(ctx)`](https://github.com/dexidp/dex/blob/11d2eeb52b42e1980e14cb91e69dd9e3faab2076/server/handlers.go#L129).
- This requires `server.Config.Signer` to be explicitly provided. Since in _idxproxy_ `main.go` never set this field, `s.signer` was `nil` at startup, causing an immediate nil pointer dereference panic before the server could serve any requests.
- The fix initializes a `signer.LocalConfig` backed by the existing dex storage, so signing keys are                                                                                                           
  read from and rotated in the same postgres `keys` table as before — no data migration required.                                                                                                              

## Root Cause                                                                                                                                                                                                               
  `cmd/idproxy/main.go` was not updated alongside the dex v2.45.1 bump in #1857 to satisfy the `Signer` requirement in `server.Config`.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [x] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
