### PR TITLE
feat(authz): authorization webhook chart with dns entry

### DIFF
--- a/.github/licenserc.yaml
+++ b/.github/licenserc.yaml
@@ -24,6 +24,7 @@ header:
     - 'hack/typescript/metadata.yaml'
     - 'docs/**'
     - '**/*.md'
+    - '**/*.md.gotmpl'
     - 'LICENSE'
     - 'NOTICE'
     - 'PROJECT'

--- a/Makefile
+++ b/Makefile
@@ -179,6 +179,7 @@ GOLINT ?= $(LOCALBIN)/golangci-lint
 ENVTEST ?= $(LOCALBIN)/setup-envtest
 ENVTEST_ACTION ?= $(LOCALBIN)/action-setup-envtest
 HELMIFY ?= $(LOCALBIN)/helmify
+HELM_DOCS ?= $(LOCALBIN)/helm-docs
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= 5.8.1
@@ -186,6 +187,7 @@ CERT_MANAGER_VERSION ?= v1.17.1
 CONTROLLER_TOOLS_VERSION ?= 0.20.0
 GOLINT_VERSION ?= 2.11.3
 GINKGOLINTER_VERSION ?= 0.23.0
+HELM_DOCS_VERSION ?= 1.14.2
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION ?= 1.35.0
 
@@ -234,6 +236,33 @@ golint: $(GOLINT)
 $(GOLINT): $(LOCALBIN)
 	GOBIN=$(LOCALBIN) go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v$(GOLINT_VERSION)
 	GOBIN=$(LOCALBIN) go install github.com/nunnatsa/ginkgolinter/cmd/ginkgolinter@v$(GINKGOLINTER_VERSION)
+
+.PHONY: helm-docs
+helm-docs: $(HELM_DOCS) ## Download helm-docs locally if necessary.
+$(HELM_DOCS): $(LOCALBIN)
+	$(call go-install-tool,$(HELM_DOCS),github.com/norwoodj/helm-docs/cmd/helm-docs,v$(HELM_DOCS_VERSION))
+
+.PHONY: authz-docs
+authz-docs: helm-docs ## Generate README for charts/authz using helm-docs.
+	$(HELM_DOCS) --chart-search-root charts/authz
+
+# go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
+# $1 - target path with name of binary
+# $2 - package url which can be installed
+# $3 - specific version of package
+define go-install-tool
+@[ -f "$(1)-$(3)" ] || { \
+set -e; \
+package=$(2)@$(3) ;\
+echo "Downloading $${package}" ;\
+rm -f $(1) || true ;\
+GOBIN=$(LOCALBIN) go install $${package} ;\
+mv $(1) $(1)-$(3) ;\
+} ;\
+ln -sf $(1)-$(3) $(1)
+endef
+
+
 
 .PHONY: serve-docs
 serve-docs: manifests

--- a/charts/authz/Chart.yaml
+++ b/charts/authz/Chart.yaml
@@ -3,7 +3,7 @@
 
 apiVersion: v2
 name: authz
-description: A Helm chart for Kubernetes
+description: Authorization server for Greenhouse, enabling support-group-scoped access control via Kubernetes authorizer webhook.
 
 # A chart can be either an 'application' or a 'library' chart.
 #

--- a/charts/authz/README.md
+++ b/charts/authz/README.md
@@ -1,0 +1,87 @@
+# Greenhouse authz
+
+Authorization server for Greenhouse, enabling support-group-scoped access control via Kubernetes authorizer webhook.
+
+## Prerequisites
+
+- Kubernetes 1.30+
+- [cert-manager](https://cert-manager.io/) for TLS certificate management
+
+## Installing the Chart
+
+```shell
+helm upgrade --install greenhouse-authz oci://ghcr.io/cloudoperators/greenhouse/charts/authz \
+  --namespace greenhouse \
+  --create-namespace
+```
+
+## Gardener Usage
+
+Use [shoot-dns-service](https://gardener.cloud/docs/extensions/shoot-dns-service/) and [HA VPN](https://gardener.cloud/docs/gardener/high-availability/) to make the webhook reachable from the seed.
+
+### How it works
+
+1. **HA VPN** — makes ClusterIPs reachable from the seed. See [Gardener docs](https://gardener.cloud/docs/gardener/reversed-vpn-tunnel/#high-availability-for-reversed-vpn-tunnel).
+2. **DNSEntry** — shoot-dns-service registers a DNS record pointing to the static ClusterIP. See [Gardener docs](https://gardener.cloud/docs/guides/networking/DNS-extension/#creating-a-dnsentry-resource-explicitly).
+3. **TLS SAN** — the serving certificate includes the DNS hostname as a SAN.
+
+### Requirements
+
+- [shoot-dns-service](https://gardener.cloud/docs/extensions/shoot-dns-service/) extension enabled on the shoot
+- [HA VPN](https://gardener.cloud/docs/gardener/high-availability/) enabled on the shoot
+
+### Configuration
+
+Pick a static `ClusterIP` from the shoot's service CIDR (check `spec.networking.services` in the shoot resource)
+
+Example configuration:
+
+```yaml
+service:
+  clusterIP: "100.104.1.10"
+
+tls:
+  extraDNSNames:
+    - "greenhouse-authz.your-shoot.example.tld"
+
+dnsEntry:
+  annotations:
+    dns.gardener.cloud/class: garden
+```
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| args | list | `[]` | Additional args to pass to the authz binary. |
+| commonAnnotations | object | `{}` | Annotations to add to all resources. |
+| commonLabels | object | `{}` | Labels to add to all resources. |
+| dnsEntry.annotations | object | `{}` | Annotations to add to the DNSEntry. Set `dns.gardener.cloud/class: garden` to enable shoot-dns-service processing. |
+| dnsEntry.dnsName | string | `""` | DNS name to register. Required when `dnsEntry.enabled` is true. |
+| dnsEntry.enabled | bool | `false` | Enable DNSEntry resource. Set to true when using Gardener shoot-dns-service to register a DNS record for the webhook. |
+| env | list | `[]` | Additional environment variables. |
+| fullnameOverride | string | `""` | Overrides the full name of the chart. |
+| ha.enabled | bool | `false` | When enabled, configures podAntiAffinity and topologySpreadConstraints for high availability. |
+| image.digest | string | `""` | Image digest. Takes precedence over tag if set. |
+| image.pullPolicy | string | `"IfNotPresent"` | Image pull policy. |
+| image.repository | string | `"ghcr.io/cloudoperators/greenhouse"` | Image repository. |
+| image.tag | string | `""` | Overrides the image tag. Defaults to the chart appVersion. |
+| imagePullSecrets | list | `[]` | Image pull secrets. |
+| nameOverride | string | `""` | Overrides the chart name. |
+| podSecurityContext | object | `{}` | Pod security context. |
+| replicaCount | int | `1` | Number of replicas. |
+| resources | object | `{}` | Resource requests and limits. |
+| securityContext | object | `{}` | Container security context. |
+| service.annotations | object | `{}` | Annotations to add to the Service. |
+| service.clusterIP | string | `""` | Static ClusterIP. Required as the DNSEntry target when `dnsEntry.enabled` is true. |
+| service.port | int | `9443` | Port the service listens on. |
+| service.type | string | `"ClusterIP"` | Kubernetes service type. |
+| serviceAccount.annotations | object | `{}` | Annotations to add to the ServiceAccount. |
+| serviceAccount.create | bool | `true` | Whether to create a ServiceAccount. |
+| serviceAccount.name | string | `""` | The name of the ServiceAccount to use. If not set, a name is generated using the fullname template. |
+| tls.enabled | bool | `true` | Enable TLS serving certs. Set to false for local debugging outside the cluster. |
+| tls.extraDNSNames | list | `[]` | Additional DNS SANs to add to the serving certificate. Example: extraDNSNames:   - "greenhouse-authz.example.tld" |
+| tls.secretName | string | `""` | Name of the cert-manager generated Secret. Defaults to `<fullname>-serving-certs`. |
+| tls.useSecret | bool | `true` | When true, mounts the cert-manager Secret as the serving-certs volume. When false, supply the volume yourself via `volumes`/`volumeMounts`. |
+| volumeMounts | list | `[]` | Additional volumeMounts to add to the container. Example: volumeMounts:   - name: serving-certs     mountPath: /tmp/k8s-webhook-server/serving-certs     readOnly: true |
+| volumes | list | `[]` | Additional volumes to add to the Deployment. Example: volumes:   - name: serving-certs     hostPath:       path: /etc/kubernetes/webhook/certs |

--- a/charts/authz/README.md.gotmpl
+++ b/charts/authz/README.md.gotmpl
@@ -1,0 +1,52 @@
+# Greenhouse {{ template "chart.name" . }}
+
+{{ template "chart.description" . }}
+
+## Prerequisites
+
+- Kubernetes 1.30+
+- [cert-manager](https://cert-manager.io/) for TLS certificate management
+
+## Installing the Chart
+
+```shell
+helm upgrade --install greenhouse-authz oci://ghcr.io/cloudoperators/greenhouse/charts/authz \
+  --namespace greenhouse \
+  --create-namespace
+```
+
+## Gardener Usage
+
+Use [shoot-dns-service](https://gardener.cloud/docs/extensions/shoot-dns-service/) and [HA VPN](https://gardener.cloud/docs/gardener/high-availability/) to make the webhook reachable from the seed.
+
+### How it works
+
+1. **HA VPN** — makes ClusterIPs reachable from the seed. See [Gardener docs](https://gardener.cloud/docs/gardener/reversed-vpn-tunnel/#high-availability-for-reversed-vpn-tunnel).
+2. **DNSEntry** — shoot-dns-service registers a DNS record pointing to the static ClusterIP. See [Gardener docs](https://gardener.cloud/docs/guides/networking/DNS-extension/#creating-a-dnsentry-resource-explicitly).
+3. **TLS SAN** — the serving certificate includes the DNS hostname as a SAN.
+
+### Requirements
+
+- [shoot-dns-service](https://gardener.cloud/docs/extensions/shoot-dns-service/) extension enabled on the shoot
+- [HA VPN](https://gardener.cloud/docs/gardener/high-availability/) enabled on the shoot
+
+### Configuration
+
+Pick a static `ClusterIP` from the shoot's service CIDR (check `spec.networking.services` in the shoot resource)
+
+Example configuration:
+
+```yaml
+service:
+  clusterIP: "100.104.1.10"
+
+tls:
+  extraDNSNames:
+    - "greenhouse-authz.your-shoot.example.tld"
+
+dnsEntry:
+  annotations:
+    dns.gardener.cloud/class: garden
+```
+
+{{ template "chart.valuesSection" . }}

--- a/charts/authz/templates/_helpers.tpl
+++ b/charts/authz/templates/_helpers.tpl
@@ -54,7 +54,7 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- with .Values.commonLabels }}
-{{ toYaml . }}
+{{- toYaml . | nindent 0 }}
 {{- end }}
 {{- end }}
 
@@ -85,10 +85,10 @@ Create the name of the serving certs secret to use
 {{- end }}
 
 {{/*
-Annotations
+Annotations — returns empty string if commonAnnotations is empty/nil, safe for fromYaml and with blocks.
 */}}
 {{- define "authz.annotations" -}}
-{{- with .Values.commonAnnotations }}
-{{ toYaml . }}
+{{- if .Values.commonAnnotations }}
+{{- toYaml .Values.commonAnnotations }}
 {{- end }}
 {{- end }}

--- a/charts/authz/templates/certificates.yaml
+++ b/charts/authz/templates/certificates.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/*
+SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 {{- if and .Values.tls.enabled .Values.tls.useSecret }}
 ---
@@ -11,6 +13,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "authz.labels" . | nindent 4 }}
+  {{- with include "authz.annotations" . }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 spec:
   selfSigned: {}
 ---
@@ -22,6 +28,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "authz.labels" . | nindent 4 }}
+  {{- with include "authz.annotations" . }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 spec:
   isCA: true
   commonName: {{ include "authz.fullname" . }}-ca
@@ -29,6 +39,7 @@ spec:
   privateKey:
     algorithm: RSA
     size: 2048
+    rotationPolicy: Always
   issuerRef:
     name: {{ include "authz.fullname" . }}-ca-bootstrap
     kind: Issuer
@@ -41,6 +52,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "authz.labels" . | nindent 4 }}
+  {{- with include "authz.annotations" . }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 spec:
   ca:
     secretName: {{ include "authz.fullname" . }}-ca
@@ -53,6 +68,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "authz.labels" . | nindent 4 }}
+  {{- with include "authz.annotations" . }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 spec:
   secretName: {{ include "authz.servingCertsSecretName" . }}
   commonName: {{ include "authz.fullname" . }}
@@ -61,11 +80,18 @@ spec:
     - {{ include "authz.fullname" . }}.{{ .Release.Namespace }}
     - {{ include "authz.fullname" . }}.{{ .Release.Namespace }}.svc
     - {{ include "authz.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+    {{- range .Values.tls.extraDNSNames }}
+    - {{ . }}
+    {{- end }}
+    {{- if and .Values.dnsEntry.enabled .Values.dnsEntry.dnsName }}
+    - {{ .Values.dnsEntry.dnsName }}
+    {{- end }}
   duration: 2160h
   renewBefore: 360h
   privateKey:
     algorithm: RSA
     size: 2048
+    rotationPolicy: Always
   issuerRef:
     name: {{ include "authz.fullname" . }}-ca
     kind: Issuer
@@ -78,6 +104,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "authz.labels" . | nindent 4 }}
+  {{- with include "authz.annotations" . }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 spec:
   secretName: {{ include "authz.fullname" . }}-apiserver-client
   commonName: kube-apiserver
@@ -88,6 +118,7 @@ spec:
   privateKey:
     algorithm: RSA
     size: 2048
+    rotationPolicy: Always
   issuerRef:
     name: {{ include "authz.fullname" . }}-ca
     kind: Issuer

--- a/charts/authz/templates/deployment.yaml
+++ b/charts/authz/templates/deployment.yaml
@@ -1,10 +1,13 @@
-# SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/*
+SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "authz.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "authz.labels" . | nindent 4 }}
   {{- with include "authz.annotations" . }}
@@ -80,6 +83,9 @@ spec:
           ports:
             - name: webhook
               containerPort: {{ .Values.service.port }}
+              protocol: TCP
+            - name: metrics
+              containerPort: 6543
               protocol: TCP
           {{- with .Values.env }}
           env:

--- a/charts/authz/templates/dnsentry.yaml
+++ b/charts/authz/templates/dnsentry.yaml
@@ -1,0 +1,30 @@
+{{/*
+SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
+
+{{- if .Values.dnsEntry.enabled }}
+{{- if not .Values.service.clusterIP }}
+{{- fail "dnsEntry.enabled requires service.clusterIP to be set as the DNSEntry target" }}
+{{- end }}
+{{- if not .Values.dnsEntry.dnsName }}
+{{- fail "dnsEntry.enabled requires dnsEntry.dnsName to be set" }}
+{{- end }}
+---
+apiVersion: dns.gardener.cloud/v1alpha1
+kind: DNSEntry
+metadata:
+  name: {{ include "authz.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "authz.labels" . | nindent 4 }}
+  {{- with merge (.Values.dnsEntry.annotations | default dict) (include "authz.annotations" . | fromYaml | default dict) }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  dnsName: {{ .Values.dnsEntry.dnsName | quote }}
+  ttl: 120
+  targets:
+    - {{ .Values.service.clusterIP | quote }}
+{{- end }}

--- a/charts/authz/templates/rbac.yaml
+++ b/charts/authz/templates/rbac.yaml
@@ -1,10 +1,18 @@
-# SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/*
+SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: authz-webhook-reader
+  name: {{ include "authz.fullname" . }}
+  labels:
+    {{- include "authz.labels" . | nindent 4 }}
+  {{- with include "authz.annotations" . }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 rules:
   - apiGroups: ["greenhouse.sap"]
     resources: ["*"]
@@ -13,12 +21,18 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: authz-webhook-reader
+  name: {{ include "authz.fullname" . }}
+  labels:
+    {{- include "authz.labels" . | nindent 4 }}
+  {{- with include "authz.annotations" . }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 subjects:
   - kind: ServiceAccount
     name: {{ include "authz.serviceAccountName" . }}
-    namespace: greenhouse
+    namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: authz-webhook-reader
+  name: {{ include "authz.fullname" . }}

--- a/charts/authz/templates/service.yaml
+++ b/charts/authz/templates/service.yaml
@@ -1,18 +1,24 @@
-# SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/*
+SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "authz.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "authz.labels" . | nindent 4 }}
-  {{- with include "authz.annotations" . }}
+  {{- with merge (.Values.service.annotations | default dict) (include "authz.annotations" . | fromYaml | default dict) }}
   annotations:
-    {{- . | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
   type: {{ .Values.service.type }}
+  {{- if .Values.service.clusterIP }}
+  clusterIP: {{ .Values.service.clusterIP }}
+  {{- end }}
   ports:
     - name: webhook
       port: {{ .Values.service.port }}
@@ -21,5 +27,9 @@ spec:
       {{- if .Values.service.nodePort }}
       nodePort: {{ .Values.service.nodePort }}
       {{- end }}
+    - name: metrics
+      port: 6543
+      targetPort: metrics
+      protocol: TCP
   selector:
     {{- include "authz.selectorLabels" . | nindent 4 }}

--- a/charts/authz/templates/serviceaccount.yaml
+++ b/charts/authz/templates/serviceaccount.yaml
@@ -1,14 +1,16 @@
-# SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/*
+SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "authz.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "authz.labels" . | nindent 4 }}
-  {{- with .Values.serviceAccount.annotations }}
+  {{- with merge (.Values.serviceAccount.annotations | default dict) (include "authz.annotations" . | fromYaml | default dict) }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-automountServiceAccountToken: {{ .Values.serviceAccount.automount }}

--- a/charts/authz/templates/servicemonitor.yaml
+++ b/charts/authz/templates/servicemonitor.yaml
@@ -1,0 +1,27 @@
+{{/*
+SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
+
+{{- if .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "authz.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "authz.labels" . | nindent 4 }}
+    plugin: kube-monitoring
+  {{- with include "authz.annotations" . }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "authz.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: metrics
+      scheme: http
+      path: /metrics
+{{- end }}

--- a/charts/authz/values.yaml
+++ b/charts/authz/values.yaml
@@ -1,35 +1,45 @@
 # SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Greenhouse contributors
 # SPDX-License-Identifier: Apache-2.0
 
+# -- Overrides the chart name.
 nameOverride: ""
-fullnameOverride: "greenhouse-authz"
+# -- Overrides the full name of the chart.
+fullnameOverride: ""
 
+# -- Number of replicas.
 replicaCount: 1
 
 image:
+  # -- Image repository.
   repository: ghcr.io/cloudoperators/greenhouse
+  # -- Image pull policy.
   pullPolicy: IfNotPresent
-  # Overrides the image tag. Defaults to the chart appVersion.
+  # -- Overrides the image tag. Defaults to the chart appVersion.
   tag: ""
-  # digest takes precedence over tag if set
+  # -- Image digest. Takes precedence over tag if set.
   digest: ""
 
+# -- Image pull secrets.
 imagePullSecrets: []
 
 serviceAccount:
+  # -- Whether to create a ServiceAccount.
   create: true
-  automount: true
+  # -- Annotations to add to the ServiceAccount.
   annotations: {}
-  # The name of the service account to use.
-  # If not set, a name is generated using the fullname template.
+  # -- The name of the ServiceAccount to use. If not set, a name is generated using the fullname template.
   name: ""
 
+# -- Annotations to add to all resources.
 commonAnnotations: {}
+# -- Labels to add to all resources.
 commonLabels: {}
 
+# -- Pod security context.
 podSecurityContext: {}
   # fsGroup: 2000
 
+# -- Container security context.
 securityContext: {}
   # capabilities:
   #   drop:
@@ -39,44 +49,60 @@ securityContext: {}
   # runAsUser: 1000
 
 service:
+  # -- Kubernetes service type.
   type: ClusterIP
+  # -- Port the service listens on.
   port: 9443
+  # -- Static ClusterIP. Required as the DNSEntry target when `dnsEntry.enabled` is true.
+  clusterIP: ""
+  # -- Annotations to add to the Service.
+  annotations: {}
+
+dnsEntry:
+  # -- Enable DNSEntry resource. Set to true when using Gardener shoot-dns-service to register a DNS record for the webhook.
+  enabled: false
+  # -- DNS name to register. Required when `dnsEntry.enabled` is true.
+  dnsName: ""
+  # -- Annotations to add to the DNSEntry. Set `dns.gardener.cloud/class: garden` to enable shoot-dns-service processing.
+  annotations: {}
 
 tls:
-  # Set to false to disable auto-mounting of serving certs (e.g. local debugger running outside cluster).
-  # Set to true with useSecret=true to auto-mount the cert-manager Secret as serving-certs volume.
-  # Set to true with useSecret=false to supply the serving-certs volume yourself via volumes/volumeMounts.
+  # -- Enable TLS serving certs. Set to false for local debugging outside the cluster.
   enabled: true
-  # When enabled=true and useSecret=true, the chart mounts the cert-manager Secret as the serving-certs volume.
-  # When enabled=true and useSecret=false, supply the serving-certs volume/mount via volumes/volumeMounts below.
+  # -- When true, mounts the cert-manager Secret as the serving-certs volume. When false, supply the volume yourself via `volumes`/`volumeMounts`.
   useSecret: true
-  # Name of the cert-manager generated Secret. Defaults to <fullname>-serving-certs.
+  # -- Name of the cert-manager generated Secret. Defaults to `<fullname>-serving-certs`.
   secretName: ""
+  # -- Additional DNS SANs to add to the serving certificate.
+  # @default -- `[]`
+  # Example:
+  # extraDNSNames:
+  #   - "greenhouse-authz.example.tld"
+  extraDNSNames: []
 
-# Additional volumes to add to the deployment.
-# Example for kind hostPath (tls.enabled=true, tls.useSecret=false):
+# -- Additional volumes to add to the Deployment.
+# Example:
 # volumes:
 #   - name: serving-certs
 #     hostPath:
 #       path: /etc/kubernetes/webhook/certs
+volumes: []
 
-# Additional volumeMounts to add to the container.
-# Example for kind hostPath (tls.enabled=true, tls.useSecret=false):
+# -- Additional volumeMounts to add to the container.
+# Example:
 # volumeMounts:
 #   - name: serving-certs
 #     mountPath: /tmp/k8s-webhook-server/serving-certs
 #     readOnly: true
+volumeMounts: []
 
-# Additional environment variables.
-# env:
-#   - name: AUTHZ_TLS_DISABLED
-#     value: "true"
+# -- Additional environment variables.
 env: []
 
-# Additional args to pass to the authz binary.
-# Use --webhook-client-ca-name="" to disable mTLS client cert verification.
+# -- Additional args to pass to the authz binary.
 args: []
 
+# -- Resource requests and limits.
 resources: {}
   # limits:
   #   cpu: 500m
@@ -85,6 +111,6 @@ resources: {}
   #   cpu: 10m
   #   memory: 64Mi
 
-# When enabled, configures podAntiAffinity and topologySpreadConstraints for high availability.
 ha:
-  enabled: true
+  # -- When enabled, configures podAntiAffinity and topologySpreadConstraints for high availability.
+  enabled: false

--- a/charts/greenhouse/perses-dashboards/authz.json
+++ b/charts/greenhouse/perses-dashboards/authz.json
@@ -7,31 +7,9 @@
   "spec": {
     "display": {
       "name": "Greenhouse Authz Webhook",
-      "description": "Authorization webhook metrics — request outcomes, denial reasons, latency, and access patterns by support group"
+      "description": "Authorization webhook metrics \u2014 request outcomes, denial reasons, latency, and access patterns by support group"
     },
-    "variables": [
-      {
-        "kind": "ListVariable",
-        "spec": {
-          "name": "support_group",
-          "display": {
-            "name": "Support Group",
-            "hidden": false
-          },
-          "defaultValue": "$__all",
-          "allowAllValue": true,
-          "allowMultiple": true,
-          "sort": "alphabetical-ci-asc",
-          "plugin": {
-            "kind": "PrometheusLabelValuesVariable",
-            "spec": {
-              "labelName": "support_group",
-              "matchers": ["greenhouse_authz_access_total"]
-            }
-          }
-        }
-      }
-    ],
+    "variables": [],
     "panels": {
       "stat_total": {
         "kind": "Panel",
@@ -44,7 +22,9 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last",
-              "format": { "unit": "decimal" },
+              "format": {
+                "unit": "decimal"
+              },
               "valueFontSize": 64
             }
           },
@@ -75,12 +55,17 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last",
-              "format": { "unit": "decimal" },
+              "format": {
+                "unit": "decimal"
+              },
               "valueFontSize": 64,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
-                  { "value": 0, "color": "#388e3c" }
+                  {
+                    "value": 0,
+                    "color": "#388e3c"
+                  }
                 ]
               }
             }
@@ -112,13 +97,21 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last",
-              "format": { "unit": "decimal" },
+              "format": {
+                "unit": "decimal"
+              },
               "valueFontSize": 64,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
-                  { "value": 0, "color": "#388e3c" },
-                  { "value": 1, "color": "#d32f2f" }
+                  {
+                    "value": 0,
+                    "color": "#388e3c"
+                  },
+                  {
+                    "value": 1,
+                    "color": "#d32f2f"
+                  }
                 ]
               }
             }
@@ -150,14 +143,26 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
-              "format": { "unit": "milliseconds", "decimalPlaces": 1 },
+              "format": {
+                "unit": "milliseconds",
+                "decimalPlaces": 1
+              },
               "valueFontSize": 64,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
-                  { "value": 0, "color": "#388e3c" },
-                  { "value": 100, "color": "#f57c00" },
-                  { "value": 500, "color": "#d32f2f" }
+                  {
+                    "value": 0,
+                    "color": "#388e3c"
+                  },
+                  {
+                    "value": 100,
+                    "color": "#f57c00"
+                  },
+                  {
+                    "value": 500,
+                    "color": "#d32f2f"
+                  }
                 ]
               }
             }
@@ -189,14 +194,26 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
-              "format": { "unit": "milliseconds", "decimalPlaces": 1 },
+              "format": {
+                "unit": "milliseconds",
+                "decimalPlaces": 1
+              },
               "valueFontSize": 64,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
-                  { "value": 0, "color": "#388e3c" },
-                  { "value": 100, "color": "#f57c00" },
-                  { "value": 500, "color": "#d32f2f" }
+                  {
+                    "value": 0,
+                    "color": "#388e3c"
+                  },
+                  {
+                    "value": 100,
+                    "color": "#f57c00"
+                  },
+                  {
+                    "value": 500,
+                    "color": "#d32f2f"
+                  }
                 ]
               }
             }
@@ -228,14 +245,26 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
-              "format": { "unit": "milliseconds", "decimalPlaces": 1 },
+              "format": {
+                "unit": "milliseconds",
+                "decimalPlaces": 1
+              },
               "valueFontSize": 64,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
-                  { "value": 0, "color": "#388e3c" },
-                  { "value": 100, "color": "#f57c00" },
-                  { "value": 500, "color": "#d32f2f" }
+                  {
+                    "value": 0,
+                    "color": "#388e3c"
+                  },
+                  {
+                    "value": 100,
+                    "color": "#f57c00"
+                  },
+                  {
+                    "value": 500,
+                    "color": "#d32f2f"
+                  }
                 ]
               }
             }
@@ -266,8 +295,15 @@
           "plugin": {
             "kind": "TimeSeriesChart",
             "spec": {
-              "legend": { "position": "bottom", "mode": "list" },
-              "yAxis": { "format": { "unit": "requests/sec" } }
+              "legend": {
+                "position": "bottom",
+                "mode": "list"
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "requests/sec"
+                }
+              }
             }
           },
           "queries": [
@@ -296,8 +332,15 @@
           "plugin": {
             "kind": "TimeSeriesChart",
             "spec": {
-              "legend": { "position": "bottom", "mode": "list" },
-              "yAxis": { "format": { "unit": "milliseconds" } }
+              "legend": {
+                "position": "bottom",
+                "mode": "list"
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "milliseconds"
+                }
+              }
             }
           },
           "queries": [
@@ -350,8 +393,15 @@
           "plugin": {
             "kind": "TimeSeriesChart",
             "spec": {
-              "legend": { "position": "bottom", "mode": "list" },
-              "yAxis": { "format": { "unit": "decimal" } }
+              "legend": {
+                "position": "bottom",
+                "mode": "list"
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
             }
           },
           "queries": [
@@ -380,8 +430,15 @@
           "plugin": {
             "kind": "TimeSeriesChart",
             "spec": {
-              "legend": { "position": "bottom", "mode": "list" },
-              "yAxis": { "format": { "unit": "decimal" } }
+              "legend": {
+                "position": "bottom",
+                "mode": "list"
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
             }
           },
           "queries": [
@@ -391,7 +448,7 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "sum by (support_group, result) (rate(greenhouse_authz_access_total{support_group=~\"$support_group\"}[5m]))",
+                    "query": "sum by (support_group, result) (rate(greenhouse_authz_access_total[5m]))",
                     "seriesNameFormat": "{{support_group}} / {{result}}"
                   }
                 }
@@ -410,8 +467,15 @@
           "plugin": {
             "kind": "TimeSeriesChart",
             "spec": {
-              "legend": { "position": "bottom", "mode": "list" },
-              "yAxis": { "format": { "unit": "decimal" } }
+              "legend": {
+                "position": "bottom",
+                "mode": "list"
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
             }
           },
           "queries": [
@@ -440,8 +504,15 @@
           "plugin": {
             "kind": "TimeSeriesChart",
             "spec": {
-              "legend": { "position": "bottom", "mode": "list" },
-              "yAxis": { "format": { "unit": "decimal" } }
+              "legend": {
+                "position": "bottom",
+                "mode": "list"
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
             }
           },
           "queries": [
@@ -467,12 +538,38 @@
         "spec": {
           "display": {
             "title": "Overview",
-            "collapse": { "open": true }
+            "collapse": {
+              "open": true
+            }
           },
           "items": [
-            { "x": 0,  "y": 0, "width": 8,  "height": 4, "content": { "$ref": "#/spec/panels/stat_total" } },
-            { "x": 8,  "y": 0, "width": 8,  "height": 4, "content": { "$ref": "#/spec/panels/stat_allowed" } },
-            { "x": 16, "y": 0, "width": 8,  "height": 4, "content": { "$ref": "#/spec/panels/stat_denied" } }
+            {
+              "x": 0,
+              "y": 0,
+              "width": 8,
+              "height": 4,
+              "content": {
+                "$ref": "#/spec/panels/stat_total"
+              }
+            },
+            {
+              "x": 8,
+              "y": 0,
+              "width": 8,
+              "height": 4,
+              "content": {
+                "$ref": "#/spec/panels/stat_allowed"
+              }
+            },
+            {
+              "x": 16,
+              "y": 0,
+              "width": 8,
+              "height": 4,
+              "content": {
+                "$ref": "#/spec/panels/stat_denied"
+              }
+            }
           ]
         }
       },
@@ -481,12 +578,38 @@
         "spec": {
           "display": {
             "title": "Latency Percentiles",
-            "collapse": { "open": true }
+            "collapse": {
+              "open": true
+            }
           },
           "items": [
-            { "x": 0,  "y": 0, "width": 8,  "height": 4, "content": { "$ref": "#/spec/panels/stat_p50" } },
-            { "x": 8,  "y": 0, "width": 8,  "height": 4, "content": { "$ref": "#/spec/panels/stat_p95" } },
-            { "x": 16, "y": 0, "width": 8,  "height": 4, "content": { "$ref": "#/spec/panels/stat_p99" } }
+            {
+              "x": 0,
+              "y": 0,
+              "width": 8,
+              "height": 4,
+              "content": {
+                "$ref": "#/spec/panels/stat_p50"
+              }
+            },
+            {
+              "x": 8,
+              "y": 0,
+              "width": 8,
+              "height": 4,
+              "content": {
+                "$ref": "#/spec/panels/stat_p95"
+              }
+            },
+            {
+              "x": 16,
+              "y": 0,
+              "width": 8,
+              "height": 4,
+              "content": {
+                "$ref": "#/spec/panels/stat_p99"
+              }
+            }
           ]
         }
       },
@@ -495,11 +618,29 @@
         "spec": {
           "display": {
             "title": "Request Traffic",
-            "collapse": { "open": true }
+            "collapse": {
+              "open": true
+            }
           },
           "items": [
-            { "x": 0,  "y": 0, "width": 12, "height": 8, "content": { "$ref": "#/spec/panels/ts_request_rate" } },
-            { "x": 12, "y": 0, "width": 12, "height": 8, "content": { "$ref": "#/spec/panels/ts_latency" } }
+            {
+              "x": 0,
+              "y": 0,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/ts_request_rate"
+              }
+            },
+            {
+              "x": 12,
+              "y": 0,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/ts_latency"
+              }
+            }
           ]
         }
       },
@@ -508,11 +649,29 @@
         "spec": {
           "display": {
             "title": "Access Patterns",
-            "collapse": { "open": true }
+            "collapse": {
+              "open": true
+            }
           },
           "items": [
-            { "x": 0,  "y": 0, "width": 12, "height": 8, "content": { "$ref": "#/spec/panels/ts_access_by_group" } },
-            { "x": 12, "y": 0, "width": 12, "height": 8, "content": { "$ref": "#/spec/panels/ts_denial_reasons" } }
+            {
+              "x": 0,
+              "y": 0,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/ts_access_by_group"
+              }
+            },
+            {
+              "x": 12,
+              "y": 0,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/ts_denial_reasons"
+              }
+            }
           ]
         }
       },
@@ -521,11 +680,29 @@
         "spec": {
           "display": {
             "title": "Errors",
-            "collapse": { "open": true }
+            "collapse": {
+              "open": true
+            }
           },
           "items": [
-            { "x": 0,  "y": 0, "width": 12, "height": 8, "content": { "$ref": "#/spec/panels/ts_kube_errors" } },
-            { "x": 12, "y": 0, "width": 12, "height": 8, "content": { "$ref": "#/spec/panels/ts_kind_errors" } }
+            {
+              "x": 0,
+              "y": 0,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/ts_kube_errors"
+              }
+            },
+            {
+              "x": 12,
+              "y": 0,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/ts_kind_errors"
+              }
+            }
           ]
         }
       }

--- a/cmd/authz/authorization.go
+++ b/cmd/authz/authorization.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Greenhouse contributors
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
 // SPDX-License-Identifier: Apache-2.0
 
 package main
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"slices"
 	"strings"
-	"time"
 
 	authv1 "k8s.io/api/authorization/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -25,7 +24,6 @@ const supportGroupClaimPrefix = "support-group:"
 
 func handleAuthorize(w http.ResponseWriter, r *http.Request, c client.Client, mapper meta.RESTMapper) {
 	ctx := r.Context()
-	start := time.Now()
 
 	if r.Method != http.MethodPost {
 		http.Error(w, "invalid method", http.StatusMethodNotAllowed)
@@ -41,7 +39,7 @@ func handleAuthorize(w http.ResponseWriter, r *http.Request, c client.Client, ma
 
 	attrs := review.Spec.ResourceAttributes
 	if attrs == nil || attrs.Name == "" {
-		recordDenied("", "", reasonMissingAttributes, nil, start)
+		recordDenied("", "", reasonMissingAttributes, nil)
 		respond(w, review, false, "missing resource attributes")
 		return
 	}
@@ -58,7 +56,7 @@ func handleAuthorize(w http.ResponseWriter, r *http.Request, c client.Client, ma
 	}
 
 	if len(userSupportGroups) == 0 {
-		recordDenied(verb, attrs.Resource, reasonNoSupportGroupClaims, nil, start)
+		recordDenied(verb, attrs.Resource, reasonNoSupportGroupClaims, nil)
 		respond(w, review, false, "user has no support-group claims")
 		return
 	}
@@ -74,7 +72,7 @@ func handleAuthorize(w http.ResponseWriter, r *http.Request, c client.Client, ma
 	gvk, err := mapper.KindFor(gvr)
 	if err != nil {
 		authzKindResolutionErrorsTotal.Inc()
-		recordDenied(verb, attrs.Resource, reasonKindResolutionFailed, userSupportGroups, start)
+		recordDenied(verb, attrs.Resource, reasonKindResolutionFailed, userSupportGroups)
 		respond(w, review, false, "failed to get Kind for the requested resource")
 		return
 	}
@@ -85,7 +83,7 @@ func handleAuthorize(w http.ResponseWriter, r *http.Request, c client.Client, ma
 	key := types.NamespacedName{Namespace: attrs.Namespace, Name: attrs.Name}
 	if err := c.Get(ctx, key, obj); err != nil {
 		authzKubeFetchErrorsTotal.WithLabelValues(err.Error()).Inc()
-		recordDenied(verb, attrs.Resource, reasonObjectNotFound, userSupportGroups, start)
+		recordDenied(verb, attrs.Resource, reasonObjectNotFound, userSupportGroups)
 		respond(w, review, false, fmt.Sprintf("failed to fetch object: %v", err))
 		return
 	}
@@ -93,7 +91,7 @@ func handleAuthorize(w http.ResponseWriter, r *http.Request, c client.Client, ma
 	labels := obj.GetLabels()
 	ownedByValue, ok := labels[greenhouseapis.LabelKeyOwnedBy]
 	if !ok {
-		recordDenied(verb, attrs.Resource, reasonNoOwnedByLabel, userSupportGroups, start)
+		recordDenied(verb, attrs.Resource, reasonNoOwnedByLabel, userSupportGroups)
 		respond(w, review, false, "requested resource has no owned-by label set")
 		return
 	}
@@ -101,12 +99,12 @@ func handleAuthorize(w http.ResponseWriter, r *http.Request, c client.Client, ma
 
 	// If the support-group matches the greenhouse.sap/owned-by label on the resources the user should get full permissions on the resource.
 	if slices.Contains(userSupportGroups, ownedByValue) {
-		recordAllowed(verb, attrs.Resource, ownedByValue, start)
+		recordAllowed(verb, attrs.Resource, ownedByValue)
 		respond(w, review, true, "user has a support-group claim for the requested resource: "+ownedByValue)
 		return
 	}
 
-	recordDenied(verb, attrs.Resource, reasonSupportGroupMismatch, userSupportGroups, start)
+	recordDenied(verb, attrs.Resource, reasonSupportGroupMismatch, userSupportGroups)
 	respond(w, review, false, "")
 }
 

--- a/cmd/authz/main.go
+++ b/cmd/authz/main.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Greenhouse contributors
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
 // SPDX-License-Identifier: Apache-2.0
 
 package main
@@ -112,9 +112,9 @@ func main() {
 	client := mgr.GetClient()
 	mapper := mgr.GetRESTMapper()
 
-	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	handler := instrumentHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		handleAuthorize(w, r, client, mapper)
-	})
+	}))
 
 	if secure {
 		mgr.GetWebhookServer().Register("/authorize", handler)

--- a/cmd/authz/metrics.go
+++ b/cmd/authz/metrics.go
@@ -1,12 +1,13 @@
-// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Greenhouse contributors
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
 // SPDX-License-Identifier: Apache-2.0
 
 package main
 
 import (
-	"time"
+	"net/http"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	crmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
@@ -27,15 +28,6 @@ var (
 			Help: "Total number of authorization requests labeled by result and verb.",
 		},
 		[]string{"result", "verb"},
-	)
-
-	authzRequestDuration = prometheus.NewHistogramVec(
-		prometheus.HistogramOpts{
-			Name:    "greenhouse_authz_request_duration_seconds",
-			Help:    "Duration of authorization requests in seconds.",
-			Buckets: prometheus.DefBuckets,
-		},
-		[]string{"result"},
 	)
 
 	authzDeniedTotal = prometheus.NewCounterVec(
@@ -68,28 +60,40 @@ var (
 			Help: "Total number of errors resolving GVR to GVK.",
 		},
 	)
+
+	authzRequestDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "greenhouse_authz_request_duration_seconds",
+			Help:    "End-to-end request duration of authorization requests.",
+			Buckets: []float64{.005, .01, .025, .05, .1, .25, .5},
+		},
+		[]string{"code", "method"},
+	)
 )
 
 func init() {
 	crmetrics.Registry.MustRegister(
 		authzRequestsTotal,
-		authzRequestDuration,
 		authzDeniedTotal,
 		authzAccessTotal,
 		authzKubeFetchErrorsTotal,
 		authzKindResolutionErrorsTotal,
+		authzRequestDuration,
 	)
 }
 
-func recordAllowed(verb, resource, supportGroup string, start time.Time) {
+// instrumentHandler wraps h with prometheus duration instrumentation using fine-grained buckets.
+func instrumentHandler(h http.Handler) http.Handler {
+	return promhttp.InstrumentHandlerDuration(authzRequestDuration, h)
+}
+
+func recordAllowed(verb, resource, supportGroup string) {
 	authzRequestsTotal.With(prometheus.Labels{"result": "allowed", "verb": verb}).Inc()
-	authzRequestDuration.With(prometheus.Labels{"result": "allowed"}).Observe(time.Since(start).Seconds())
 	authzAccessTotal.With(prometheus.Labels{"support_group": supportGroup, "resource": resource, "result": "allowed"}).Inc()
 }
 
-func recordDenied(verb, resource, reason string, supportGroups []string, start time.Time) {
+func recordDenied(verb, resource, reason string, supportGroups []string) {
 	authzRequestsTotal.With(prometheus.Labels{"result": "denied", "verb": verb}).Inc()
-	authzRequestDuration.With(prometheus.Labels{"result": "denied"}).Observe(time.Since(start).Seconds())
 	authzDeniedTotal.With(prometheus.Labels{"reason": reason}).Inc()
 	for _, sg := range supportGroups {
 		authzAccessTotal.With(prometheus.Labels{"support_group": sg, "resource": resource, "result": "denied"}).Inc()


### PR DESCRIPTION
## Description

- Predictable hostname for cluster ip via DNSEntry in gardener usage. 
- This should provide helm friendly installation
- Generate README from helm-docs
- Metrics via prometheus instrumentation handler
- Adds `ServiceMonitor`

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

- Related Issue #1100 

## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

## Added to documentation?

- [x] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [ ] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
