### PR TITLE
fix(plugins): use primaryMirror instead of baseDomain for replication targets

### DIFF
--- a/internal/controller/plugindefinition/utils.go
+++ b/internal/controller/plugindefinition/utils.go
@@ -236,7 +236,7 @@ func (h *helmer) ensureChartReplication(ctx context.Context) error {
 	if err != nil {
 		return failReplication(err, "failed to create image mirror")
 	}
-	replicatedRef, manifest, err := mirror.EnsureReplicated(ctx, chartRef)
+	replicatedRef, manifest, err := mirror.EnsureChartReplicated(ctx, chartRef)
 	if err != nil {
 		return failReplication(err, "chart replication failed")
 	}

--- a/internal/ocimirror/image_mirror.go
+++ b/internal/ocimirror/image_mirror.go
@@ -61,31 +61,41 @@ func NewImageMirrorForTest(config *RegistryMirrorConfig, auth authn.Authenticato
 	}
 }
 
-// EnsureReplicated warms the pull-through cache for an OCI artifact.
-func (m *ImageMirror) EnsureReplicated(ctx context.Context, ociRef string) (replicatedRef string, manifest []byte, err error) {
-	// Upstream registry. Rewrite to mirror.
+// EnsureChartReplicated warms the pull-through cache for a chart on a mirror domain.
+func (m *ImageMirror) EnsureChartReplicated(ctx context.Context, ociRef string) (replicatedRef string, manifest []byte, err error) {
+	replicationRef, returnRef := m.buildReplicationRef(ociRef)
+	if replicationRef == "" {
+		return "", nil, nil
+	}
+	manifest, err = m.triggerReplication(ctx, replicationRef)
+	return returnRef, manifest, err
+}
+
+// EnsureImageReplicated warms the pull-through cache for a container image, including upstream refs.
+func (m *ImageMirror) EnsureImageReplicated(ctx context.Context, ociRef string) (replicatedRef string, manifest []byte, err error) {
 	if mirroredRef := m.buildMirroredOCIRef(ociRef); mirroredRef != "" {
-		manifest, err := m.triggerReplication(ctx, mirroredRef)
+		manifest, err = m.triggerReplication(ctx, mirroredRef)
 		return mirroredRef, manifest, err
 	}
+	return m.EnsureChartReplicated(ctx, ociRef)
+}
 
-	// Already on primaryMirror. Replicate directly.
+// buildReplicationRef resolves an OCI ref on a mirror domain to the primaryMirror ref for replication.
+func (m *ImageMirror) buildReplicationRef(ociRef string) (replicationRef, returnRef string) {
 	registry, repo, tagOrDigest := SplitOCIRef(ociRef)
+
 	if registry == m.config.PrimaryMirror {
-		manifest, err := m.triggerReplication(ctx, ociRef)
-		return ociRef, manifest, err
+		return ociRef, ociRef
 	}
 
-	// On a baseDomain mirror. Rewrite to primaryMirror for replication.
 	for _, mirror := range m.config.RegistryMirrors {
 		if mirror.BaseDomain == registry {
 			primaryRef := fmt.Sprintf("%s/%s", m.config.PrimaryMirror, repo) + tagOrDigest
-			manifest, err := m.triggerReplication(ctx, primaryRef)
-			return ociRef, manifest, err
+			return primaryRef, ociRef
 		}
 	}
 
-	return "", nil, nil
+	return "", ""
 }
 
 // BuildImageTransformations extracts image refs from the given rendered manifest
@@ -150,7 +160,7 @@ func (m *ImageMirror) ReplicateOCIArtifacts(ctx context.Context, alreadyReplicat
 			continue
 		}
 
-		replicatedRef, _, err := m.EnsureReplicated(ctx, imageRef)
+		replicatedRef, _, err := m.EnsureImageReplicated(ctx, imageRef)
 		if err != nil {
 			replicationErrors = append(replicationErrors, fmt.Errorf("%s: %w", imageRef, err))
 			continue

--- a/internal/ocimirror/image_mirror.go
+++ b/internal/ocimirror/image_mirror.go
@@ -69,8 +69,14 @@ func (m *ImageMirror) EnsureReplicated(ctx context.Context, ociRef string) (repl
 		return mirroredRef, manifest, err
 	}
 
-	// Already on a mirror. Rewrite to primaryMirror for replication.
+	// Already on primaryMirror. Replicate directly.
 	registry, repo, tagOrDigest := SplitOCIRef(ociRef)
+	if registry == m.config.PrimaryMirror {
+		manifest, err := m.triggerReplication(ctx, ociRef)
+		return ociRef, manifest, err
+	}
+
+	// On a baseDomain mirror. Rewrite to primaryMirror for replication.
 	for _, mirror := range m.config.RegistryMirrors {
 		if mirror.BaseDomain == registry {
 			primaryRef := fmt.Sprintf("%s/%s", m.config.PrimaryMirror, repo) + tagOrDigest

--- a/internal/ocimirror/image_mirror.go
+++ b/internal/ocimirror/image_mirror.go
@@ -69,11 +69,12 @@ func (m *ImageMirror) EnsureReplicated(ctx context.Context, ociRef string) (repl
 		return mirroredRef, manifest, err
 	}
 
-	// Already on a mirror. Replicate directly.
-	registry, _, _ := SplitOCIRef(ociRef)
+	// Already on a mirror. Rewrite to primaryMirror for replication.
+	registry, repo, tagOrDigest := SplitOCIRef(ociRef)
 	for _, mirror := range m.config.RegistryMirrors {
 		if mirror.BaseDomain == registry {
-			manifest, err := m.triggerReplication(ctx, ociRef)
+			primaryRef := fmt.Sprintf("%s/%s", m.config.PrimaryMirror, repo) + tagOrDigest
+			manifest, err := m.triggerReplication(ctx, primaryRef)
 			return ociRef, manifest, err
 		}
 	}
@@ -167,7 +168,7 @@ func (m *ImageMirror) buildMirroredOCIRef(imageRef string) string {
 		return ""
 	}
 
-	mirroredRef := fmt.Sprintf("%s/%s/%s", resolved.Mirror.BaseDomain, resolved.Mirror.SubPath, resolved.Repository)
+	mirroredRef := fmt.Sprintf("%s/%s/%s", m.config.PrimaryMirror, resolved.Mirror.SubPath, resolved.Repository)
 	if resolved.TagOrDigest != "" {
 		mirroredRef += resolved.TagOrDigest
 	}

--- a/internal/ocimirror/image_mirror_test.go
+++ b/internal/ocimirror/image_mirror_test.go
@@ -64,6 +64,20 @@ var _ = Describe("EnsureReplicated", func() {
 		Expect(manifest).NotTo(BeEmpty())
 	})
 
+	It("should replicate directly when ref is already on primaryMirror", func() {
+		var fetchedRef string
+		mirror := newTestImageMirror(mirrorConfig, func(ref string, opts ...crane.Option) ([]byte, error) {
+			fetchedRef = ref
+			return []byte(`{"test":"manifest"}`), nil
+		})
+
+		replicatedRef, manifest, err := mirror.EnsureReplicated(context.Background(), "primary.registry.com/ghcr-mirror/cloudoperators/greenhouse:v1.0")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(replicatedRef).To(Equal("primary.registry.com/ghcr-mirror/cloudoperators/greenhouse:v1.0"))
+		Expect(fetchedRef).To(Equal("primary.registry.com/ghcr-mirror/cloudoperators/greenhouse:v1.0"))
+		Expect(manifest).NotTo(BeEmpty())
+	})
+
 	It("should return empty when no mirror relationship exists", func() {
 		fetchCount := 0
 		mirror := newTestImageMirror(mirrorConfig, func(ref string, opts ...crane.Option) ([]byte, error) {

--- a/internal/ocimirror/image_mirror_test.go
+++ b/internal/ocimirror/image_mirror_test.go
@@ -17,11 +17,11 @@ var mirrorConfig = &RegistryMirrorConfig{
 	PrimaryMirror: "primary.registry.com",
 	RegistryMirrors: map[string]RegistryMirror{
 		"ghcr.io": {
-			BaseDomain: "primary.registry.com",
+			BaseDomain: "global.registry.com",
 			SubPath:    "ghcr-mirror",
 		},
 		"docker.io": {
-			BaseDomain: "primary.registry.com",
+			BaseDomain: "global.registry.com",
 			SubPath:    "dockerhub-mirror",
 		},
 	},
@@ -57,9 +57,9 @@ var _ = Describe("EnsureReplicated", func() {
 			return []byte(`{"test":"manifest"}`), nil
 		})
 
-		replicatedRef, manifest, err := mirror.EnsureReplicated(context.Background(), "primary.registry.com/ghcr-mirror/cloudoperators/greenhouse:v1.0")
+		replicatedRef, manifest, err := mirror.EnsureReplicated(context.Background(), "global.registry.com/ghcr-mirror/cloudoperators/greenhouse:v1.0")
 		Expect(err).NotTo(HaveOccurred())
-		Expect(replicatedRef).To(Equal("primary.registry.com/ghcr-mirror/cloudoperators/greenhouse:v1.0"))
+		Expect(replicatedRef).To(Equal("global.registry.com/ghcr-mirror/cloudoperators/greenhouse:v1.0"))
 		Expect(fetchedRef).To(Equal("primary.registry.com/ghcr-mirror/cloudoperators/greenhouse:v1.0"))
 		Expect(manifest).NotTo(BeEmpty())
 	})
@@ -114,11 +114,11 @@ containers:
 		Expect(transforms).To(HaveLen(2))
 		Expect(transforms).To(ContainElement(ImageTransform{
 			Original: "docker.io/library/nginx",
-			Mirrored: "primary.registry.com/dockerhub-mirror/library/nginx",
+			Mirrored: "global.registry.com/dockerhub-mirror/library/nginx",
 		}))
 		Expect(transforms).To(ContainElement(ImageTransform{
 			Original: "ghcr.io/cloudoperators/greenhouse",
-			Mirrored: "primary.registry.com/ghcr-mirror/cloudoperators/greenhouse",
+			Mirrored: "global.registry.com/ghcr-mirror/cloudoperators/greenhouse",
 		}))
 	})
 
@@ -127,7 +127,7 @@ containers:
 
 		manifests := `
 containers:
-- image: primary.registry.com/ghcr-mirror/cloudoperators/greenhouse:main
+- image: global.registry.com/ghcr-mirror/cloudoperators/greenhouse:main
 `
 		transforms := mirror.BuildImageTransformations(manifests)
 		Expect(transforms).To(BeEmpty())
@@ -150,7 +150,7 @@ containers:
 		manifests := `
 containers:
 - image: ghcr.io/cloudoperators/greenhouse:main
-- image: primary.registry.com/ghcr-mirror/already-mirrored:v1
+- image: global.registry.com/ghcr-mirror/already-mirrored:v1
 - image: registry.k8s.io/pause:3.9
 `
 		transforms := mirror.BuildImageTransformations(manifests)
@@ -178,6 +178,23 @@ containers:
 		Expect(fetchedRefs).To(HaveLen(2))
 		Expect(fetchedRefs).To(ContainElement("primary.registry.com/dockerhub-mirror/library/nginx:latest"))
 		Expect(fetchedRefs).To(ContainElement("primary.registry.com/ghcr-mirror/cloudoperators/greenhouse:main"))
+	})
+
+	It("should replicate via primaryMirror when ref is on baseDomain", func() {
+		var fetchedRef string
+		mirror := newTestImageMirror(mirrorConfig, func(ref string, opts ...crane.Option) ([]byte, error) {
+			fetchedRef = ref
+			return []byte("{}"), nil
+		})
+
+		manifests := `
+containers:
+- image: global.registry.com/ghcr-mirror/cloudoperators/greenhouse:main
+`
+		replicated, err := mirror.ReplicateOCIArtifacts(context.Background(), nil, manifests)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(replicated).To(HaveLen(1))
+		Expect(fetchedRef).To(Equal("primary.registry.com/ghcr-mirror/cloudoperators/greenhouse:main"))
 	})
 
 	It("should skip already replicated images", func() {

--- a/internal/ocimirror/image_mirror_test.go
+++ b/internal/ocimirror/image_mirror_test.go
@@ -35,29 +35,15 @@ func newTestImageMirror(config *RegistryMirrorConfig, fetcher manifestFetcherFun
 	}
 }
 
-var _ = Describe("EnsureReplicated", func() {
-	It("should rewrite upstream ref to mirror and replicate", func() {
+var _ = Describe("EnsureChartReplicated", func() {
+	It("should replicate via primaryMirror when ref is on baseDomain", func() {
 		var fetchedRef string
 		mirror := newTestImageMirror(mirrorConfig, func(ref string, opts ...crane.Option) ([]byte, error) {
 			fetchedRef = ref
 			return []byte(`{"test":"manifest"}`), nil
 		})
 
-		replicatedRef, manifest, err := mirror.EnsureReplicated(context.Background(), "ghcr.io/cloudoperators/greenhouse:main")
-		Expect(err).NotTo(HaveOccurred())
-		Expect(replicatedRef).To(Equal("primary.registry.com/ghcr-mirror/cloudoperators/greenhouse:main"))
-		Expect(fetchedRef).To(Equal("primary.registry.com/ghcr-mirror/cloudoperators/greenhouse:main"))
-		Expect(manifest).NotTo(BeEmpty())
-	})
-
-	It("should replicate directly when ref is already on a mirror", func() {
-		var fetchedRef string
-		mirror := newTestImageMirror(mirrorConfig, func(ref string, opts ...crane.Option) ([]byte, error) {
-			fetchedRef = ref
-			return []byte(`{"test":"manifest"}`), nil
-		})
-
-		replicatedRef, manifest, err := mirror.EnsureReplicated(context.Background(), "global.registry.com/ghcr-mirror/cloudoperators/greenhouse:v1.0")
+		replicatedRef, manifest, err := mirror.EnsureChartReplicated(context.Background(), "global.registry.com/ghcr-mirror/cloudoperators/greenhouse:v1.0")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(replicatedRef).To(Equal("global.registry.com/ghcr-mirror/cloudoperators/greenhouse:v1.0"))
 		Expect(fetchedRef).To(Equal("primary.registry.com/ghcr-mirror/cloudoperators/greenhouse:v1.0"))
@@ -71,7 +57,89 @@ var _ = Describe("EnsureReplicated", func() {
 			return []byte(`{"test":"manifest"}`), nil
 		})
 
-		replicatedRef, manifest, err := mirror.EnsureReplicated(context.Background(), "primary.registry.com/ghcr-mirror/cloudoperators/greenhouse:v1.0")
+		replicatedRef, manifest, err := mirror.EnsureChartReplicated(context.Background(), "primary.registry.com/ghcr-mirror/cloudoperators/greenhouse:v1.0")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(replicatedRef).To(Equal("primary.registry.com/ghcr-mirror/cloudoperators/greenhouse:v1.0"))
+		Expect(fetchedRef).To(Equal("primary.registry.com/ghcr-mirror/cloudoperators/greenhouse:v1.0"))
+		Expect(manifest).NotTo(BeEmpty())
+	})
+
+	It("should return empty for upstream refs (charts should not be upstream)", func() {
+		fetchCount := 0
+		mirror := newTestImageMirror(mirrorConfig, func(ref string, opts ...crane.Option) ([]byte, error) {
+			fetchCount++
+			return []byte("{}"), nil
+		})
+
+		replicatedRef, manifest, err := mirror.EnsureChartReplicated(context.Background(), "ghcr.io/cloudoperators/greenhouse:main")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(replicatedRef).To(BeEmpty())
+		Expect(manifest).To(BeNil())
+		Expect(fetchCount).To(Equal(0))
+	})
+
+	It("should return empty when no mirror relationship exists", func() {
+		fetchCount := 0
+		mirror := newTestImageMirror(mirrorConfig, func(ref string, opts ...crane.Option) ([]byte, error) {
+			fetchCount++
+			return []byte("{}"), nil
+		})
+
+		replicatedRef, manifest, err := mirror.EnsureChartReplicated(context.Background(), "registry.k8s.io/pause:3.9")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(replicatedRef).To(BeEmpty())
+		Expect(manifest).To(BeNil())
+		Expect(fetchCount).To(Equal(0))
+	})
+
+	It("should propagate replication errors", func() {
+		mirror := newTestImageMirror(mirrorConfig, func(ref string, opts ...crane.Option) ([]byte, error) {
+			return nil, errors.New("connection refused")
+		})
+
+		_, _, err := mirror.EnsureChartReplicated(context.Background(), "primary.registry.com/ghcr-mirror/cloudoperators/greenhouse:v1.0")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("connection refused"))
+	})
+})
+
+var _ = Describe("EnsureImageReplicated", func() {
+	It("should rewrite upstream ref to mirror and replicate", func() {
+		var fetchedRef string
+		mirror := newTestImageMirror(mirrorConfig, func(ref string, opts ...crane.Option) ([]byte, error) {
+			fetchedRef = ref
+			return []byte(`{"test":"manifest"}`), nil
+		})
+
+		replicatedRef, manifest, err := mirror.EnsureImageReplicated(context.Background(), "ghcr.io/cloudoperators/greenhouse:main")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(replicatedRef).To(Equal("primary.registry.com/ghcr-mirror/cloudoperators/greenhouse:main"))
+		Expect(fetchedRef).To(Equal("primary.registry.com/ghcr-mirror/cloudoperators/greenhouse:main"))
+		Expect(manifest).NotTo(BeEmpty())
+	})
+
+	It("should replicate via primaryMirror when ref is on baseDomain", func() {
+		var fetchedRef string
+		mirror := newTestImageMirror(mirrorConfig, func(ref string, opts ...crane.Option) ([]byte, error) {
+			fetchedRef = ref
+			return []byte(`{"test":"manifest"}`), nil
+		})
+
+		replicatedRef, manifest, err := mirror.EnsureImageReplicated(context.Background(), "global.registry.com/ghcr-mirror/cloudoperators/greenhouse:v1.0")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(replicatedRef).To(Equal("global.registry.com/ghcr-mirror/cloudoperators/greenhouse:v1.0"))
+		Expect(fetchedRef).To(Equal("primary.registry.com/ghcr-mirror/cloudoperators/greenhouse:v1.0"))
+		Expect(manifest).NotTo(BeEmpty())
+	})
+
+	It("should replicate directly when ref is already on primaryMirror", func() {
+		var fetchedRef string
+		mirror := newTestImageMirror(mirrorConfig, func(ref string, opts ...crane.Option) ([]byte, error) {
+			fetchedRef = ref
+			return []byte(`{"test":"manifest"}`), nil
+		})
+
+		replicatedRef, manifest, err := mirror.EnsureImageReplicated(context.Background(), "primary.registry.com/ghcr-mirror/cloudoperators/greenhouse:v1.0")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(replicatedRef).To(Equal("primary.registry.com/ghcr-mirror/cloudoperators/greenhouse:v1.0"))
 		Expect(fetchedRef).To(Equal("primary.registry.com/ghcr-mirror/cloudoperators/greenhouse:v1.0"))
@@ -85,7 +153,7 @@ var _ = Describe("EnsureReplicated", func() {
 			return []byte("{}"), nil
 		})
 
-		replicatedRef, manifest, err := mirror.EnsureReplicated(context.Background(), "registry.k8s.io/pause:3.9")
+		replicatedRef, manifest, err := mirror.EnsureImageReplicated(context.Background(), "registry.k8s.io/pause:3.9")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(replicatedRef).To(BeEmpty())
 		Expect(manifest).To(BeNil())
@@ -99,7 +167,7 @@ var _ = Describe("EnsureReplicated", func() {
 			return []byte(`{}`), nil
 		})
 
-		_, _, err := mirror.EnsureReplicated(context.Background(), "ghcr.io/cloudoperators/greenhouse:main")
+		_, _, err := mirror.EnsureImageReplicated(context.Background(), "ghcr.io/cloudoperators/greenhouse:main")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(len(receivedOpts)).To(BeNumerically(">=", 2))
 	})
@@ -109,7 +177,7 @@ var _ = Describe("EnsureReplicated", func() {
 			return nil, errors.New("connection refused")
 		})
 
-		_, _, err := mirror.EnsureReplicated(context.Background(), "ghcr.io/cloudoperators/greenhouse:main")
+		_, _, err := mirror.EnsureImageReplicated(context.Background(), "ghcr.io/cloudoperators/greenhouse:main")
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("connection refused"))
 	})

--- a/internal/ocimirror/registry_mirror.go
+++ b/internal/ocimirror/registry_mirror.go
@@ -95,6 +95,9 @@ func (c *RegistryMirrorConfig) ResolveOCIRef(imageRef string) *ResolvedOCIRef {
 
 // validateRegistryMirrorConfig validates the registry mirror configuration.
 func validateRegistryMirrorConfig(config *RegistryMirrorConfig) error {
+	if config.PrimaryMirror == "" {
+		return errors.New("primaryMirror cannot be empty")
+	}
 	if len(config.RegistryMirrors) == 0 {
 		return errors.New("registryMirrors cannot be empty")
 	}

--- a/internal/ocimirror/registry_mirror_test.go
+++ b/internal/ocimirror/registry_mirror_test.go
@@ -136,7 +136,7 @@ registryMirrors:
 			})
 		})
 
-		Context("when PrimaryMirror is empty, SecretName should not be defaulted", func() {
+		Context("when PrimaryMirror is empty", func() {
 			BeforeEach(func() {
 				org := &greenhousev1alpha1.Organization{
 					ObjectMeta: metav1.ObjectMeta{
@@ -166,12 +166,12 @@ registryMirrors:
 					Build()
 			})
 
-			It("should leave SecretName empty", func() {
+			It("should return a validation error", func() {
 				config, err := GetRegistryMirrorConfig(ctx, fakeClient, orgName)
 
-				Expect(err).NotTo(HaveOccurred())
-				Expect(config).NotTo(BeNil())
-				Expect(config.SecretName).To(BeEmpty())
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("primaryMirror cannot be empty"))
+				Expect(config).To(BeNil())
 			})
 		})
 
@@ -336,7 +336,7 @@ registryMirrors:
 						},
 					},
 				}, true, ""),
-			Entry("valid configuration with empty primary mirror",
+			Entry("empty primary mirror should fail",
 				&RegistryMirrorConfig{
 					PrimaryMirror: "",
 					RegistryMirrors: map[string]RegistryMirror{
@@ -345,7 +345,7 @@ registryMirrors:
 							SubPath:    "dockerhub-mirror",
 						},
 					},
-				}, true, ""),
+				}, false, "primaryMirror cannot be empty"),
 			Entry("empty subPath should fail",
 				&RegistryMirrorConfig{
 					PrimaryMirror: "primary.registry.com",


### PR DESCRIPTION
## Description

This PR fixes `EnsureReplicated` constructing `crane.Manifest` targets using `baseDomain` instead of `primaryMirror` 

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

- Fixes https://github.com/cloudoperators/greenhouse/issues/1916

## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [x] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
