### PR TITLE
fix(plugins): collect exposed ingress  resources if service-proxy disabled

### DIFF
--- a/api/v1alpha1/cluster_types.go
+++ b/api/v1alpha1/cluster_types.go
@@ -134,23 +134,23 @@ func (c *Cluster) CanBeSuspended() bool {
 	return false
 }
 
-// IsExposedServicesDisabled returns true if the exposed services are disabled for the cluster, false otherwise. The value of the annotation "greenhouse.sap/service-proxy-disabled" is used to determine if the exposed services are disabled. Returns true if the annotation is present and its value is "true".
-func (c *Cluster) IsExposedServicesDisabled() bool {
+// ExposedServicesEnabled returns true if the exposed services are enabled for the cluster, false otherwise. The value of the annotation "greenhouse.sap/service-proxy-disabled" is used to determine if the exposed services are disabled. Returns true if the annotation is not present or its value is not "true".
+func (c *Cluster) ExposedServicesEnabled() bool {
 	if c == nil {
 		return false
 	}
 
 	annotations := c.GetAnnotations()
 	if len(annotations) == 0 {
-		return false
+		return true
 	}
 
 	value, ok := annotations[ServiceProxyDisabledKey]
 	if !ok {
-		return false
+		return true
 	}
-
-	return strings.ToLower(value) == "true"
+	// annotation is opt-out. Only if the annotation is set to "true" (case-insensitive) the exposed services are disabled.
+	return strings.ToLower(value) != "true"
 }
 
 // GetSecretName returns the Kubernetes secret containing sensitive data for this cluster.

--- a/api/v1alpha1/cluster_types_test.go
+++ b/api/v1alpha1/cluster_types_test.go
@@ -11,7 +11,7 @@ import (
 	greenhousev1alpha1 "github.com/cloudoperators/greenhouse/api/v1alpha1"
 )
 
-var _ = Describe("Cluster.IsExposedServicesDisabled", func() {
+var _ = Describe("Cluster.ExposedServicesEnabled", func() {
 	DescribeTable("should return expected result based on annotation",
 		func(annotations map[string]string, expected bool) {
 			cluster := &greenhousev1alpha1.Cluster{
@@ -23,14 +23,14 @@ var _ = Describe("Cluster.IsExposedServicesDisabled", func() {
 			}
 			Expect(cluster.ExposedServicesEnabled()).To(Equal(expected))
 		},
-		Entry("no annotations", nil, false),
-		Entry("annotation not present", map[string]string{"some-other-annotation": "value"}, false),
-		Entry("annotation set to 'true'", map[string]string{greenhousev1alpha1.ServiceProxyDisabledKey: "true"}, true),
-		Entry("annotation set to 'True' (case-insensitive)", map[string]string{greenhousev1alpha1.ServiceProxyDisabledKey: "True"}, true),
-		Entry("annotation set to 'TRUE' (case-insensitive)", map[string]string{greenhousev1alpha1.ServiceProxyDisabledKey: "TRUE"}, true),
-		Entry("annotation set to 'false'", map[string]string{greenhousev1alpha1.ServiceProxyDisabledKey: "false"}, false),
-		Entry("annotation set to empty string", map[string]string{greenhousev1alpha1.ServiceProxyDisabledKey: ""}, false),
-		Entry("annotation set to arbitrary non-true value", map[string]string{greenhousev1alpha1.ServiceProxyDisabledKey: "yes"}, false),
+		Entry("no annotations", nil, true),
+		Entry("annotation not present", map[string]string{"some-other-annotation": "value"}, true),
+		Entry("annotation set to 'true'", map[string]string{greenhousev1alpha1.ServiceProxyDisabledKey: "true"}, false),
+		Entry("annotation set to 'True' (case-insensitive)", map[string]string{greenhousev1alpha1.ServiceProxyDisabledKey: "True"}, false),
+		Entry("annotation set to 'TRUE' (case-insensitive)", map[string]string{greenhousev1alpha1.ServiceProxyDisabledKey: "TRUE"}, false),
+		Entry("annotation set to 'false'", map[string]string{greenhousev1alpha1.ServiceProxyDisabledKey: "false"}, true),
+		Entry("annotation set to empty string", map[string]string{greenhousev1alpha1.ServiceProxyDisabledKey: ""}, true),
+		Entry("annotation set to arbitrary non-true value", map[string]string{greenhousev1alpha1.ServiceProxyDisabledKey: "yes"}, true),
 	)
 
 	It("should return false for a nil cluster", func() {

--- a/api/v1alpha1/cluster_types_test.go
+++ b/api/v1alpha1/cluster_types_test.go
@@ -21,7 +21,7 @@ var _ = Describe("Cluster.IsExposedServicesDisabled", func() {
 					Annotations: annotations,
 				},
 			}
-			Expect(cluster.IsExposedServicesDisabled()).To(Equal(expected))
+			Expect(cluster.ExposedServicesEnabled()).To(Equal(expected))
 		},
 		Entry("no annotations", nil, false),
 		Entry("annotation not present", map[string]string{"some-other-annotation": "value"}, false),
@@ -35,6 +35,6 @@ var _ = Describe("Cluster.IsExposedServicesDisabled", func() {
 
 	It("should return false for a nil cluster", func() {
 		var cluster *greenhousev1alpha1.Cluster
-		Expect(cluster.IsExposedServicesDisabled()).To(BeFalse())
+		Expect(cluster.ExposedServicesEnabled()).To(BeFalse())
 	})
 })

--- a/docs/reference/components/cluster.md
+++ b/docs/reference/components/cluster.md
@@ -33,6 +33,11 @@ kubectl label cluster example-cluster \
   --namespace=example-organization
 ```
 
+### Disabling service-proxy for a Cluster
+
+By default, Greenhouse allows exposing Kubernetes Ingress and Service resources on a remote cluster via [annotations](./../../../user-guides/plugin/plugin-deployment/#urls-for-exposed-services-and-ingresses).
+This feature can be disabled for a Cluster by annotating the Cluster resource with `greenhouse.sap/service-proxy-disabled=true`. This will disable the creation of service-proxy endpoints for Service resources. Ingress resources will still be collected and added to the Plugin status.
+
 ## Next Steps
 
 - [Cluster Onboarding](./../../../user-guides/cluster/onboarding)

--- a/docs/reference/components/plugin.md
+++ b/docs/reference/components/plugin.md
@@ -105,6 +105,10 @@ The annotation `greenhouse.sap/suspend` can be added to a Plugin resource to tem
 
 The annotation `greenhouse.sap/reconcile` can be added to a Plugin resource to trigger a reconciliation of the Plugin and its managed resources. When the Plugin is deployed using FluxCD this annotation is propagated to the Flux HelmRelease resource and triggers a reconciliation of the Helm release on the target cluster. This can be useful to trigger a reconciliation even if no changes were made to the Plugin resource.
 
+### Exposed Services
+
+The Plugin status contains `.status.exposedServices` which is a list of Service and Ingress resources that are annotated for exposure. In the case of Kubernetes Services they are exposed via the service-proxy. See [disabling service-proxy for a Cluster](./../cluster/#disabling-service-proxy-for-a-cluster) for how to disable the service-proxy for a Cluster.
+
 ## Next Steps
 
 - [Cluster reference](./../cluster)

--- a/e2e/plugin/scenarios/flux_controller.go
+++ b/e2e/plugin/scenarios/flux_controller.go
@@ -175,18 +175,16 @@ func FluxControllerPodInfoByPlugin(ctx context.Context, adminClient, remoteClien
 	By("Disabling exposed services for the cluster")
 	test.MustSetAnnotation(ctx, adminClient, remoteCluster, greenhousev1alpha1.ServiceProxyDisabledKey, "true")
 
-	By("verifying exposed services are nil and condition reflects disabled state")
+	By("verifying exposed services are not-nil and condition reflects synced state if ingress are present but service-proxy is disabled")
 	Eventually(func(g Gomega) {
 		err := adminClient.Get(ctx, client.ObjectKeyFromObject(plugin), plugin)
 		g.Expect(err).ToNot(HaveOccurred(), "failed to get Plugin")
 
-		g.Expect(plugin.Status.ExposedServices).To(BeNil(), "ExposedServices should be nil when service-proxy is disabled")
+		g.Expect(plugin.Status.ExposedServices).NotTo(BeNil(), "ExposedServices should be not be nil when service-proxy is disabled and Chart contains an ingress with greenhouse.sap/expose annotation")
 
 		exposedServicesSyncedCondition := plugin.Status.GetConditionByType(greenhousev1alpha1.ExposedServicesSyncedCondition)
 		g.Expect(exposedServicesSyncedCondition).ToNot(BeNil(), "ExposedServicesSynced condition should be set")
 		g.Expect(exposedServicesSyncedCondition.IsTrue()).To(BeTrue(), "ExposedServicesSynced condition should be true")
-		g.Expect(exposedServicesSyncedCondition.Reason).To(Equal(greenhousev1alpha1.ExposedServicesDisabledReason),
-			"ExposedServicesSynced condition should have ExposedServicesDisabled reason")
 	}).Should(Succeed())
 
 	By("removing the service-proxy-disabled annotation from the cluster")

--- a/internal/controller/plugin/plugin_controller.go
+++ b/internal/controller/plugin/plugin_controller.go
@@ -328,15 +328,17 @@ func getExposedIngressesForPluginFromHelmRelease(restClientGetter genericcliopti
 //   - Protocol automatically detected from TLS configuration
 //
 // If either service or ingress discovery encounters an error, the entire operation fails.
-func getAllExposedServicesForPlugin(restClientGetter genericclioptions.RESTClientGetter, helmRelease *release.Release, plugin *greenhousev1alpha1.Plugin) (map[string]greenhousev1alpha1.Service, error) {
+func getAllExposedServicesForPlugin(restClientGetter genericclioptions.RESTClientGetter, helmRelease *release.Release, plugin *greenhousev1alpha1.Plugin, exposeServices bool) (map[string]greenhousev1alpha1.Service, error) {
 	var errorMessages []string
 	exposedServices := make(map[string]greenhousev1alpha1.Service)
 
-	serviceList, err := getExposedServicesForPluginFromHelmRelease(restClientGetter, helmRelease, plugin)
-	if err != nil {
-		errorMessages = append(errorMessages, "services: "+err.Error())
-	} else {
-		maps.Copy(exposedServices, serviceList)
+	if exposeServices {
+		serviceList, err := getExposedServicesForPluginFromHelmRelease(restClientGetter, helmRelease, plugin)
+		if err != nil {
+			errorMessages = append(errorMessages, "services: "+err.Error())
+		} else {
+			maps.Copy(exposedServices, serviceList)
+		}
 	}
 
 	ingressList, err := getExposedIngressesForPluginFromHelmRelease(restClientGetter, helmRelease)

--- a/internal/controller/plugin/plugin_controller_flux.go
+++ b/internal/controller/plugin/plugin_controller_flux.go
@@ -463,6 +463,7 @@ func (r *PluginReconciler) fetchReleaseStatus(ctx context.Context,
 	default:
 		releaseStatus.Status = "progressing"
 	}
+	pluginStatus.Version = pluginVersion
 	pluginStatus.HelmReleaseStatus = releaseStatus
 
 	oldChecksum := ""

--- a/internal/controller/plugin/plugin_controller_flux.go
+++ b/internal/controller/plugin/plugin_controller_flux.go
@@ -291,7 +291,7 @@ func (r *PluginReconciler) computeReadyConditionFlux(ctx context.Context, plugin
 	plugin.Status.Weight = pluginDefinitionSpec.Weight
 	plugin.Status.Description = pluginDefinitionSpec.Description
 
-	r.fetchReleaseStatus(ctx, restClientGetter, plugin, *pluginDefinitionSpec, &plugin.Status, cluster.IsExposedServicesDisabled())
+	r.fetchReleaseStatus(ctx, restClientGetter, plugin, *pluginDefinitionSpec, &plugin.Status, cluster.ExposedServicesEnabled())
 
 	if err := r.reconcileTechnicalLabels(ctx, plugin); err != nil {
 		log.FromContext(ctx).Error(err, "failed to reconcile technical labels")
@@ -339,7 +339,7 @@ func (r *PluginReconciler) fetchReleaseStatus(ctx context.Context,
 	plugin *greenhousev1alpha1.Plugin,
 	pluginDefinitionSpec greenhousev1alpha1.PluginDefinitionSpec,
 	pluginStatus *greenhousev1alpha1.PluginStatus,
-	exposedServicesDisabled bool,
+	exposeServices bool,
 ) {
 
 	var (
@@ -361,111 +361,6 @@ func (r *PluginReconciler) fetchReleaseStatus(ctx context.Context,
 		return
 	}
 
-	// Collect status from the Helm release.
-	helmRelease := &helmv2.HelmRelease{}
-	err := r.Get(ctx, types.NamespacedName{Name: plugin.Name, Namespace: plugin.Namespace}, helmRelease)
-	if err != nil {
-		// helm release does not exist or cannot be accessed
-		plugin.SetCondition(greenhousemetav1alpha1.FalseCondition(greenhousev1alpha1.ExposedServicesSyncedCondition, "", "failed to load Flux HelmRelease: "+err.Error()))
-		plugin.SetCondition(greenhousemetav1alpha1.FalseCondition(greenhousev1alpha1.HelmReleaseDeployedCondition, "", "failed to load Flux HelmRelease: "+err.Error()))
-	}
-	if exposedServicesDisabled {
-		// exposed services are disabled for the cluster
-		plugin.SetCondition(greenhousemetav1alpha1.TrueCondition(greenhousev1alpha1.ExposedServicesSyncedCondition, greenhousev1alpha1.ExposedServicesDisabledReason, "Exposed services are disabled for cluster "+plugin.Spec.ClusterName))
-	}
-	if err == nil {
-		// helm release exists
-		if !exposedServicesDisabled {
-			// exposed services are not disabled, attempt to fetch exposed services from the cluster
-			helmSDKRelease, err := helm.GetReleaseForHelmChartFromPlugin(ctx, restClientGetter, plugin)
-			if err != nil {
-				plugin.SetCondition(greenhousemetav1alpha1.FalseCondition(
-					greenhousev1alpha1.ExposedServicesSyncedCondition, "", "failed to fetch Helm release from remote cluster: "+err.Error()))
-			} else {
-				serviceList, err := getAllExposedServicesForPlugin(restClientGetter, helmSDKRelease, plugin)
-				if err != nil {
-					plugin.SetCondition(greenhousemetav1alpha1.FalseCondition(
-						greenhousev1alpha1.ExposedServicesSyncedCondition, "", "failed to get exposed services: "+err.Error()))
-				} else {
-					exposedServices = serviceList
-					plugin.SetCondition(greenhousemetav1alpha1.TrueCondition(greenhousev1alpha1.ExposedServicesSyncedCondition, "", "Fetched exposed services successfully"))
-				}
-			}
-		}
-
-		// Get the latest successfully deployed release to set the dates.
-		latestSnapshot := helmRelease.Status.History.Latest()
-		if latestSnapshot != nil {
-			releaseStatus.FirstDeployed = latestSnapshot.FirstDeployed
-			releaseStatus.LastDeployed = latestSnapshot.LastDeployed
-		}
-
-		// HelmRelease Ready condition is the best representation of the release status.
-		ready := meta.FindStatusCondition(helmRelease.Status.Conditions, fluxmeta.ReadyCondition)
-		isReadyCurrent := ready != nil && ready.ObservedGeneration == helmRelease.Generation
-
-		if ready == nil {
-			plugin.SetCondition(greenhousemetav1alpha1.UnknownCondition(greenhousev1alpha1.HelmReleaseDeployedCondition, "", ""))
-		} else {
-			switch ready.Status {
-			case metav1.ConditionTrue:
-				plugin.SetCondition(greenhousemetav1alpha1.TrueCondition(greenhousev1alpha1.HelmReleaseDeployedCondition, greenhousemetav1alpha1.ConditionReason(ready.Reason), ready.Message))
-			case metav1.ConditionFalse:
-				plugin.SetCondition(greenhousemetav1alpha1.FalseCondition(greenhousev1alpha1.HelmReleaseDeployedCondition, greenhousemetav1alpha1.ConditionReason(ready.Reason), ready.Message))
-			case metav1.ConditionUnknown:
-				plugin.SetCondition(greenhousemetav1alpha1.UnknownCondition(greenhousev1alpha1.HelmReleaseDeployedCondition, greenhousemetav1alpha1.ConditionReason(ready.Reason), ready.Message))
-			}
-		}
-
-		switch {
-		case helmRelease.Spec.Suspend:
-			releaseStatus.Status = "suspended"
-		case isReadyCurrent && ready.Status == metav1.ConditionTrue:
-			// If the current release is successfully deployed, get the status from history.
-			if latestSnapshot != nil {
-				releaseStatus.Status = latestSnapshot.Status
-			} else {
-				releaseStatus.Status = "deployed"
-			}
-			pluginVersion = pluginDefinitionSpec.Version
-		case isReadyCurrent && ready.Status == metav1.ConditionUnknown:
-			switch helmRelease.Status.LastAttemptedReleaseAction {
-			case helmv2.ReleaseActionInstall:
-				releaseStatus.Status = "pending-install"
-			case helmv2.ReleaseActionUpgrade:
-				releaseStatus.Status = "pending-upgrade"
-			default:
-				releaseStatus.Status = "progressing"
-			}
-		case isReadyCurrent && ready.Status == metav1.ConditionFalse:
-			stalledCondition := meta.FindStatusCondition(helmRelease.Status.Conditions, string(fluxstatus.ConditionStalled))
-			if stalledCondition != nil && stalledCondition.Status == metav1.ConditionTrue {
-				plugin.SetCondition(greenhousemetav1alpha1.FalseCondition(
-					greenhousev1alpha1.HelmReleaseDeployedCondition, greenhousev1alpha1.FluxHelmReleaseStalledReason, stalledCondition.Message))
-			}
-			releaseStatus.Status = "failed"
-		default:
-			releaseStatus.Status = "progressing"
-		}
-
-		oldChecksum := ""
-		newChecksum := ""
-		if plugin.Status.HelmReleaseStatus != nil && plugin.Status.HelmReleaseStatus.PluginOptionChecksum != "" {
-			oldChecksum = plugin.Status.HelmReleaseStatus.PluginOptionChecksum
-		}
-		if plugin.Spec.OptionValues != nil {
-			newChecksum, err = helm.CalculatePluginOptionChecksum(ctx, r.Client, plugin)
-			if err != nil {
-				releaseStatus.PluginOptionChecksum = ""
-			} else {
-				releaseStatus.PluginOptionChecksum = newChecksum
-			}
-		}
-		if oldChecksum != "" {
-			r.reconcileTrackingResources(ctx, plugin, oldChecksum, newChecksum)
-		}
-	}
-
 	var (
 		helmChartReference *greenhousev1alpha1.HelmChartReference
 	)
@@ -481,6 +376,111 @@ func (r *PluginReconciler) fetchReleaseStatus(ctx context.Context,
 	pluginStatus.Version = pluginVersion
 	pluginStatus.HelmReleaseStatus = releaseStatus
 	pluginStatus.ExposedServices = exposedServices
+
+	// Collect status from the Helm release.
+	helmRelease := &helmv2.HelmRelease{}
+	err := r.Get(ctx, types.NamespacedName{Name: plugin.Name, Namespace: plugin.Namespace}, helmRelease)
+	if err != nil {
+		// helm release does not exist or cannot be accessed
+		plugin.SetCondition(greenhousemetav1alpha1.FalseCondition(greenhousev1alpha1.ExposedServicesSyncedCondition, "", "failed to load Flux HelmRelease: "+err.Error()))
+		plugin.SetCondition(greenhousemetav1alpha1.FalseCondition(greenhousev1alpha1.HelmReleaseDeployedCondition, "", "failed to load Flux HelmRelease: "+err.Error()))
+		return
+	}
+
+	// helm release exists
+	// exposed services are not disabled, attempt to fetch exposed services from the cluster
+	helmSDKRelease, err := helm.GetReleaseForHelmChartFromPlugin(ctx, restClientGetter, plugin)
+	if err != nil {
+		plugin.SetCondition(greenhousemetav1alpha1.FalseCondition(
+			greenhousev1alpha1.ExposedServicesSyncedCondition, "", "failed to fetch Helm release from remote cluster: "+err.Error()))
+	} else {
+		serviceList, err := getAllExposedServicesForPlugin(restClientGetter, helmSDKRelease, plugin, exposeServices)
+		switch {
+		case err != nil:
+			plugin.SetCondition(greenhousemetav1alpha1.FalseCondition(
+				greenhousev1alpha1.ExposedServicesSyncedCondition, "", "failed to get exposed services: "+err.Error()))
+		case len(serviceList) == 0 && !exposeServices:
+			plugin.SetCondition(greenhousemetav1alpha1.TrueCondition(
+				greenhousev1alpha1.ExposedServicesSyncedCondition, greenhousev1alpha1.ExposedServicesDisabledReason, "exposed services are disabled for this cluster"))
+		default:
+			exposedServices = serviceList
+			plugin.SetCondition(greenhousemetav1alpha1.TrueCondition(greenhousev1alpha1.ExposedServicesSyncedCondition, "", "Fetched exposed services successfully"))
+		}
+	}
+	pluginStatus.ExposedServices = exposedServices
+
+	// Get the latest successfully deployed release to set the dates.
+	latestSnapshot := helmRelease.Status.History.Latest()
+	if latestSnapshot != nil {
+		releaseStatus.FirstDeployed = latestSnapshot.FirstDeployed
+		releaseStatus.LastDeployed = latestSnapshot.LastDeployed
+	}
+
+	// HelmRelease Ready condition is the best representation of the release status.
+	ready := meta.FindStatusCondition(helmRelease.Status.Conditions, fluxmeta.ReadyCondition)
+	isReadyCurrent := ready != nil && ready.ObservedGeneration == helmRelease.Generation
+
+	if ready == nil {
+		plugin.SetCondition(greenhousemetav1alpha1.UnknownCondition(greenhousev1alpha1.HelmReleaseDeployedCondition, "", ""))
+	} else {
+		switch ready.Status {
+		case metav1.ConditionTrue:
+			plugin.SetCondition(greenhousemetav1alpha1.TrueCondition(greenhousev1alpha1.HelmReleaseDeployedCondition, greenhousemetav1alpha1.ConditionReason(ready.Reason), ready.Message))
+		case metav1.ConditionFalse:
+			plugin.SetCondition(greenhousemetav1alpha1.FalseCondition(greenhousev1alpha1.HelmReleaseDeployedCondition, greenhousemetav1alpha1.ConditionReason(ready.Reason), ready.Message))
+		case metav1.ConditionUnknown:
+			plugin.SetCondition(greenhousemetav1alpha1.UnknownCondition(greenhousev1alpha1.HelmReleaseDeployedCondition, greenhousemetav1alpha1.ConditionReason(ready.Reason), ready.Message))
+		}
+	}
+
+	switch {
+	case helmRelease.Spec.Suspend:
+		releaseStatus.Status = "suspended"
+	case isReadyCurrent && ready.Status == metav1.ConditionTrue:
+		// If the current release is successfully deployed, get the status from history.
+		if latestSnapshot != nil {
+			releaseStatus.Status = latestSnapshot.Status
+		} else {
+			releaseStatus.Status = "deployed"
+		}
+		pluginVersion = pluginDefinitionSpec.Version
+	case isReadyCurrent && ready.Status == metav1.ConditionUnknown:
+		switch helmRelease.Status.LastAttemptedReleaseAction {
+		case helmv2.ReleaseActionInstall:
+			releaseStatus.Status = "pending-install"
+		case helmv2.ReleaseActionUpgrade:
+			releaseStatus.Status = "pending-upgrade"
+		default:
+			releaseStatus.Status = "progressing"
+		}
+	case isReadyCurrent && ready.Status == metav1.ConditionFalse:
+		stalledCondition := meta.FindStatusCondition(helmRelease.Status.Conditions, string(fluxstatus.ConditionStalled))
+		if stalledCondition != nil && stalledCondition.Status == metav1.ConditionTrue {
+			plugin.SetCondition(greenhousemetav1alpha1.FalseCondition(
+				greenhousev1alpha1.HelmReleaseDeployedCondition, greenhousev1alpha1.FluxHelmReleaseStalledReason, stalledCondition.Message))
+		}
+		releaseStatus.Status = "failed"
+	default:
+		releaseStatus.Status = "progressing"
+	}
+	pluginStatus.HelmReleaseStatus = releaseStatus
+
+	oldChecksum := ""
+	newChecksum := ""
+	if plugin.Status.HelmReleaseStatus != nil && plugin.Status.HelmReleaseStatus.PluginOptionChecksum != "" {
+		oldChecksum = plugin.Status.HelmReleaseStatus.PluginOptionChecksum
+	}
+	if plugin.Spec.OptionValues != nil {
+		newChecksum, err = helm.CalculatePluginOptionChecksum(ctx, r.Client, plugin)
+		if err != nil {
+			releaseStatus.PluginOptionChecksum = ""
+		} else {
+			releaseStatus.PluginOptionChecksum = newChecksum
+		}
+	}
+	if oldChecksum != "" {
+		r.reconcileTrackingResources(ctx, plugin, oldChecksum, newChecksum)
+	}
 }
 
 // computeReleaseValues resolves Expressions and ValueFromRefs in the Plugin's option values


### PR DESCRIPTION
<!--
Please ensure the PR title follows the conventional commit format:
<type>(<scope>): description

For a list of accepted types and scopes see the workflow documentation: https://github.com/cloudoperators/greenhouse/blob/main/.github/workflows/ci-pr-title.yaml

-->

## Description

If the service-proxy is disabled for a Cluster this should not disable the collection of ingress resources.

This ensures only exposed services are ignored.
If the service list is empty and the service-proxy is disabled the status will reflect this.
This documents the feature of disabling the service proxy for a cluster.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [x] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 

- Related Issue # (issue)
- Closes # (issue)
- Fixes # (issue)

-->

## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [ ] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
