### PR TITLE
feat(plugins): add ociMirroringEnabledfeature flag

### DIFF
--- a/charts/greenhouse/ci/test-values.yaml
+++ b/charts/greenhouse/ci/test-values.yaml
@@ -14,6 +14,7 @@ global:
   plugin:
     expressionEvaluationEnabled: false
     integrationEnabled: false
+    ociMirroringEnabled: false
   linkerd_enabled: false
   region: greenhouse
   registry: ghcr.io/cloudoperators/greenhouse

--- a/charts/greenhouse/values.yaml
+++ b/charts/greenhouse/values.yaml
@@ -22,6 +22,7 @@ global:
   plugin:
     expressionEvaluationEnabled: false
     integrationEnabled: false
+    ociMirroringEnabled: false
 
 postgresqlng:
   enabled: true

--- a/charts/manager/ci/test-values.yaml
+++ b/charts/manager/ci/test-values.yaml
@@ -12,6 +12,7 @@ global:
   plugin:
     expressionEvaluationEnabled: false
     integrationEnabled: false
+    ociMirroringEnabled: false
 
 controllerManager:
   args:

--- a/charts/manager/templates/_helpers.tpl
+++ b/charts/manager/templates/_helpers.tpl
@@ -114,3 +114,6 @@ Define postgresql helpers
 {{- define "plugin.integrationEnabled" -}}
   {{- printf "%t" (required "global.plugin.integrationEnabled missing" .Values.global.plugin.integrationEnabled) }}
 {{- end }}
+{{- define "plugin.ociMirroringEnabled" -}}
+  {{- printf "%t" (required "global.plugin.ociMirroringEnabled missing" .Values.global.plugin.ociMirroringEnabled) }}
+{{- end }}

--- a/charts/manager/templates/manager/feature-flag.yaml
+++ b/charts/manager/templates/manager/feature-flag.yaml
@@ -20,11 +20,15 @@ data:
     # set to true to enable expression evaluation (expressions will be evaluated using CEL)
     # integrationEnabled allows you to enable or disable plugin to plugin integration features
     # set true to enable value references from another plugin via CEL expressions
+    # ociMirroringEnabled allows you to enable or disable OCI mirroring
+    # set to true to enable OCI mirroring, defaults to false
     plugin: |
       expressionEvaluationEnabled: false / true
       integrationEnabled: false / true
+      ociMirroringEnabled: false / true
   dex: |
     storage: {{ include "dex.backend" $ }}
   plugin: |
     expressionEvaluationEnabled: {{ include "plugin.expressionEvaluationEnabled" $ }}
     integrationEnabled: {{ include "plugin.integrationEnabled" $ }}
+    ociMirroringEnabled: {{ include "plugin.ociMirroringEnabled" $ }}

--- a/cmd/greenhouse/controllers.go
+++ b/cmd/greenhouse/controllers.go
@@ -38,7 +38,7 @@ var knownControllers = map[string]func(controllerName string, mgr ctrl.Manager) 
 	"pluginPreset": (&plugincontrollers.PluginPresetReconciler{}).SetupWithManager,
 
 	"catalog":                 startCatalogReconciler,
-	"pluginDefinition":        (&plugindefinitioncontroller.PluginDefinitionReconciler{}).SetupWithManager,
+	"pluginDefinition":        startPluginDefinitionReconciler,
 	"clusterPluginDefinition": (&plugindefinitioncontroller.ClusterPluginDefinitionReconciler{}).SetupWithManager,
 
 	// Cluster controllers
@@ -87,6 +87,13 @@ func startPluginReconciler(name string, mgr ctrl.Manager) error {
 		KubeRuntimeOpts:             kubeClientOpts,
 		ExpressionEvaluationEnabled: featureFlags.IsExpressionEvaluationEnabled(),
 		IntegrationEnabled:          featureFlags.IsIntegrationEnabled(),
+		OCIMirroringEnabled:         featureFlags.IsOCIMirroringEnabled(),
+	}).SetupWithManager(name, mgr)
+}
+
+func startPluginDefinitionReconciler(name string, mgr ctrl.Manager) error {
+	return (&plugindefinitioncontroller.PluginDefinitionReconciler{
+		OCIMirroringEnabled: featureFlags.IsOCIMirroringEnabled(),
 	}).SetupWithManager(name, mgr)
 }
 

--- a/dev-env/dev.values.yaml
+++ b/dev-env/dev.values.yaml
@@ -8,6 +8,7 @@ global:
   plugin:
     expressionEvaluationEnabled: true
     integrationEnabled: true
+    ociMirroringEnabled: false
 alerts:
   enabled: false
 certManager:

--- a/dev-env/dev.values.yaml
+++ b/dev-env/dev.values.yaml
@@ -8,7 +8,7 @@ global:
   plugin:
     expressionEvaluationEnabled: true
     integrationEnabled: true
-    ociMirroringEnabled: false
+    ociMirroringEnabled: true
 alerts:
   enabled: false
 certManager:

--- a/internal/controller/plugin/oci_mirror.go
+++ b/internal/controller/plugin/oci_mirror.go
@@ -12,10 +12,67 @@ import (
 
 	greenhousemetav1alpha1 "github.com/cloudoperators/greenhouse/api/meta/v1alpha1"
 	greenhousev1alpha1 "github.com/cloudoperators/greenhouse/api/v1alpha1"
+	"github.com/cloudoperators/greenhouse/internal/helm"
 	"github.com/cloudoperators/greenhouse/internal/ocimirror"
 )
 
-func createRegistryMirrorPostRenderer(mirror *ocimirror.ImageMirror, manifestSets ...string) *helmv2.PostRenderer {
+// createRegistryMirrorPostRenderer handles the full OCI mirroring flow.
+func (r *PluginReconciler) createRegistryMirrorPostRenderer(
+	ctx context.Context,
+	plugin *greenhousev1alpha1.Plugin,
+	pluginDefinitionSpec greenhousev1alpha1.PluginDefinitionSpec,
+	optionValues []greenhousev1alpha1.PluginOptionValue,
+) (*helmv2.PostRenderer, error) {
+
+	if !r.OCIMirroringEnabled {
+		return nil, nil
+	}
+
+	mirrorConfig, err := ocimirror.GetRegistryMirrorConfig(ctx, r.Client, plugin.GetNamespace())
+	if err != nil {
+		plugin.SetCondition(greenhousemetav1alpha1.FalseCondition(
+			greenhousev1alpha1.HelmReleaseCreatedCondition, greenhousev1alpha1.ImageReplicationFailedReason, "Failed to read Organization registry mirror configuration: "+err.Error()))
+		return nil, fmt.Errorf("failed to read registry mirror configuration for Plugin %s: %w", plugin.Name, err)
+	}
+
+	var mirror *ocimirror.ImageMirror
+	if mirrorConfig != nil && len(mirrorConfig.RegistryMirrors) > 0 {
+		mirror, err = ocimirror.NewImageMirror(ctx, r.Client, mirrorConfig, plugin.GetNamespace())
+		if err != nil {
+			plugin.SetCondition(greenhousemetav1alpha1.FalseCondition(
+				greenhousev1alpha1.HelmReleaseCreatedCondition, greenhousev1alpha1.ImageReplicationFailedReason, "Failed to create image mirror: "+err.Error()))
+			return nil, fmt.Errorf("failed to create image mirror for Plugin %s: %w", plugin.Name, err)
+		}
+	}
+
+	if mirror == nil {
+		return nil, nil
+	}
+
+	restClientGetter, _, err := initClientGetter(ctx, r.Client, r.kubeClientOpts, plugin)
+	if err != nil {
+		return nil, fmt.Errorf("failed to init client getter for Plugin %s: %w", plugin.Name, err)
+	}
+
+	helmRelease, err := helm.TemplateHelmChartFromPluginOptionValues(ctx, r.Client, restClientGetter, &pluginDefinitionSpec, plugin, optionValues)
+	if err != nil {
+		plugin.SetCondition(greenhousemetav1alpha1.FalseCondition(greenhousev1alpha1.HelmReleaseCreatedCondition, greenhousev1alpha1.PluginHelmTemplateFailedReason, err.Error()))
+		return nil, fmt.Errorf("failed to template helm chart for Plugin %s: %w", plugin.Name, err)
+	}
+
+	manifestSets := []string{helmRelease.Manifest}
+	for _, h := range helmRelease.Hooks {
+		manifestSets = append(manifestSets, h.Manifest)
+	}
+
+	if err := ensureImageReplication(ctx, mirror, plugin, manifestSets...); err != nil {
+		return nil, err
+	}
+
+	return buildPostRenderer(mirror, manifestSets...), nil
+}
+
+func buildPostRenderer(mirror *ocimirror.ImageMirror, manifestSets ...string) *helmv2.PostRenderer {
 	if mirror == nil {
 		return nil
 	}

--- a/internal/controller/plugin/oci_mirror_test.go
+++ b/internal/controller/plugin/oci_mirror_test.go
@@ -22,7 +22,7 @@ func newTestMirror(config *ocimirror.RegistryMirrorConfig) *ocimirror.ImageMirro
 	})
 }
 
-var _ = Describe("createRegistryMirrorPostRenderer", func() {
+var _ = Describe("buildPostRenderer", func() {
 	var mirror *ocimirror.ImageMirror
 
 	BeforeEach(func() {
@@ -42,7 +42,7 @@ var _ = Describe("createRegistryMirrorPostRenderer", func() {
 
 	It("should return nil when mirror is nil", func() {
 		manifest := `image: ghcr.io/cloudoperators/greenhouse:main`
-		postRenderer := createRegistryMirrorPostRenderer(nil, manifest)
+		postRenderer := buildPostRenderer(nil, manifest)
 		Expect(postRenderer).To(BeNil())
 	})
 
@@ -55,19 +55,19 @@ var _ = Describe("createRegistryMirrorPostRenderer", func() {
 		data:
 		key: value
 		`
-		postRenderer := createRegistryMirrorPostRenderer(mirror, manifest)
+		postRenderer := buildPostRenderer(mirror, manifest)
 		Expect(postRenderer).To(BeNil())
 	})
 
 	It("should return nil when no matching mirrors", func() {
 		manifest := `image: registry.k8s.io/pause:3.9`
-		postRenderer := createRegistryMirrorPostRenderer(mirror, manifest)
+		postRenderer := buildPostRenderer(mirror, manifest)
 		Expect(postRenderer).To(BeNil())
 	})
 
 	It("should create transformation preserving full image path", func() {
 		manifest := `image: ghcr.io/cloudoperators/greenhouse:main`
-		postRenderer := createRegistryMirrorPostRenderer(mirror, manifest)
+		postRenderer := buildPostRenderer(mirror, manifest)
 		Expect(postRenderer).NotTo(BeNil())
 		Expect(postRenderer.Kustomize.Images).To(HaveLen(1))
 		Expect(postRenderer.Kustomize.Images[0].Name).To(Equal("ghcr.io/cloudoperators/greenhouse"))
@@ -81,7 +81,7 @@ var _ = Describe("createRegistryMirrorPostRenderer", func() {
 		- image: docker.io/library/nginx:latest
 		- image: registry.k8s.io/pause:3.9
 		`
-		postRenderer := createRegistryMirrorPostRenderer(mirror, manifest)
+		postRenderer := buildPostRenderer(mirror, manifest)
 		Expect(postRenderer).NotTo(BeNil())
 		Expect(postRenderer.Kustomize.Images).To(HaveLen(2))
 
@@ -99,7 +99,7 @@ var _ = Describe("createRegistryMirrorPostRenderer", func() {
 		- image: ghcr.io/cloudoperators/greenhouse:main
 		- image: ghcr.io/cloudoperators/greenhouse:main
 		`
-		postRenderer := createRegistryMirrorPostRenderer(mirror, manifest)
+		postRenderer := buildPostRenderer(mirror, manifest)
 		Expect(postRenderer).NotTo(BeNil())
 		Expect(postRenderer.Kustomize.Images).To(HaveLen(1))
 		Expect(postRenderer.Kustomize.Images[0].Name).To(Equal("ghcr.io/cloudoperators/greenhouse"))
@@ -108,7 +108,7 @@ var _ = Describe("createRegistryMirrorPostRenderer", func() {
 
 	It("should preserve nested repository paths", func() {
 		manifest := `image: ghcr.io/org/team/project/app:v1.0`
-		postRenderer := createRegistryMirrorPostRenderer(mirror, manifest)
+		postRenderer := buildPostRenderer(mirror, manifest)
 		Expect(postRenderer).NotTo(BeNil())
 		Expect(postRenderer.Kustomize.Images[0].Name).To(Equal("ghcr.io/org/team/project/app"))
 		Expect(postRenderer.Kustomize.Images[0].NewName).To(Equal("mirror.example.com/ghcr-mirror/org/team/project/app"))
@@ -116,7 +116,7 @@ var _ = Describe("createRegistryMirrorPostRenderer", func() {
 
 	It("should handle images with digest", func() {
 		manifest := `image: ghcr.io/cloudoperators/greenhouse@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855`
-		postRenderer := createRegistryMirrorPostRenderer(mirror, manifest)
+		postRenderer := buildPostRenderer(mirror, manifest)
 		Expect(postRenderer).NotTo(BeNil())
 		Expect(postRenderer.Kustomize.Images[0].Name).To(Equal("ghcr.io/cloudoperators/greenhouse"))
 		Expect(postRenderer.Kustomize.Images[0].NewName).To(Equal("mirror.example.com/ghcr-mirror/cloudoperators/greenhouse"))
@@ -128,7 +128,7 @@ var _ = Describe("createRegistryMirrorPostRenderer", func() {
 		- image: "ghcr.io/cloudoperators/greenhouse:main"
 		- image: 'docker.io/library/nginx:latest'
 		`
-		postRenderer := createRegistryMirrorPostRenderer(mirror, manifest)
+		postRenderer := buildPostRenderer(mirror, manifest)
 		Expect(postRenderer).NotTo(BeNil())
 
 		names := []string{postRenderer.Kustomize.Images[0].Name, postRenderer.Kustomize.Images[1].Name}
@@ -149,7 +149,7 @@ var _ = Describe("createRegistryMirrorPostRenderer", func() {
 		- image: nginx:latest
 		- image: myorg/myapp:v1.0
 		`
-		postRenderer := createRegistryMirrorPostRenderer(mirror, manifest)
+		postRenderer := buildPostRenderer(mirror, manifest)
 		Expect(postRenderer).NotTo(BeNil())
 		Expect(postRenderer.Kustomize.Images).To(HaveLen(2))
 
@@ -169,7 +169,7 @@ var _ = Describe("createRegistryMirrorPostRenderer", func() {
 	It("should include image refs from helm hook manifests", func() {
 		mainManifest := `image: ghcr.io/cloudoperators/greenhouse:main`
 		hookManifest := `image: docker.io/library/busybox:1.36`
-		postRenderer := createRegistryMirrorPostRenderer(mirror, mainManifest, hookManifest)
+		postRenderer := buildPostRenderer(mirror, mainManifest, hookManifest)
 		Expect(postRenderer).NotTo(BeNil())
 		Expect(postRenderer.Kustomize.Images).To(HaveLen(2))
 
@@ -183,14 +183,14 @@ var _ = Describe("createRegistryMirrorPostRenderer", func() {
 	It("should deduplicate image refs across manifest and hooks", func() {
 		mainManifest := `image: ghcr.io/cloudoperators/greenhouse:main`
 		hookManifest := `image: ghcr.io/cloudoperators/greenhouse:main`
-		postRenderer := createRegistryMirrorPostRenderer(mirror, mainManifest, hookManifest)
+		postRenderer := buildPostRenderer(mirror, mainManifest, hookManifest)
 		Expect(postRenderer).NotTo(BeNil())
 		Expect(postRenderer.Kustomize.Images).To(HaveLen(1))
 	})
 
 	It("should pick up image refs even when only present in a hook", func() {
 		hookManifest := `image: ghcr.io/cloudoperators/greenhouse:main`
-		postRenderer := createRegistryMirrorPostRenderer(mirror, "", hookManifest)
+		postRenderer := buildPostRenderer(mirror, "", hookManifest)
 		Expect(postRenderer).NotTo(BeNil())
 		Expect(postRenderer.Kustomize.Images).To(HaveLen(1))
 		Expect(postRenderer.Kustomize.Images[0].Name).To(Equal("ghcr.io/cloudoperators/greenhouse"))

--- a/internal/controller/plugin/plugin_controller.go
+++ b/internal/controller/plugin/plugin_controller.go
@@ -40,6 +40,7 @@ type PluginReconciler struct {
 	kubeClientOpts              []clientutil.KubeClientOption
 	ExpressionEvaluationEnabled bool
 	IntegrationEnabled          bool
+	OCIMirroringEnabled         bool
 }
 
 //+kubebuilder:rbac:groups=greenhouse.sap,resources=plugindefinitions,verbs=get;list;watch;create;update;patch;delete

--- a/internal/controller/plugin/plugin_controller_flux.go
+++ b/internal/controller/plugin/plugin_controller_flux.go
@@ -30,7 +30,6 @@ import (
 	"github.com/cloudoperators/greenhouse/internal/common"
 	"github.com/cloudoperators/greenhouse/internal/flux"
 	"github.com/cloudoperators/greenhouse/internal/helm"
-	"github.com/cloudoperators/greenhouse/internal/ocimirror"
 	"github.com/cloudoperators/greenhouse/internal/util"
 	"github.com/cloudoperators/greenhouse/pkg/lifecycle"
 )
@@ -147,53 +146,11 @@ func (r *PluginReconciler) ensureHelmRelease(
 	release.SetName(plugin.Name)
 	release.SetNamespace(plugin.Namespace)
 
-	mirrorConfig, err := ocimirror.GetRegistryMirrorConfig(ctx, r.Client, plugin.GetNamespace())
-	if err != nil {
-		plugin.SetCondition(greenhousemetav1alpha1.FalseCondition(
-			greenhousev1alpha1.HelmReleaseCreatedCondition, greenhousev1alpha1.ImageReplicationFailedReason, "Failed to read Organization registry mirror configuration: "+err.Error()))
-		return fmt.Errorf("failed to read registry mirror configuration for Plugin %s: %w", plugin.Name, err)
-	}
-
-	var mirror *ocimirror.ImageMirror
-	if mirrorConfig != nil && len(mirrorConfig.RegistryMirrors) > 0 {
-		mirror, err = ocimirror.NewImageMirror(ctx, r.Client, mirrorConfig, plugin.GetNamespace())
-		if err != nil {
-			plugin.SetCondition(greenhousemetav1alpha1.FalseCondition(
-				greenhousev1alpha1.HelmReleaseCreatedCondition, greenhousev1alpha1.ImageReplicationFailedReason, "Failed to create image mirror: "+err.Error()))
-			return fmt.Errorf("failed to create image mirror for Plugin %s: %w", plugin.Name, err)
-		}
-	}
-
 	values, err := generateHelmValues(ctx, optionValues)
 	if err != nil {
 		plugin.SetCondition(greenhousemetav1alpha1.FalseCondition(
 			greenhousev1alpha1.HelmReleaseCreatedCondition, greenhousev1alpha1.PluginOptionValueInvalidReason, err.Error()))
 		return fmt.Errorf("failed to generate HelmRelease values for Plugin %s: %w", plugin.Name, err)
-	}
-
-	var postRenderer *helmv2.PostRenderer
-	if mirror != nil {
-		restClientGetter, _, err := initClientGetter(ctx, r.Client, r.kubeClientOpts, plugin)
-		if err != nil {
-			return fmt.Errorf("failed to init client getter for Plugin %s: %w", plugin.Name, err)
-		}
-
-		helmRelease, err := helm.TemplateHelmChartFromPluginOptionValues(ctx, r.Client, restClientGetter, &pluginDefinitionSpec, plugin, optionValues)
-		if err != nil {
-			plugin.SetCondition(greenhousemetav1alpha1.FalseCondition(greenhousev1alpha1.HelmReleaseCreatedCondition, greenhousev1alpha1.PluginHelmTemplateFailedReason, err.Error()))
-			return fmt.Errorf("failed to template helm chart for Plugin %s: %w", plugin.Name, err)
-		}
-
-		manifestSets := []string{helmRelease.Manifest}
-		for _, h := range helmRelease.Hooks {
-			manifestSets = append(manifestSets, h.Manifest)
-		}
-
-		if err := ensureImageReplication(ctx, mirror, plugin, manifestSets...); err != nil {
-			return err
-		}
-
-		postRenderer = createRegistryMirrorPostRenderer(mirror, manifestSets...)
 	}
 
 	result, err := controllerutil.CreateOrPatch(ctx, r.Client, release, func() error {
@@ -234,6 +191,10 @@ func (r *PluginReconciler) ensureHelmRelease(
 			WithStorageNamespace(plugin.Spec.ReleaseNamespace).
 			WithTargetNamespace(plugin.Spec.ReleaseNamespace)
 
+		postRenderer, err := r.createRegistryMirrorPostRenderer(ctx, plugin, pluginDefinitionSpec, optionValues)
+		if err != nil {
+			return err
+		}
 		if postRenderer != nil {
 			builder = builder.WithPostRenderers([]helmv2.PostRenderer{*postRenderer})
 		}

--- a/internal/controller/plugindefinition/cluster_plugindefinition_controller.go
+++ b/internal/controller/plugindefinition/cluster_plugindefinition_controller.go
@@ -77,10 +77,11 @@ func (r *ClusterPluginDefinitionReconciler) EnsureCreated(ctx context.Context, o
 	}
 
 	h := &helmer{
-		k8sClient:     r.Client,
-		recorder:      r.recorder,
-		pluginDef:     clusterDef,
-		namespaceName: flux.HelmRepositoryDefaultNamespace,
+		k8sClient:           r.Client,
+		recorder:            r.recorder,
+		pluginDef:           clusterDef,
+		namespaceName:       flux.HelmRepositoryDefaultNamespace,
+		ociMirroringEnabled: false,
 	}
 
 	helmRepo, err := h.createUpdateHelmRepository(ctx)

--- a/internal/controller/plugindefinition/plugindefinition_controller.go
+++ b/internal/controller/plugindefinition/plugindefinition_controller.go
@@ -24,8 +24,9 @@ import (
 // PluginDefinitionReconciler reconciles a PluginDefinition object.
 type PluginDefinitionReconciler struct {
 	client.Client
-	Scheme   *runtime.Scheme
-	recorder events.EventRecorder
+	Scheme              *runtime.Scheme
+	recorder            events.EventRecorder
+	OCIMirroringEnabled bool
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -82,10 +83,11 @@ func (r *PluginDefinitionReconciler) EnsureCreated(ctx context.Context, obj life
 	}
 
 	h := &helmer{
-		k8sClient:     r.Client,
-		recorder:      r.recorder,
-		pluginDef:     pluginDef,
-		namespaceName: pluginDef.Namespace,
+		k8sClient:           r.Client,
+		recorder:            r.recorder,
+		pluginDef:           pluginDef,
+		namespaceName:       pluginDef.Namespace,
+		ociMirroringEnabled: r.OCIMirroringEnabled,
 	}
 
 	helmRepo, err := h.createUpdateHelmRepository(ctx)

--- a/internal/controller/plugindefinition/utils.go
+++ b/internal/controller/plugindefinition/utils.go
@@ -29,10 +29,11 @@ import (
 )
 
 type helmer struct {
-	k8sClient     client.Client
-	recorder      events.EventRecorder
-	pluginDef     common.GenericPluginDefinition
-	namespaceName string
+	k8sClient           client.Client
+	recorder            events.EventRecorder
+	pluginDef           common.GenericPluginDefinition
+	namespaceName       string
+	ociMirroringEnabled bool
 }
 
 // initializeConditions sets the provided conditions to Unknown if they do not already exist.
@@ -174,6 +175,14 @@ func (h *helmer) createUpdateHelmChart(ctx context.Context, helmRepo *sourcev1.H
 
 // ensureChartReplication triggers replication for the Helm chart OCI artifact to the configured mirror registry.
 func (h *helmer) ensureChartReplication(ctx context.Context) error {
+	if !h.ociMirroringEnabled {
+		h.pluginDef.SetCondition(greenhousemetav1alpha1.TrueCondition(
+			greenhousev1alpha1.OCIReplicationReadyCondition,
+			greenhousev1alpha1.OCIReplicationNotConfiguredReason,
+			"OCI mirroring is disabled"))
+		return nil
+	}
+
 	logger := log.FromContext(ctx)
 
 	// Check if the chart is OCI before making any API calls — non-OCI charts cannot be replicated.

--- a/internal/features/features.go
+++ b/internal/features/features.go
@@ -33,6 +33,7 @@ type dexFeatures struct {
 type pluginFeatures struct {
 	ExpressionEvaluationEnabled bool `yaml:"expressionEvaluationEnabled"`
 	IntegrationEnabled          bool `yaml:"integrationEnabled"`
+	OCIMirroringEnabled         bool `yaml:"ociMirroringEnabled"`
 }
 
 func NewFeatures(ctx context.Context, k8sClient client.Reader, configMapName, namespace string) (*Features, error) {
@@ -126,4 +127,20 @@ func (f *Features) IsIntegrationEnabled() bool {
 		return false
 	}
 	return f.plugin.IntegrationEnabled
+}
+
+// IsOCIMirroringEnabled returns whether OCI mirroring is enabled.
+func (f *Features) IsOCIMirroringEnabled() bool {
+	if f == nil {
+		return false
+	}
+
+	if f.plugin != nil {
+		return f.plugin.OCIMirroringEnabled
+	}
+	if err := f.resolvePluginFeatures(); err != nil {
+		ctrl.LoggerFrom(context.Background()).Error(err, "failed to resolve plugin features")
+		return false
+	}
+	return f.plugin.OCIMirroringEnabled
 }

--- a/internal/features/features_test.go
+++ b/internal/features/features_test.go
@@ -114,6 +114,7 @@ func Test_PluginFeatures(t *testing.T) {
 		getError                     error
 		expectedExpressionEvaluation bool
 		expectedIntegrationEnabled   bool
+		expectedOCIMirroringEnabled  bool
 	}
 
 	testCases := []testCase{
@@ -122,42 +123,70 @@ func Test_PluginFeatures(t *testing.T) {
 			configMapData:                map[string]string{PluginFeatureKey: "expressionEvaluationEnabled: true\n"},
 			expectedExpressionEvaluation: true,
 			expectedIntegrationEnabled:   false,
+			expectedOCIMirroringEnabled:  false,
 		},
 		{
 			name:                         "it should return false when plugin expression evaluation is disabled",
 			configMapData:                map[string]string{PluginFeatureKey: "expressionEvaluationEnabled: false\n"},
 			expectedExpressionEvaluation: false,
 			expectedIntegrationEnabled:   false,
+			expectedOCIMirroringEnabled:  false,
 		},
 		{
 			name:                         "it should return true when plugin integration is enabled",
 			configMapData:                map[string]string{PluginFeatureKey: "integrationEnabled: true\n"},
 			expectedExpressionEvaluation: false,
 			expectedIntegrationEnabled:   true,
+			expectedOCIMirroringEnabled:  false,
 		},
 		{
 			name:                         "it should return both values when both are set",
 			configMapData:                map[string]string{PluginFeatureKey: "expressionEvaluationEnabled: true\nintegrationEnabled: true\n"},
 			expectedExpressionEvaluation: true,
 			expectedIntegrationEnabled:   true,
+			expectedOCIMirroringEnabled:  false,
 		},
 		{
 			name:                         "it should return false when plugin key is not found in feature-flags cm",
 			configMapData:                map[string]string{"someOtherKey": "value\n"},
 			expectedExpressionEvaluation: false,
 			expectedIntegrationEnabled:   false,
+			expectedOCIMirroringEnabled:  false,
 		},
 		{
 			name:                         "it should return false when feature-flags cm is not found",
 			getError:                     apierrors.NewNotFound(schema.GroupResource{}, "configmap not found"),
 			expectedExpressionEvaluation: false,
 			expectedIntegrationEnabled:   false,
+			expectedOCIMirroringEnabled:  false,
 		},
 		{
 			name:                         "it should return false when flag is malformed in feature-flags cm",
 			configMapData:                map[string]string{PluginFeatureKey: "expressionEvaluationEnabled:: invalid_yaml"},
 			expectedExpressionEvaluation: false,
 			expectedIntegrationEnabled:   false,
+			expectedOCIMirroringEnabled:  false,
+		},
+		{
+			name:                         "it should return true when ociMirroringEnabled is explicitly true",
+			configMapData:                map[string]string{PluginFeatureKey: "ociMirroringEnabled: true\n"},
+			expectedExpressionEvaluation: false,
+			expectedIntegrationEnabled:   false,
+			expectedOCIMirroringEnabled:  true,
+		},
+		{
+			name:                         "it should return false when ociMirroringEnabled is explicitly false",
+			configMapData:                map[string]string{PluginFeatureKey: "ociMirroringEnabled: false\n"},
+			expectedExpressionEvaluation: false,
+			expectedIntegrationEnabled:   false,
+			expectedOCIMirroringEnabled:  false,
+		},
+		{
+			name:                         "it should return false when ociMirroringEnabled key is missing",
+			configMapData:                map[string]string{PluginFeatureKey: "expressionEvaluationEnabled: false\n"},
+			expectedExpressionEvaluation: false,
+			expectedIntegrationEnabled:   false,
+			expectedOCIMirroringEnabled:  false,
 		},
 	}
 
@@ -191,9 +220,11 @@ func Test_PluginFeatures(t *testing.T) {
 
 				expressionEvaluationValue := featuresInstance.IsExpressionEvaluationEnabled()
 				integrationEnabledValue := featuresInstance.IsIntegrationEnabled()
+				ociMirroringValue := featuresInstance.IsOCIMirroringEnabled()
 
 				assert.Equal(t, tc.expectedExpressionEvaluation, expressionEvaluationValue)
 				assert.Equal(t, tc.expectedIntegrationEnabled, integrationEnabledValue)
+				assert.Equal(t, tc.expectedOCIMirroringEnabled, ociMirroringValue)
 				mockK8sClient.AssertExpectations(t)
 				return
 			}
@@ -201,10 +232,12 @@ func Test_PluginFeatures(t *testing.T) {
 
 			expressionEvaluationValue := featuresInstance.IsExpressionEvaluationEnabled()
 			integrationEnabledValue := featuresInstance.IsIntegrationEnabled()
+			ociMirroringValue := featuresInstance.IsOCIMirroringEnabled()
 
 			// Assert expected values
 			assert.Equal(t, tc.expectedExpressionEvaluation, expressionEvaluationValue)
 			assert.Equal(t, tc.expectedIntegrationEnabled, integrationEnabledValue)
+			assert.Equal(t, tc.expectedOCIMirroringEnabled, ociMirroringValue)
 			mockK8sClient.AssertExpectations(t)
 		})
 	}


### PR DESCRIPTION
## Description

This PR adds a feature flag `ociMirroringEnabled` to gate all OCI mirroring. Defaults to `true` so existing behavior is unchanged. Setting it to `false` in the `greenhouse-feature-flags` ConfigMap disables all mirroring.

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

- Closes https://github.com/cloudoperators/greenhouse/issues/1909

## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [x] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
