### PR TITLE
feat(e2e): e2e tests for multiple team refs in TRB

### DIFF
--- a/e2e/teamrolebinding/e2e_test.go
+++ b/e2e/teamrolebinding/e2e_test.go
@@ -25,8 +25,7 @@ import (
 )
 
 const (
-	remoteClusterName    = "remote-trb-cluster"
-	supportGroupTeamName = "test-trb-support-team"
+	remoteClusterName = "remote-trb-cluster"
 )
 
 var (
@@ -61,10 +60,6 @@ var _ = BeforeSuite(func() {
 
 	env = env.WithOrganization(ctx, adminClient, "./testdata/organization.yaml")
 
-	By("onboarding the remote cluster")
-	shared.OnboardRemoteCluster(ctx, adminClient, env.RemoteKubeConfigBytes, remoteClusterName, env.TestNamespace, supportGroupTeamName)
-	shared.ClusterIsReady(ctx, adminClient, remoteClusterName, env.TestNamespace)
-
 	By("creating shared Teams")
 	teamAlpha = test.NewTeam(ctx, "trb-team-alpha", env.TestNamespace,
 		test.WithMappedIDPGroup("idp-group-trb-alpha"),
@@ -79,6 +74,10 @@ var _ = BeforeSuite(func() {
 	)
 	err = adminClient.Create(ctx, teamBeta)
 	Expect(client.IgnoreAlreadyExists(err)).ToNot(HaveOccurred(), "there should be no error creating teamBeta")
+
+	By("onboarding the remote cluster")
+	shared.OnboardRemoteCluster(ctx, adminClient, env.RemoteKubeConfigBytes, remoteClusterName, env.TestNamespace, teamAlpha.Name)
+	shared.ClusterIsReady(ctx, adminClient, remoteClusterName, env.TestNamespace)
 
 	By("creating shared TeamRole")
 	teamRole = test.NewTeamRole(ctx, "trb-test-role", env.TestNamespace)

--- a/e2e/teamrolebinding/e2e_test.go
+++ b/e2e/teamrolebinding/e2e_test.go
@@ -1,0 +1,138 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build teamrolebindingE2E
+
+package teamrolebinding
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	greenhouseapis "github.com/cloudoperators/greenhouse/api"
+	greenhousev1alpha1 "github.com/cloudoperators/greenhouse/api/v1alpha1"
+	"github.com/cloudoperators/greenhouse/e2e/shared"
+	"github.com/cloudoperators/greenhouse/e2e/teamrolebinding/scenarios"
+	"github.com/cloudoperators/greenhouse/internal/clientutil"
+	"github.com/cloudoperators/greenhouse/internal/test"
+)
+
+const (
+	remoteClusterName    = "remote-trb-cluster"
+	supportGroupTeamName = "test-trb-support-team"
+)
+
+var (
+	env           *shared.TestEnv
+	ctx           context.Context
+	adminClient   client.Client
+	remoteClient  client.Client
+	testStartTime time.Time
+
+	teamAlpha *greenhousev1alpha1.Team
+	teamBeta  *greenhousev1alpha1.Team
+	teamRole  *greenhousev1alpha1.TeamRole
+
+	trb scenarios.ITRBScenario
+)
+
+func TestTeamRoleBindingE2e(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "TeamRoleBinding E2E Suite")
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+	ctx = context.Background()
+
+	var err error
+	env = shared.NewExecutionEnv()
+	adminClient, err = clientutil.NewK8sClientFromRestClientGetter(env.AdminRestClientGetter)
+	Expect(err).ToNot(HaveOccurred(), "there should be no error creating the admin client")
+	remoteClient, err = clientutil.NewK8sClientFromRestClientGetter(env.RemoteRestClientGetter)
+	Expect(err).ToNot(HaveOccurred(), "there should be no error creating the remote client")
+
+	env = env.WithOrganization(ctx, adminClient, "./testdata/organization.yaml")
+
+	By("onboarding the remote cluster")
+	shared.OnboardRemoteCluster(ctx, adminClient, env.RemoteKubeConfigBytes, remoteClusterName, env.TestNamespace, supportGroupTeamName)
+	shared.ClusterIsReady(ctx, adminClient, remoteClusterName, env.TestNamespace)
+
+	By("creating shared Teams")
+	teamAlpha = test.NewTeam(ctx, "trb-team-alpha", env.TestNamespace,
+		test.WithMappedIDPGroup("idp-group-trb-alpha"),
+		test.WithTeamLabel(greenhouseapis.LabelKeySupportGroup, "true"),
+	)
+	err = adminClient.Create(ctx, teamAlpha)
+	Expect(client.IgnoreAlreadyExists(err)).ToNot(HaveOccurred(), "there should be no error creating teamAlpha")
+
+	teamBeta = test.NewTeam(ctx, "trb-team-beta", env.TestNamespace,
+		test.WithMappedIDPGroup("idp-group-trb-beta"),
+		test.WithTeamLabel(greenhouseapis.LabelKeySupportGroup, "true"),
+	)
+	err = adminClient.Create(ctx, teamBeta)
+	Expect(client.IgnoreAlreadyExists(err)).ToNot(HaveOccurred(), "there should be no error creating teamBeta")
+
+	By("creating shared TeamRole")
+	teamRole = test.NewTeamRole(ctx, "trb-test-role", env.TestNamespace)
+	err = adminClient.Create(ctx, teamRole)
+	Expect(client.IgnoreAlreadyExists(err)).ToNot(HaveOccurred(), "there should be no error creating teamRole")
+
+	By("building scenario runner")
+	trb = scenarios.NewScenario(
+		adminClient, remoteClient,
+		env.TestNamespace, remoteClusterName,
+		teamAlpha, teamBeta,
+		teamRole,
+	)
+
+	testStartTime = time.Now().UTC()
+})
+
+var _ = AfterSuite(func() {
+	By("deleting shared resources")
+	test.EventuallyDeleted(ctx, adminClient, teamRole)
+	test.EventuallyDeleted(ctx, adminClient, teamAlpha)
+	test.EventuallyDeleted(ctx, adminClient, teamBeta)
+
+	By("off-boarding the remote cluster")
+	shared.OffBoardRemoteCluster(ctx, adminClient, remoteClient, testStartTime, remoteClusterName, env.TestNamespace)
+
+	env.GenerateGreenhouseControllerLogs(ctx, testStartTime)
+})
+
+var _ = Describe("TeamRoleBinding E2E", Ordered, func() {
+	DescribeTable("TeamRoleBinding scenarios",
+		func(execute func(scenarios.ITRBScenario, context.Context)) {
+			execute(trb, ctx)
+		},
+		Entry("Single teamRef (baseline)",
+			func(s scenarios.ITRBScenario, c context.Context) { s.ExecuteSingleTeamRefScenario(c) },
+		),
+		Entry("Multiple teamRefs",
+			func(s scenarios.ITRBScenario, c context.Context) { s.ExecuteMultipleTeamRefsScenario(c) },
+		),
+		Entry("Deprecated teamRef migration",
+			func(s scenarios.ITRBScenario, c context.Context) { s.ExecuteDeprecatedTeamRefMigrationScenario(c) },
+		),
+		Entry("Mutation of teamRefs (add/remove)",
+			func(s scenarios.ITRBScenario, c context.Context) { s.ExecuteTeamRefsMutationScenario(c) },
+		),
+		Entry("Partial failure (some teams missing)",
+			func(s scenarios.ITRBScenario, c context.Context) { s.ExecutePartialFailureScenario(c) },
+		),
+		Entry("Namespace creation with multiple teams",
+			func(s scenarios.ITRBScenario, c context.Context) { s.ExecuteNamespaceCreationScenario(c) },
+		),
+		Entry("Cluster selector",
+			func(s scenarios.ITRBScenario, c context.Context) { s.ExecuteClusterSelectorScenario(c) },
+		),
+	)
+})

--- a/e2e/teamrolebinding/scenarios/scenario.go
+++ b/e2e/teamrolebinding/scenarios/scenario.go
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package scenarios
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	greenhousev1alpha1 "github.com/cloudoperators/greenhouse/api/v1alpha1"
+	greenhousev1alpha2 "github.com/cloudoperators/greenhouse/api/v1alpha2"
+	"github.com/cloudoperators/greenhouse/internal/test"
+)
+
+// ITRBScenario defines all executable TeamRoleBinding E2E scenarios.
+type ITRBScenario interface {
+	// ExecuteSingleTeamRefScenario verifies RBAC for a single teamRefs entry (baseline).
+	ExecuteSingleTeamRefScenario(ctx context.Context)
+	// ExecuteMultipleTeamRefsScenario verifies RBAC for two teams in teamRefs.
+	ExecuteMultipleTeamRefsScenario(ctx context.Context)
+	// ExecuteDeprecatedTeamRefMigrationScenario verifies the webhook migrates teamRef → teamRefs.
+	ExecuteDeprecatedTeamRefMigrationScenario(ctx context.Context)
+	// ExecuteTeamRefsMutationScenario verifies subjects update when teamRefs are modified.
+	ExecuteTeamRefsMutationScenario(ctx context.Context)
+	// ExecutePartialFailureScenario verifies RBAC resilience when some teams are missing.
+	ExecutePartialFailureScenario(ctx context.Context)
+	// ExecuteNamespaceCreationScenario verifies createNamespaces=true with multiple teams.
+	ExecuteNamespaceCreationScenario(ctx context.Context)
+	// ExecuteClusterSelectorScenario verifies RBAC is applied only to clusters matching a selector.
+	ExecuteClusterSelectorScenario(ctx context.Context)
+}
+
+// scenario holds the shared state for all TeamRoleBinding E2E scenarios.
+type scenario struct {
+	adminClient  client.Client
+	remoteClient client.Client
+	namespace    string
+	clusterName  string
+	teamAlpha    *greenhousev1alpha1.Team
+	teamBeta     *greenhousev1alpha1.Team
+	teamRole     *greenhousev1alpha1.TeamRole
+}
+
+// NewScenario constructs an ITRBScenario from the given test context.
+func NewScenario(
+	adminClient, remoteClient client.Client,
+	namespace, clusterName string,
+	teamAlpha, teamBeta *greenhousev1alpha1.Team,
+	teamRole *greenhousev1alpha1.TeamRole,
+) ITRBScenario {
+
+	GinkgoHelper()
+	return &scenario{
+		adminClient:  adminClient,
+		remoteClient: remoteClient,
+		namespace:    namespace,
+		clusterName:  clusterName,
+		teamAlpha:    teamAlpha,
+		teamBeta:     teamBeta,
+		teamRole:     teamRole,
+	}
+}
+
+// createTRB is a helper that creates a TeamRoleBinding and returns it.
+func (s *scenario) createTRB(ctx context.Context, name string, opts ...func(*greenhousev1alpha2.TeamRoleBinding)) *greenhousev1alpha2.TeamRoleBinding {
+	GinkgoHelper()
+	trb := test.NewTeamRoleBinding(ctx, name, s.namespace, opts...)
+	s.mustCreate(ctx, trb)
+	return trb
+}
+
+// mustCreate creates a resource and fails the test on error.
+func (s *scenario) mustCreate(ctx context.Context, obj client.Object) {
+	GinkgoHelper()
+	Expect(s.adminClient.Create(ctx, obj)).To(Succeed(), "there should be no error creating %T %s", obj, obj.GetName())
+}
+
+// cleanup deletes a TeamRoleBinding if it is non-nil, waiting for it to disappear.
+func (s *scenario) cleanup(ctx context.Context, trb *greenhousev1alpha2.TeamRoleBinding) {
+	GinkgoHelper()
+	test.EventuallyDeleted(ctx, s.adminClient, trb)
+}

--- a/e2e/teamrolebinding/scenarios/scenario.go
+++ b/e2e/teamrolebinding/scenarios/scenario.go
@@ -12,6 +12,7 @@ import (
 
 	greenhousev1alpha1 "github.com/cloudoperators/greenhouse/api/v1alpha1"
 	greenhousev1alpha2 "github.com/cloudoperators/greenhouse/api/v1alpha2"
+	"github.com/cloudoperators/greenhouse/internal/clientutil"
 	"github.com/cloudoperators/greenhouse/internal/test"
 )
 
@@ -64,18 +65,18 @@ func NewScenario(
 	}
 }
 
-// createTRB is a helper that creates a TeamRoleBinding and returns it.
+// createTRB is a helper that creates or patches a TeamRoleBinding and returns it.
 func (s *scenario) createTRB(ctx context.Context, name string, opts ...func(*greenhousev1alpha2.TeamRoleBinding)) *greenhousev1alpha2.TeamRoleBinding {
 	GinkgoHelper()
 	trb := test.NewTeamRoleBinding(ctx, name, s.namespace, opts...)
-	s.mustCreate(ctx, trb)
+	_, err := clientutil.CreateOrPatch(ctx, s.adminClient, trb, func() error {
+		for _, opt := range opts {
+			opt(trb)
+		}
+		return nil
+	})
+	Expect(err).ToNot(HaveOccurred(), "there should be no error creating or patching %T %s", trb, trb.GetName())
 	return trb
-}
-
-// mustCreate creates a resource and fails the test on error.
-func (s *scenario) mustCreate(ctx context.Context, obj client.Object) {
-	GinkgoHelper()
-	Expect(s.adminClient.Create(ctx, obj)).To(Succeed(), "there should be no error creating %T %s", obj, obj.GetName())
 }
 
 // cleanup deletes a TeamRoleBinding if it is non-nil, waiting for it to disappear.

--- a/e2e/teamrolebinding/scenarios/scenario.go
+++ b/e2e/teamrolebinding/scenarios/scenario.go
@@ -68,7 +68,7 @@ func NewScenario(
 // createTRB is a helper that creates or patches a TeamRoleBinding and returns it.
 func (s *scenario) createTRB(ctx context.Context, name string, opts ...func(*greenhousev1alpha2.TeamRoleBinding)) *greenhousev1alpha2.TeamRoleBinding {
 	GinkgoHelper()
-	trb := test.NewTeamRoleBinding(ctx, name, s.namespace, opts...)
+	trb := test.NewTeamRoleBinding(ctx, name, s.namespace)
 	_, err := clientutil.CreateOrPatch(ctx, s.adminClient, trb, func() error {
 		for _, opt := range opts {
 			opt(trb)

--- a/e2e/teamrolebinding/scenarios/trb_cluster_selector.go
+++ b/e2e/teamrolebinding/scenarios/trb_cluster_selector.go
@@ -65,20 +65,18 @@ func (s *scenario) ExecuteClusterSelectorScenario(ctx context.Context) {
 		}),
 	)
 
-	By("verifying the ClusterRoleBinding is created on the matching remote cluster")
+	By("verifying the ClusterRoleBinding is created on the matching remote cluster with subjects for both teams")
 	remoteCRB := &rbacv1.ClusterRoleBinding{}
 	Eventually(func(g Gomega) {
 		g.Expect(s.remoteClient.Get(ctx, client.ObjectKey{Name: trb.GetRBACName()}, remoteCRB)).
 			To(Succeed(), "ClusterRoleBinding should be created on the matching cluster")
-	}).Should(Succeed(), "ClusterRoleBinding should exist on the matching cluster")
-
-	By("verifying subjects include both teams' IDP groups on the matching cluster")
-	Expect(slices.ContainsFunc(remoteCRB.Subjects, func(sub rbacv1.Subject) bool {
-		return sub.Kind == rbacv1.GroupKind && sub.Name == s.teamAlpha.Spec.MappedIDPGroup
-	})).To(BeTrue(), "subjects should contain teamAlpha's IDP group")
-	Expect(slices.ContainsFunc(remoteCRB.Subjects, func(sub rbacv1.Subject) bool {
-		return sub.Kind == rbacv1.GroupKind && sub.Name == s.teamBeta.Spec.MappedIDPGroup
-	})).To(BeTrue(), "subjects should contain teamBeta's IDP group")
+		g.Expect(slices.ContainsFunc(remoteCRB.Subjects, func(sub rbacv1.Subject) bool {
+			return sub.Kind == rbacv1.GroupKind && sub.Name == s.teamAlpha.Spec.MappedIDPGroup
+		})).To(BeTrue(), "subjects should contain teamAlpha's IDP group")
+		g.Expect(slices.ContainsFunc(remoteCRB.Subjects, func(sub rbacv1.Subject) bool {
+			return sub.Kind == rbacv1.GroupKind && sub.Name == s.teamBeta.Spec.MappedIDPGroup
+		})).To(BeTrue(), "subjects should contain teamBeta's IDP group")
+	}).Should(Succeed(), "ClusterRoleBinding should exist on the matching cluster with subjects for both teams")
 
 	By("verifying the TeamRoleBinding PropagationStatus references only the matching cluster")
 	Eventually(func(g Gomega) {

--- a/e2e/teamrolebinding/scenarios/trb_cluster_selector.go
+++ b/e2e/teamrolebinding/scenarios/trb_cluster_selector.go
@@ -12,6 +12,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/rand"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	greenhousev1alpha1 "github.com/cloudoperators/greenhouse/api/v1alpha1"
@@ -28,7 +29,7 @@ func (s *scenario) ExecuteClusterSelectorScenario(ctx context.Context) {
 	var trb *greenhousev1alpha2.TeamRoleBinding
 
 	// A unique label key used only by this test run to avoid interference.
-	const labelKey = "trb-selector-test"
+	labelKey := "trb-selector-test-" + rand.String(6)
 	const labelMatch = "match"
 	const labelNoMatch = "no-match"
 

--- a/e2e/teamrolebinding/scenarios/trb_cluster_selector.go
+++ b/e2e/teamrolebinding/scenarios/trb_cluster_selector.go
@@ -1,0 +1,105 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package scenarios
+
+import (
+	"context"
+	"slices"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	greenhousev1alpha1 "github.com/cloudoperators/greenhouse/api/v1alpha1"
+	greenhousev1alpha2 "github.com/cloudoperators/greenhouse/api/v1alpha2"
+	"github.com/cloudoperators/greenhouse/internal/clientutil"
+	"github.com/cloudoperators/greenhouse/internal/test"
+)
+
+// ExecuteClusterSelectorScenario verifies that a TeamRoleBinding with a label-based
+// clusterSelector applies RBAC only to clusters whose labels match the selector, and that RBAC
+// is removed from a cluster when it no longer matches (label change).
+func (s *scenario) ExecuteClusterSelectorScenario(ctx context.Context) {
+	GinkgoHelper()
+	var trb *greenhousev1alpha2.TeamRoleBinding
+
+	// A unique label key used only by this test run to avoid interference.
+	const labelKey = "trb-selector-test"
+	const labelMatch = "match"
+	const labelNoMatch = "no-match"
+
+	By("adding a unique label to the remote cluster for the selector test")
+	cluster := &greenhousev1alpha1.Cluster{}
+	Expect(s.adminClient.Get(ctx, client.ObjectKey{Name: s.clusterName, Namespace: s.namespace}, cluster)).
+		To(Succeed(), "remote cluster should exist")
+
+	_, err := clientutil.CreateOrPatch(ctx, s.adminClient, cluster, func() error {
+		if cluster.Labels == nil {
+			cluster.Labels = make(map[string]string)
+		}
+		cluster.Labels[labelKey] = labelMatch
+		return nil
+	})
+	Expect(err).ToNot(HaveOccurred(), "there should be no error labeling the cluster")
+
+	// Restore the cluster label on cleanup regardless of test outcome.
+	DeferCleanup(func() {
+		_, err := clientutil.CreateOrPatch(ctx, s.adminClient, cluster, func() error {
+			delete(cluster.Labels, labelKey)
+			return nil
+		})
+		Expect(err).ToNot(HaveOccurred(), "there should be no error restoring the cluster label during cleanup")
+		s.cleanup(ctx, trb)
+	})
+
+	By("creating a TeamRoleBinding with a label selector matching the remote cluster")
+	trb = s.createTRB(ctx, "trb-selector",
+		test.WithTeamRoleRef(s.teamRole.Name),
+		test.WithTeamRefs(s.teamAlpha.Name, s.teamBeta.Name),
+		test.WithClusterSelector(metav1.LabelSelector{
+			MatchLabels: map[string]string{labelKey: labelMatch},
+		}),
+	)
+
+	By("verifying the ClusterRoleBinding is created on the matching remote cluster")
+	remoteCRB := &rbacv1.ClusterRoleBinding{}
+	Eventually(func(g Gomega) {
+		g.Expect(s.remoteClient.Get(ctx, client.ObjectKey{Name: trb.GetRBACName()}, remoteCRB)).
+			To(Succeed(), "ClusterRoleBinding should be created on the matching cluster")
+	}).Should(Succeed(), "ClusterRoleBinding should exist on the matching cluster")
+
+	By("verifying subjects include both teams' IDP groups on the matching cluster")
+	Expect(slices.ContainsFunc(remoteCRB.Subjects, func(sub rbacv1.Subject) bool {
+		return sub.Kind == rbacv1.GroupKind && sub.Name == s.teamAlpha.Spec.MappedIDPGroup
+	})).To(BeTrue(), "subjects should contain teamAlpha's IDP group")
+	Expect(slices.ContainsFunc(remoteCRB.Subjects, func(sub rbacv1.Subject) bool {
+		return sub.Kind == rbacv1.GroupKind && sub.Name == s.teamBeta.Spec.MappedIDPGroup
+	})).To(BeTrue(), "subjects should contain teamBeta's IDP group")
+
+	By("verifying the TeamRoleBinding PropagationStatus references only the matching cluster")
+	Eventually(func(g Gomega) {
+		g.Expect(s.adminClient.Get(ctx, client.ObjectKeyFromObject(trb), trb)).To(Succeed())
+		g.Expect(trb.Status.PropagationStatus).To(HaveLen(1),
+			"only one cluster should appear in PropagationStatus")
+		g.Expect(trb.Status.PropagationStatus[0].ClusterName).To(Equal(s.clusterName))
+		g.Expect(trb.Status.PropagationStatus[0].Condition.Status).To(Equal(metav1.ConditionTrue))
+	}).Should(Succeed(), "PropagationStatus should only show the matching cluster")
+
+	By("changing the cluster label so it no longer matches the selector")
+	_, err = clientutil.CreateOrPatch(ctx, s.adminClient, cluster, func() error {
+		cluster.Labels[labelKey] = labelNoMatch
+		return nil
+	})
+	Expect(err).ToNot(HaveOccurred(), "there should be no error updating cluster label")
+
+	By("verifying the ClusterRoleBinding is removed after the cluster label no longer matches")
+	Eventually(func(g Gomega) {
+		err := s.remoteClient.Get(ctx, client.ObjectKey{Name: trb.GetRBACName()}, remoteCRB)
+		g.Expect(apierrors.IsNotFound(err)).To(BeTrue(),
+			"ClusterRoleBinding should be removed after cluster label no longer matches the selector")
+	}).Should(Succeed(), "ClusterRoleBinding should be cleaned up when cluster no longer matches selector")
+}

--- a/e2e/teamrolebinding/scenarios/trb_deprecated_migration.go
+++ b/e2e/teamrolebinding/scenarios/trb_deprecated_migration.go
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package scenarios
+
+import (
+	"context"
+	"slices"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	greenhousev1alpha2 "github.com/cloudoperators/greenhouse/api/v1alpha2"
+	"github.com/cloudoperators/greenhouse/internal/test"
+)
+
+// ExecuteDeprecatedTeamRefMigrationScenario verifies that the mutating webhook migrates the
+// deprecated singular teamRef field into teamRefs, and that RBAC is applied correctly afterwards.
+func (s *scenario) ExecuteDeprecatedTeamRefMigrationScenario(ctx context.Context) {
+	GinkgoHelper()
+	var trb *greenhousev1alpha2.TeamRoleBinding
+	DeferCleanup(func() { s.cleanup(ctx, trb) })
+
+	By("creating a TeamRoleBinding using the deprecated teamRef field")
+	trb = s.createTRB(ctx, "trb-deprecated",
+		test.WithTeamRoleRef(s.teamRole.Name),
+		test.WithTeamRef(s.teamAlpha.Name), // deprecated singular field
+		test.WithClusterName(s.clusterName),
+	)
+
+	By("verifying the webhook merged teamRef into teamRefs")
+	Eventually(func(g Gomega) {
+		g.Expect(s.adminClient.Get(ctx, client.ObjectKeyFromObject(trb), trb)).To(Succeed())
+		g.Expect(trb.Spec.TeamRefs).To(ContainElement(s.teamAlpha.Name),
+			"webhook should have migrated teamRef into teamRefs")
+	}).Should(Succeed(), "teamRef should be merged into teamRefs by the defaulting webhook")
+
+	By("verifying the ClusterRoleBinding is created on the remote cluster")
+	remoteCRB := &rbacv1.ClusterRoleBinding{}
+	Eventually(func(g Gomega) {
+		g.Expect(s.remoteClient.Get(ctx, client.ObjectKey{Name: trb.GetRBACName()}, remoteCRB)).
+			To(Succeed(), "ClusterRoleBinding should exist on the remote cluster")
+	}).Should(Succeed(), "ClusterRoleBinding should be created after migration")
+
+	By("verifying the subjects contain the migrated team's IDP group")
+	Expect(slices.ContainsFunc(remoteCRB.Subjects, func(sub rbacv1.Subject) bool {
+		return sub.Kind == rbacv1.GroupKind && sub.Name == s.teamAlpha.Spec.MappedIDPGroup
+	})).To(BeTrue(), "subjects should contain teamAlpha's IDP group after migration")
+
+	By("verifying the TeamRoleBinding RBACReady status is True")
+	Eventually(func(g Gomega) {
+		g.Expect(s.adminClient.Get(ctx, client.ObjectKeyFromObject(trb), trb)).To(Succeed())
+		cond := trb.Status.GetConditionByType(greenhousev1alpha2.RBACReady)
+		g.Expect(cond).NotTo(BeNil())
+		g.Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+	}).Should(Succeed(), "RBACReady should be True after deprecated teamRef migration")
+}

--- a/e2e/teamrolebinding/scenarios/trb_deprecated_migration.go
+++ b/e2e/teamrolebinding/scenarios/trb_deprecated_migration.go
@@ -18,7 +18,7 @@ import (
 )
 
 // ExecuteDeprecatedTeamRefMigrationScenario verifies that the mutating webhook migrates the
-// deprecated singular teamRef field into teamRefs, and that RBAC is applied correctly afterwards.
+// deprecated singular teamRef field into teamRefs, and that RBAC is applied correctly.
 func (s *scenario) ExecuteDeprecatedTeamRefMigrationScenario(ctx context.Context) {
 	GinkgoHelper()
 	var trb *greenhousev1alpha2.TeamRoleBinding
@@ -27,28 +27,26 @@ func (s *scenario) ExecuteDeprecatedTeamRefMigrationScenario(ctx context.Context
 	By("creating a TeamRoleBinding using the deprecated teamRef field")
 	trb = s.createTRB(ctx, "trb-deprecated",
 		test.WithTeamRoleRef(s.teamRole.Name),
-		test.WithTeamRef(s.teamAlpha.Name), // deprecated singular field
+		test.WithTeamRef(s.teamAlpha.Name),
 		test.WithClusterName(s.clusterName),
 	)
 
-	By("verifying the webhook merged teamRef into teamRefs")
+	By("verifying the webhook migrated teamRef into teamRefs")
 	Eventually(func(g Gomega) {
 		g.Expect(s.adminClient.Get(ctx, client.ObjectKeyFromObject(trb), trb)).To(Succeed())
 		g.Expect(trb.Spec.TeamRefs).To(ContainElement(s.teamAlpha.Name),
-			"webhook should have migrated teamRef into teamRefs")
-	}).Should(Succeed(), "teamRef should be merged into teamRefs by the defaulting webhook")
+			"teamRefs should contain the migrated teamRef value")
+	}).Should(Succeed(), "teamRef should be migrated into teamRefs by the webhook")
 
-	By("verifying the ClusterRoleBinding is created on the remote cluster")
+	By("verifying the ClusterRoleBinding is created on the remote cluster with the correct subject")
 	remoteCRB := &rbacv1.ClusterRoleBinding{}
 	Eventually(func(g Gomega) {
 		g.Expect(s.remoteClient.Get(ctx, client.ObjectKey{Name: trb.GetRBACName()}, remoteCRB)).
 			To(Succeed(), "ClusterRoleBinding should exist on the remote cluster")
-	}).Should(Succeed(), "ClusterRoleBinding should be created after migration")
-
-	By("verifying the subjects contain the migrated team's IDP group")
-	Expect(slices.ContainsFunc(remoteCRB.Subjects, func(sub rbacv1.Subject) bool {
-		return sub.Kind == rbacv1.GroupKind && sub.Name == s.teamAlpha.Spec.MappedIDPGroup
-	})).To(BeTrue(), "subjects should contain teamAlpha's IDP group after migration")
+		g.Expect(slices.ContainsFunc(remoteCRB.Subjects, func(sub rbacv1.Subject) bool {
+			return sub.Kind == rbacv1.GroupKind && sub.Name == s.teamAlpha.Spec.MappedIDPGroup
+		})).To(BeTrue(), "subjects should contain teamAlpha's IDP group after migration")
+	}).Should(Succeed(), "ClusterRoleBinding should be created with the correct subject after teamRef migration")
 
 	By("verifying the TeamRoleBinding RBACReady status is True")
 	Eventually(func(g Gomega) {

--- a/e2e/teamrolebinding/scenarios/trb_multi_teams.go
+++ b/e2e/teamrolebinding/scenarios/trb_multi_teams.go
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package scenarios
+
+import (
+	"context"
+	"slices"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	greenhousev1alpha2 "github.com/cloudoperators/greenhouse/api/v1alpha2"
+	"github.com/cloudoperators/greenhouse/internal/test"
+)
+
+// ExecuteMultipleTeamRefsScenario verifies that a TeamRoleBinding with multiple entries in
+// teamRefs creates a ClusterRoleBinding whose subjects include all referenced teams' IDP groups.
+func (s *scenario) ExecuteMultipleTeamRefsScenario(ctx context.Context) {
+	GinkgoHelper()
+	var trb *greenhousev1alpha2.TeamRoleBinding
+	DeferCleanup(func() { s.cleanup(ctx, trb) })
+
+	By("creating a TeamRoleBinding referencing two teams")
+	trb = s.createTRB(ctx, "trb-multi",
+		test.WithTeamRoleRef(s.teamRole.Name),
+		test.WithTeamRefs(s.teamAlpha.Name, s.teamBeta.Name),
+		test.WithClusterName(s.clusterName),
+	)
+
+	By("verifying the ClusterRoleBinding is created on the remote cluster")
+	remoteCRB := &rbacv1.ClusterRoleBinding{}
+	Eventually(func(g Gomega) {
+		g.Expect(s.remoteClient.Get(ctx, client.ObjectKey{Name: trb.GetRBACName()}, remoteCRB)).
+			To(Succeed(), "ClusterRoleBinding should exist on the remote cluster")
+	}).Should(Succeed(), "ClusterRoleBinding should be created")
+
+	By("verifying the subjects contain IDP groups for both teams")
+	Expect(slices.ContainsFunc(remoteCRB.Subjects, func(sub rbacv1.Subject) bool {
+		return sub.Kind == rbacv1.GroupKind && sub.Name == s.teamAlpha.Spec.MappedIDPGroup
+	})).To(BeTrue(), "subjects should contain teamAlpha's IDP group")
+	Expect(slices.ContainsFunc(remoteCRB.Subjects, func(sub rbacv1.Subject) bool {
+		return sub.Kind == rbacv1.GroupKind && sub.Name == s.teamBeta.Spec.MappedIDPGroup
+	})).To(BeTrue(), "subjects should contain teamBeta's IDP group")
+
+	By("verifying the TeamRoleBinding RBACReady status is True")
+	Eventually(func(g Gomega) {
+		g.Expect(s.adminClient.Get(ctx, client.ObjectKeyFromObject(trb), trb)).To(Succeed())
+		cond := trb.Status.GetConditionByType(greenhousev1alpha2.RBACReady)
+		g.Expect(cond).NotTo(BeNil())
+		g.Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+	}).Should(Succeed(), "RBACReady should be True")
+}

--- a/e2e/teamrolebinding/scenarios/trb_multi_teams.go
+++ b/e2e/teamrolebinding/scenarios/trb_multi_teams.go
@@ -31,20 +31,18 @@ func (s *scenario) ExecuteMultipleTeamRefsScenario(ctx context.Context) {
 		test.WithClusterName(s.clusterName),
 	)
 
-	By("verifying the ClusterRoleBinding is created on the remote cluster")
+	By("verifying the ClusterRoleBinding is created on the remote cluster with subjects for both teams")
 	remoteCRB := &rbacv1.ClusterRoleBinding{}
 	Eventually(func(g Gomega) {
 		g.Expect(s.remoteClient.Get(ctx, client.ObjectKey{Name: trb.GetRBACName()}, remoteCRB)).
 			To(Succeed(), "ClusterRoleBinding should exist on the remote cluster")
-	}).Should(Succeed(), "ClusterRoleBinding should be created")
-
-	By("verifying the subjects contain IDP groups for both teams")
-	Expect(slices.ContainsFunc(remoteCRB.Subjects, func(sub rbacv1.Subject) bool {
-		return sub.Kind == rbacv1.GroupKind && sub.Name == s.teamAlpha.Spec.MappedIDPGroup
-	})).To(BeTrue(), "subjects should contain teamAlpha's IDP group")
-	Expect(slices.ContainsFunc(remoteCRB.Subjects, func(sub rbacv1.Subject) bool {
-		return sub.Kind == rbacv1.GroupKind && sub.Name == s.teamBeta.Spec.MappedIDPGroup
-	})).To(BeTrue(), "subjects should contain teamBeta's IDP group")
+		g.Expect(slices.ContainsFunc(remoteCRB.Subjects, func(sub rbacv1.Subject) bool {
+			return sub.Kind == rbacv1.GroupKind && sub.Name == s.teamAlpha.Spec.MappedIDPGroup
+		})).To(BeTrue(), "subjects should contain teamAlpha's IDP group")
+		g.Expect(slices.ContainsFunc(remoteCRB.Subjects, func(sub rbacv1.Subject) bool {
+			return sub.Kind == rbacv1.GroupKind && sub.Name == s.teamBeta.Spec.MappedIDPGroup
+		})).To(BeTrue(), "subjects should contain teamBeta's IDP group")
+	}).Should(Succeed(), "ClusterRoleBinding should be created with subjects for both teams")
 
 	By("verifying the TeamRoleBinding RBACReady status is True")
 	Eventually(func(g Gomega) {

--- a/e2e/teamrolebinding/scenarios/trb_mutation.go
+++ b/e2e/teamrolebinding/scenarios/trb_mutation.go
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package scenarios
+
+import (
+	"context"
+	"slices"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	greenhousev1alpha2 "github.com/cloudoperators/greenhouse/api/v1alpha2"
+	"github.com/cloudoperators/greenhouse/internal/clientutil"
+	"github.com/cloudoperators/greenhouse/internal/test"
+)
+
+// ExecuteTeamRefsMutationScenario verifies that updating teamRefs on an existing TeamRoleBinding
+// causes the ClusterRoleBinding subjects on the remote cluster to be updated accordingly.
+func (s *scenario) ExecuteTeamRefsMutationScenario(ctx context.Context) {
+	GinkgoHelper()
+	var trb *greenhousev1alpha2.TeamRoleBinding
+	DeferCleanup(func() { s.cleanup(ctx, trb) })
+
+	By("creating a TeamRoleBinding with a single team")
+	trb = s.createTRB(ctx, "trb-mutate",
+		test.WithTeamRoleRef(s.teamRole.Name),
+		test.WithTeamRefs(s.teamAlpha.Name),
+		test.WithClusterName(s.clusterName),
+	)
+
+	remoteCRB := &rbacv1.ClusterRoleBinding{}
+	By("verifying the initial ClusterRoleBinding has only teamAlpha subjects")
+	Eventually(func(g Gomega) {
+		g.Expect(s.remoteClient.Get(ctx, client.ObjectKey{Name: trb.GetRBACName()}, remoteCRB)).To(Succeed())
+		g.Expect(slices.ContainsFunc(remoteCRB.Subjects, func(sub rbacv1.Subject) bool {
+			return sub.Kind == rbacv1.GroupKind && sub.Name == s.teamAlpha.Spec.MappedIDPGroup
+		})).To(BeTrue(), "initially teamAlpha's IDP group should be in subjects")
+		g.Expect(slices.ContainsFunc(remoteCRB.Subjects, func(sub rbacv1.Subject) bool {
+			return sub.Kind == rbacv1.GroupKind && sub.Name == s.teamBeta.Spec.MappedIDPGroup
+		})).To(BeFalse(), "teamBeta's IDP group should not yet be in subjects")
+	}).Should(Succeed(), "initial subjects should only contain teamAlpha")
+
+	By("adding teamBeta to teamRefs")
+	_, err := clientutil.CreateOrPatch(ctx, s.adminClient, trb, func() error {
+		trb.Spec.TeamRefs = []string{s.teamAlpha.Name, s.teamBeta.Name}
+		return nil
+	})
+	Expect(err).ToNot(HaveOccurred(), "there should be no error adding teamBeta to teamRefs")
+
+	By("verifying ClusterRoleBinding subjects now include both teams")
+	Eventually(func(g Gomega) {
+		g.Expect(s.remoteClient.Get(ctx, client.ObjectKey{Name: trb.GetRBACName()}, remoteCRB)).To(Succeed())
+		g.Expect(slices.ContainsFunc(remoteCRB.Subjects, func(sub rbacv1.Subject) bool {
+			return sub.Kind == rbacv1.GroupKind && sub.Name == s.teamAlpha.Spec.MappedIDPGroup
+		})).To(BeTrue(), "teamAlpha's IDP group should remain in subjects")
+		g.Expect(slices.ContainsFunc(remoteCRB.Subjects, func(sub rbacv1.Subject) bool {
+			return sub.Kind == rbacv1.GroupKind && sub.Name == s.teamBeta.Spec.MappedIDPGroup
+		})).To(BeTrue(), "teamBeta's IDP group should now appear in subjects")
+	}).Should(Succeed(), "subjects should contain both teams after adding teamBeta")
+
+	By("removing teamAlpha from teamRefs")
+	_, err = clientutil.CreateOrPatch(ctx, s.adminClient, trb, func() error {
+		trb.Spec.TeamRefs = []string{s.teamBeta.Name}
+		return nil
+	})
+	Expect(err).ToNot(HaveOccurred(), "there should be no error removing teamAlpha from teamRefs")
+
+	By("verifying ClusterRoleBinding subjects now only contain teamBeta")
+	Eventually(func(g Gomega) {
+		g.Expect(s.remoteClient.Get(ctx, client.ObjectKey{Name: trb.GetRBACName()}, remoteCRB)).To(Succeed())
+		g.Expect(slices.ContainsFunc(remoteCRB.Subjects, func(sub rbacv1.Subject) bool {
+			return sub.Kind == rbacv1.GroupKind && sub.Name == s.teamAlpha.Spec.MappedIDPGroup
+		})).To(BeFalse(), "teamAlpha's IDP group should have been removed from subjects")
+		g.Expect(slices.ContainsFunc(remoteCRB.Subjects, func(sub rbacv1.Subject) bool {
+			return sub.Kind == rbacv1.GroupKind && sub.Name == s.teamBeta.Spec.MappedIDPGroup
+		})).To(BeTrue(), "teamBeta's IDP group should remain in subjects")
+	}).Should(Succeed(), "subjects should only contain teamBeta after removing teamAlpha")
+
+	By("verifying TeamRoleBinding status remains ready after mutation")
+	Eventually(func(g Gomega) {
+		g.Expect(s.adminClient.Get(ctx, client.ObjectKeyFromObject(trb), trb)).To(Succeed())
+		cond := trb.Status.GetConditionByType(greenhousev1alpha2.RBACReady)
+		g.Expect(cond).NotTo(BeNil())
+		g.Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+	}).Should(Succeed(), "RBACReady should stay True after mutation")
+}

--- a/e2e/teamrolebinding/scenarios/trb_namespace_creation.go
+++ b/e2e/teamrolebinding/scenarios/trb_namespace_creation.go
@@ -34,7 +34,7 @@ func (s *scenario) ExecuteNamespaceCreationScenario(ctx context.Context) {
 
 	var trb *greenhousev1alpha2.TeamRoleBinding
 	DeferCleanup(func() {
-		// Delete the TRB first.
+		// Delete the TRB first – this removes the RoleBindings but not the namespaces.
 		s.cleanup(ctx, trb)
 		// Explicitly remove the namespaces the TRB created on the remote cluster.
 		for _, ns := range []string{nsOne, nsTwo} {
@@ -54,37 +54,33 @@ func (s *scenario) ExecuteNamespaceCreationScenario(ctx context.Context) {
 		test.WithCreateNamespace(true),
 	)
 
-	By("verifying RoleBinding in namespace one is created on the remote cluster")
+	By("verifying RoleBinding in namespace one is created on the remote cluster with subjects for both teams")
 	rb1 := &rbacv1.RoleBinding{}
 	Eventually(func(g Gomega) {
 		g.Expect(s.remoteClient.Get(ctx,
 			types.NamespacedName{Name: trb.GetRBACName(), Namespace: nsOne},
 			rb1)).To(Succeed(), "RoleBinding in nsOne should exist on remote cluster")
-	}).Should(Succeed(), "RoleBinding should be created in nsOne")
+		g.Expect(slices.ContainsFunc(rb1.Subjects, func(sub rbacv1.Subject) bool {
+			return sub.Kind == rbacv1.GroupKind && sub.Name == s.teamAlpha.Spec.MappedIDPGroup
+		})).To(BeTrue(), "RoleBinding in nsOne should contain teamAlpha's IDP group")
+		g.Expect(slices.ContainsFunc(rb1.Subjects, func(sub rbacv1.Subject) bool {
+			return sub.Kind == rbacv1.GroupKind && sub.Name == s.teamBeta.Spec.MappedIDPGroup
+		})).To(BeTrue(), "RoleBinding in nsOne should contain teamBeta's IDP group")
+	}).Should(Succeed(), "RoleBinding should be created in nsOne with subjects for both teams")
 
-	By("verifying RoleBinding in namespace two is created on the remote cluster")
+	By("verifying RoleBinding in namespace two is created on the remote cluster with subjects for both teams")
 	rb2 := &rbacv1.RoleBinding{}
 	Eventually(func(g Gomega) {
 		g.Expect(s.remoteClient.Get(ctx,
 			types.NamespacedName{Name: trb.GetRBACName(), Namespace: nsTwo},
 			rb2)).To(Succeed(), "RoleBinding in nsTwo should exist on remote cluster")
-	}).Should(Succeed(), "RoleBinding should be created in nsTwo")
-
-	By("verifying RoleBinding subjects in nsOne include both teams' IDP groups")
-	Expect(slices.ContainsFunc(rb1.Subjects, func(sub rbacv1.Subject) bool {
-		return sub.Kind == rbacv1.GroupKind && sub.Name == s.teamAlpha.Spec.MappedIDPGroup
-	})).To(BeTrue(), "RoleBinding in nsOne should contain teamAlpha's IDP group")
-	Expect(slices.ContainsFunc(rb1.Subjects, func(sub rbacv1.Subject) bool {
-		return sub.Kind == rbacv1.GroupKind && sub.Name == s.teamBeta.Spec.MappedIDPGroup
-	})).To(BeTrue(), "RoleBinding in nsOne should contain teamBeta's IDP group")
-
-	By("verifying RoleBinding subjects in nsTwo include both teams' IDP groups")
-	Expect(slices.ContainsFunc(rb2.Subjects, func(sub rbacv1.Subject) bool {
-		return sub.Kind == rbacv1.GroupKind && sub.Name == s.teamAlpha.Spec.MappedIDPGroup
-	})).To(BeTrue(), "RoleBinding in nsTwo should contain teamAlpha's IDP group")
-	Expect(slices.ContainsFunc(rb2.Subjects, func(sub rbacv1.Subject) bool {
-		return sub.Kind == rbacv1.GroupKind && sub.Name == s.teamBeta.Spec.MappedIDPGroup
-	})).To(BeTrue(), "RoleBinding in nsTwo should contain teamBeta's IDP group")
+		g.Expect(slices.ContainsFunc(rb2.Subjects, func(sub rbacv1.Subject) bool {
+			return sub.Kind == rbacv1.GroupKind && sub.Name == s.teamAlpha.Spec.MappedIDPGroup
+		})).To(BeTrue(), "RoleBinding in nsTwo should contain teamAlpha's IDP group")
+		g.Expect(slices.ContainsFunc(rb2.Subjects, func(sub rbacv1.Subject) bool {
+			return sub.Kind == rbacv1.GroupKind && sub.Name == s.teamBeta.Spec.MappedIDPGroup
+		})).To(BeTrue(), "RoleBinding in nsTwo should contain teamBeta's IDP group")
+	}).Should(Succeed(), "RoleBinding should be created in nsTwo with subjects for both teams")
 
 	By("verifying the TeamRoleBinding RBACReady status is True")
 	Eventually(func(g Gomega) {

--- a/e2e/teamrolebinding/scenarios/trb_namespace_creation.go
+++ b/e2e/teamrolebinding/scenarios/trb_namespace_creation.go
@@ -9,9 +9,11 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/rand"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	greenhousev1alpha2 "github.com/cloudoperators/greenhouse/api/v1alpha2"
@@ -24,13 +26,24 @@ import (
 func (s *scenario) ExecuteNamespaceCreationScenario(ctx context.Context) {
 	GinkgoHelper()
 
-	const (
-		nsOne = "trb-e2e-ns-one"
-		nsTwo = "trb-e2e-ns-two"
-	)
+	// Use unique namespace names per run so that leftover resources from a previous
+	// failed run on a shared/long-lived cluster do not interfere.
+	suffix := rand.String(6)
+	nsOne := "trb-e2e-ns-one-" + suffix
+	nsTwo := "trb-e2e-ns-two-" + suffix
 
 	var trb *greenhousev1alpha2.TeamRoleBinding
-	DeferCleanup(func() { s.cleanup(ctx, trb) })
+	DeferCleanup(func() {
+		// Delete the TRB first.
+		s.cleanup(ctx, trb)
+		// Explicitly remove the namespaces the TRB created on the remote cluster.
+		for _, ns := range []string{nsOne, nsTwo} {
+			nsObj := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}
+			if err := s.remoteClient.Delete(ctx, nsObj); client.IgnoreNotFound(err) != nil {
+				GinkgoWriter.Printf("warning: could not delete namespace %s on remote cluster: %v\n", ns, err)
+			}
+		}
+	})
 
 	By("creating a TeamRoleBinding with createNamespaces=true referencing two teams")
 	trb = s.createTRB(ctx, "trb-ns-create",

--- a/e2e/teamrolebinding/scenarios/trb_namespace_creation.go
+++ b/e2e/teamrolebinding/scenarios/trb_namespace_creation.go
@@ -37,12 +37,10 @@ func (s *scenario) ExecuteNamespaceCreationScenario(ctx context.Context) {
 		// Delete the TRB first – this removes the RoleBindings but not the namespaces.
 		s.cleanup(ctx, trb)
 		// Explicitly remove the namespaces the TRB created on the remote cluster.
-		for _, ns := range []string{nsOne, nsTwo} {
-			nsObj := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}
-			if err := s.remoteClient.Delete(ctx, nsObj); client.IgnoreNotFound(err) != nil {
-				GinkgoWriter.Printf("warning: could not delete namespace %s on remote cluster: %v\n", ns, err)
-			}
-		}
+		nsOneObj := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: nsOne}}
+		test.EventuallyDeleted(ctx, s.remoteClient, nsOneObj)
+		nsTwoObj := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: nsTwo}}
+		test.EventuallyDeleted(ctx, s.remoteClient, nsTwoObj)
 	})
 
 	By("creating a TeamRoleBinding with createNamespaces=true referencing two teams")

--- a/e2e/teamrolebinding/scenarios/trb_namespace_creation.go
+++ b/e2e/teamrolebinding/scenarios/trb_namespace_creation.go
@@ -1,0 +1,83 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package scenarios
+
+import (
+	"context"
+	"slices"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	greenhousev1alpha2 "github.com/cloudoperators/greenhouse/api/v1alpha2"
+	"github.com/cloudoperators/greenhouse/internal/test"
+)
+
+// ExecuteNamespaceCreationScenario verifies that, when createNamespaces=true is set on a
+// TeamRoleBinding that references multiple teams, namespaces are created on the remote cluster
+// and each namespace receives a RoleBinding whose subjects include all teams' IDP groups.
+func (s *scenario) ExecuteNamespaceCreationScenario(ctx context.Context) {
+	GinkgoHelper()
+
+	const (
+		nsOne = "trb-e2e-ns-one"
+		nsTwo = "trb-e2e-ns-two"
+	)
+
+	var trb *greenhousev1alpha2.TeamRoleBinding
+	DeferCleanup(func() { s.cleanup(ctx, trb) })
+
+	By("creating a TeamRoleBinding with createNamespaces=true referencing two teams")
+	trb = s.createTRB(ctx, "trb-ns-create",
+		test.WithTeamRoleRef(s.teamRole.Name),
+		test.WithTeamRefs(s.teamAlpha.Name, s.teamBeta.Name),
+		test.WithClusterName(s.clusterName),
+		test.WithNamespaces(nsOne, nsTwo),
+		test.WithCreateNamespace(true),
+	)
+
+	By("verifying RoleBinding in namespace one is created on the remote cluster")
+	rb1 := &rbacv1.RoleBinding{}
+	Eventually(func(g Gomega) {
+		g.Expect(s.remoteClient.Get(ctx,
+			types.NamespacedName{Name: trb.GetRBACName(), Namespace: nsOne},
+			rb1)).To(Succeed(), "RoleBinding in nsOne should exist on remote cluster")
+	}).Should(Succeed(), "RoleBinding should be created in nsOne")
+
+	By("verifying RoleBinding in namespace two is created on the remote cluster")
+	rb2 := &rbacv1.RoleBinding{}
+	Eventually(func(g Gomega) {
+		g.Expect(s.remoteClient.Get(ctx,
+			types.NamespacedName{Name: trb.GetRBACName(), Namespace: nsTwo},
+			rb2)).To(Succeed(), "RoleBinding in nsTwo should exist on remote cluster")
+	}).Should(Succeed(), "RoleBinding should be created in nsTwo")
+
+	By("verifying RoleBinding subjects in nsOne include both teams' IDP groups")
+	Expect(slices.ContainsFunc(rb1.Subjects, func(sub rbacv1.Subject) bool {
+		return sub.Kind == rbacv1.GroupKind && sub.Name == s.teamAlpha.Spec.MappedIDPGroup
+	})).To(BeTrue(), "RoleBinding in nsOne should contain teamAlpha's IDP group")
+	Expect(slices.ContainsFunc(rb1.Subjects, func(sub rbacv1.Subject) bool {
+		return sub.Kind == rbacv1.GroupKind && sub.Name == s.teamBeta.Spec.MappedIDPGroup
+	})).To(BeTrue(), "RoleBinding in nsOne should contain teamBeta's IDP group")
+
+	By("verifying RoleBinding subjects in nsTwo include both teams' IDP groups")
+	Expect(slices.ContainsFunc(rb2.Subjects, func(sub rbacv1.Subject) bool {
+		return sub.Kind == rbacv1.GroupKind && sub.Name == s.teamAlpha.Spec.MappedIDPGroup
+	})).To(BeTrue(), "RoleBinding in nsTwo should contain teamAlpha's IDP group")
+	Expect(slices.ContainsFunc(rb2.Subjects, func(sub rbacv1.Subject) bool {
+		return sub.Kind == rbacv1.GroupKind && sub.Name == s.teamBeta.Spec.MappedIDPGroup
+	})).To(BeTrue(), "RoleBinding in nsTwo should contain teamBeta's IDP group")
+
+	By("verifying the TeamRoleBinding RBACReady status is True")
+	Eventually(func(g Gomega) {
+		g.Expect(s.adminClient.Get(ctx, client.ObjectKeyFromObject(trb), trb)).To(Succeed())
+		cond := trb.Status.GetConditionByType(greenhousev1alpha2.RBACReady)
+		g.Expect(cond).NotTo(BeNil())
+		g.Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+	}).Should(Succeed(), "RBACReady should be True after namespace creation with multiple teams")
+}

--- a/e2e/teamrolebinding/scenarios/trb_partial_failure.go
+++ b/e2e/teamrolebinding/scenarios/trb_partial_failure.go
@@ -36,17 +36,15 @@ func (s *scenario) ExecutePartialFailureScenario(ctx context.Context) {
 		test.WithClusterName(s.clusterName),
 	)
 
-	By("verifying the ClusterRoleBinding is still created for the valid team")
+	By("verifying the ClusterRoleBinding is still created for the valid team with the correct subject")
 	remoteCRB := &rbacv1.ClusterRoleBinding{}
 	Eventually(func(g Gomega) {
 		g.Expect(s.remoteClient.Get(ctx, client.ObjectKey{Name: trbPartial.GetRBACName()}, remoteCRB)).
 			To(Succeed(), "ClusterRoleBinding should be created despite the missing team")
-	}).Should(Succeed(), "ClusterRoleBinding should exist for the valid team")
-
-	By("verifying subjects contain only the valid team's IDP group")
-	Expect(slices.ContainsFunc(remoteCRB.Subjects, func(sub rbacv1.Subject) bool {
-		return sub.Kind == rbacv1.GroupKind && sub.Name == s.teamAlpha.Spec.MappedIDPGroup
-	})).To(BeTrue(), "subjects should contain teamAlpha's IDP group")
+		g.Expect(slices.ContainsFunc(remoteCRB.Subjects, func(sub rbacv1.Subject) bool {
+			return sub.Kind == rbacv1.GroupKind && sub.Name == s.teamAlpha.Spec.MappedIDPGroup
+		})).To(BeTrue(), "subjects should contain teamAlpha's IDP group")
+	}).Should(Succeed(), "ClusterRoleBinding should exist with the valid team's subject")
 
 	By("verifying the status reports the partial failure for the missing team")
 	Eventually(func(g Gomega) {

--- a/e2e/teamrolebinding/scenarios/trb_partial_failure.go
+++ b/e2e/teamrolebinding/scenarios/trb_partial_failure.go
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package scenarios
+
+import (
+	"context"
+	"slices"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	greenhousev1alpha2 "github.com/cloudoperators/greenhouse/api/v1alpha2"
+	"github.com/cloudoperators/greenhouse/internal/test"
+)
+
+// ExecutePartialFailureScenario covers two sub-cases:
+//  1. One valid team + one missing team → RBAC is applied for the valid team and the status
+//     message mentions the missing team.
+//  2. All referenced teams missing → RBACReady=False with TeamNotFound reason.
+func (s *scenario) ExecutePartialFailureScenario(ctx context.Context) {
+	GinkgoHelper()
+
+	// ── Sub-case 1: one valid, one non-existent ──────────────────────────────
+	By("Sub-case 1: one valid team and one non-existent team")
+	var trbPartial *greenhousev1alpha2.TeamRoleBinding
+	DeferCleanup(func() { s.cleanup(ctx, trbPartial) })
+
+	trbPartial = s.createTRB(ctx, "trb-partial",
+		test.WithTeamRoleRef(s.teamRole.Name),
+		test.WithTeamRefs(s.teamAlpha.Name, "non-existent-team"),
+		test.WithClusterName(s.clusterName),
+	)
+
+	By("verifying the ClusterRoleBinding is still created for the valid team")
+	remoteCRB := &rbacv1.ClusterRoleBinding{}
+	Eventually(func(g Gomega) {
+		g.Expect(s.remoteClient.Get(ctx, client.ObjectKey{Name: trbPartial.GetRBACName()}, remoteCRB)).
+			To(Succeed(), "ClusterRoleBinding should be created despite the missing team")
+	}).Should(Succeed(), "ClusterRoleBinding should exist for the valid team")
+
+	By("verifying subjects contain only the valid team's IDP group")
+	Expect(slices.ContainsFunc(remoteCRB.Subjects, func(sub rbacv1.Subject) bool {
+		return sub.Kind == rbacv1.GroupKind && sub.Name == s.teamAlpha.Spec.MappedIDPGroup
+	})).To(BeTrue(), "subjects should contain teamAlpha's IDP group")
+
+	By("verifying the status reports the partial failure for the missing team")
+	Eventually(func(g Gomega) {
+		g.Expect(s.adminClient.Get(ctx, client.ObjectKeyFromObject(trbPartial), trbPartial)).To(Succeed())
+		cond := trbPartial.Status.GetConditionByType(greenhousev1alpha2.RBACReady)
+		g.Expect(cond).NotTo(BeNil())
+		g.Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+		g.Expect(cond.Message).To(ContainSubstring("non-existent-team"),
+			"status message should mention the missing team")
+	}).Should(Succeed(), "status should reflect partial success with missing team information")
+
+	// ── Sub-case 2: all teams missing ────────────────────────────────────────
+	By("Sub-case 2: all referenced teams are missing")
+	var trbAllMissing *greenhousev1alpha2.TeamRoleBinding
+	DeferCleanup(func() { s.cleanup(ctx, trbAllMissing) })
+
+	trbAllMissing = s.createTRB(ctx, "trb-all-missing",
+		test.WithTeamRoleRef(s.teamRole.Name),
+		test.WithTeamRefs("ghost-team-1", "ghost-team-2"),
+		test.WithClusterName(s.clusterName),
+	)
+
+	By("verifying no ClusterRoleBinding is created on the remote cluster")
+	missingCRB := &rbacv1.ClusterRoleBinding{}
+	Consistently(func() bool {
+		return apierrors.IsNotFound(
+			s.remoteClient.Get(ctx, client.ObjectKey{Name: trbAllMissing.GetRBACName()}, missingCRB),
+		)
+	}, "15s", "2s").Should(BeTrue(), "ClusterRoleBinding should not be created when all teams are missing")
+
+	By("verifying RBACReady=False with TeamNotFound reason")
+	Eventually(func(g Gomega) {
+		g.Expect(s.adminClient.Get(ctx, client.ObjectKeyFromObject(trbAllMissing), trbAllMissing)).To(Succeed())
+		cond := trbAllMissing.Status.GetConditionByType(greenhousev1alpha2.RBACReady)
+		g.Expect(cond).NotTo(BeNil())
+		g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+		g.Expect(cond.Reason).To(Equal(greenhousev1alpha2.TeamNotFound))
+	}).Should(Succeed(), "RBACReady should be False when all referenced teams are missing")
+}

--- a/e2e/teamrolebinding/scenarios/trb_partial_failure.go
+++ b/e2e/teamrolebinding/scenarios/trb_partial_failure.go
@@ -67,14 +67,6 @@ func (s *scenario) ExecutePartialFailureScenario(ctx context.Context) {
 		test.WithClusterName(s.clusterName),
 	)
 
-	By("verifying no ClusterRoleBinding is created on the remote cluster")
-	missingCRB := &rbacv1.ClusterRoleBinding{}
-	Consistently(func() bool {
-		return apierrors.IsNotFound(
-			s.remoteClient.Get(ctx, client.ObjectKey{Name: trbAllMissing.GetRBACName()}, missingCRB),
-		)
-	}, "15s", "2s").Should(BeTrue(), "ClusterRoleBinding should not be created when all teams are missing")
-
 	By("verifying RBACReady=False with TeamNotFound reason")
 	Eventually(func(g Gomega) {
 		g.Expect(s.adminClient.Get(ctx, client.ObjectKeyFromObject(trbAllMissing), trbAllMissing)).To(Succeed())
@@ -83,4 +75,12 @@ func (s *scenario) ExecutePartialFailureScenario(ctx context.Context) {
 		g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
 		g.Expect(cond.Reason).To(Equal(greenhousev1alpha2.TeamNotFound))
 	}).Should(Succeed(), "RBACReady should be False when all referenced teams are missing")
+
+	By("verifying no ClusterRoleBinding is created on the remote cluster")
+	missingCRB := &rbacv1.ClusterRoleBinding{}
+	Consistently(func() bool {
+		return apierrors.IsNotFound(
+			s.remoteClient.Get(ctx, client.ObjectKey{Name: trbAllMissing.GetRBACName()}, missingCRB),
+		)
+	}, "5s", "200ms").Should(BeTrue(), "ClusterRoleBinding should not be created when all teams are missing")
 }

--- a/e2e/teamrolebinding/scenarios/trb_partial_failure.go
+++ b/e2e/teamrolebinding/scenarios/trb_partial_failure.go
@@ -12,6 +12,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/rand"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	greenhousev1alpha2 "github.com/cloudoperators/greenhouse/api/v1alpha2"
@@ -25,12 +26,15 @@ import (
 func (s *scenario) ExecutePartialFailureScenario(ctx context.Context) {
 	GinkgoHelper()
 
+	// Unique suffix per run to avoid collisions with leftover resources.
+	suffix := rand.String(6)
+
 	// ── Sub-case 1: one valid, one non-existent ──────────────────────────────
 	By("Sub-case 1: one valid team and one non-existent team")
 	var trbPartial *greenhousev1alpha2.TeamRoleBinding
 	DeferCleanup(func() { s.cleanup(ctx, trbPartial) })
 
-	trbPartial = s.createTRB(ctx, "trb-partial",
+	trbPartial = s.createTRB(ctx, "trb-partial-"+suffix,
 		test.WithTeamRoleRef(s.teamRole.Name),
 		test.WithTeamRefs(s.teamAlpha.Name, "non-existent-team"),
 		test.WithClusterName(s.clusterName),
@@ -61,7 +65,7 @@ func (s *scenario) ExecutePartialFailureScenario(ctx context.Context) {
 	var trbAllMissing *greenhousev1alpha2.TeamRoleBinding
 	DeferCleanup(func() { s.cleanup(ctx, trbAllMissing) })
 
-	trbAllMissing = s.createTRB(ctx, "trb-all-missing",
+	trbAllMissing = s.createTRB(ctx, "trb-all-missing-"+suffix,
 		test.WithTeamRoleRef(s.teamRole.Name),
 		test.WithTeamRefs("ghost-team-1", "ghost-team-2"),
 		test.WithClusterName(s.clusterName),

--- a/e2e/teamrolebinding/scenarios/trb_single_team.go
+++ b/e2e/teamrolebinding/scenarios/trb_single_team.go
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package scenarios
+
+import (
+	"context"
+	"slices"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	greenhousev1alpha2 "github.com/cloudoperators/greenhouse/api/v1alpha2"
+	"github.com/cloudoperators/greenhouse/internal/test"
+)
+
+// ExecuteSingleTeamRefScenario verifies that a TeamRoleBinding with a single entry in teamRefs
+// creates a ClusterRoleBinding on the remote cluster with the correct subjects.
+func (s *scenario) ExecuteSingleTeamRefScenario(ctx context.Context) {
+	GinkgoHelper()
+	var trb *greenhousev1alpha2.TeamRoleBinding
+	DeferCleanup(func() { s.cleanup(ctx, trb) })
+
+	By("creating a TeamRoleBinding with a single teamRefs entry")
+	trb = s.createTRB(ctx, "trb-single",
+		test.WithTeamRoleRef(s.teamRole.Name),
+		test.WithTeamRefs(s.teamAlpha.Name),
+		test.WithClusterName(s.clusterName),
+	)
+
+	By("verifying the ClusterRoleBinding is created on the remote cluster")
+	remoteCRB := &rbacv1.ClusterRoleBinding{}
+	Eventually(func(g Gomega) {
+		g.Expect(s.remoteClient.Get(ctx, client.ObjectKey{Name: trb.GetRBACName()}, remoteCRB)).
+			To(Succeed(), "ClusterRoleBinding should exist on the remote cluster")
+	}).Should(Succeed(), "ClusterRoleBinding should be created on the remote cluster")
+
+	By("verifying the subjects contain the team's IDP group")
+	Expect(slices.ContainsFunc(remoteCRB.Subjects, func(sub rbacv1.Subject) bool {
+		return sub.Kind == rbacv1.GroupKind && sub.Name == s.teamAlpha.Spec.MappedIDPGroup
+	})).To(BeTrue(), "subjects should contain the alpha team's IDP group")
+
+	By("verifying the TeamRoleBinding RBACReady status is True")
+	Eventually(func(g Gomega) {
+		g.Expect(s.adminClient.Get(ctx, client.ObjectKeyFromObject(trb), trb)).To(Succeed())
+		cond := trb.Status.GetConditionByType(greenhousev1alpha2.RBACReady)
+		g.Expect(cond).NotTo(BeNil())
+		g.Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+	}).Should(Succeed(), "RBACReady should be True")
+}

--- a/e2e/teamrolebinding/scenarios/trb_single_team.go
+++ b/e2e/teamrolebinding/scenarios/trb_single_team.go
@@ -17,31 +17,29 @@ import (
 	"github.com/cloudoperators/greenhouse/internal/test"
 )
 
-// ExecuteSingleTeamRefScenario verifies that a TeamRoleBinding with a single entry in teamRefs
-// creates a ClusterRoleBinding on the remote cluster with the correct subjects.
+// ExecuteSingleTeamRefScenario verifies that a TeamRoleBinding with a single entry in
+// teamRefs creates a ClusterRoleBinding whose subjects include that team's IDP group.
 func (s *scenario) ExecuteSingleTeamRefScenario(ctx context.Context) {
 	GinkgoHelper()
 	var trb *greenhousev1alpha2.TeamRoleBinding
 	DeferCleanup(func() { s.cleanup(ctx, trb) })
 
-	By("creating a TeamRoleBinding with a single teamRefs entry")
+	By("creating a TeamRoleBinding with a single team")
 	trb = s.createTRB(ctx, "trb-single",
 		test.WithTeamRoleRef(s.teamRole.Name),
 		test.WithTeamRefs(s.teamAlpha.Name),
 		test.WithClusterName(s.clusterName),
 	)
 
-	By("verifying the ClusterRoleBinding is created on the remote cluster")
+	By("verifying the ClusterRoleBinding is created on the remote cluster with the correct subject")
 	remoteCRB := &rbacv1.ClusterRoleBinding{}
 	Eventually(func(g Gomega) {
 		g.Expect(s.remoteClient.Get(ctx, client.ObjectKey{Name: trb.GetRBACName()}, remoteCRB)).
 			To(Succeed(), "ClusterRoleBinding should exist on the remote cluster")
-	}).Should(Succeed(), "ClusterRoleBinding should be created on the remote cluster")
-
-	By("verifying the subjects contain the team's IDP group")
-	Expect(slices.ContainsFunc(remoteCRB.Subjects, func(sub rbacv1.Subject) bool {
-		return sub.Kind == rbacv1.GroupKind && sub.Name == s.teamAlpha.Spec.MappedIDPGroup
-	})).To(BeTrue(), "subjects should contain the alpha team's IDP group")
+		g.Expect(slices.ContainsFunc(remoteCRB.Subjects, func(sub rbacv1.Subject) bool {
+			return sub.Kind == rbacv1.GroupKind && sub.Name == s.teamAlpha.Spec.MappedIDPGroup
+		})).To(BeTrue(), "subjects should contain teamAlpha's IDP group")
+	}).Should(Succeed(), "ClusterRoleBinding should be created with the correct subject")
 
 	By("verifying the TeamRoleBinding RBACReady status is True")
 	Eventually(func(g Gomega) {

--- a/e2e/teamrolebinding/testdata/organization.yaml
+++ b/e2e/teamrolebinding/testdata/organization.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+# Cluster Scoped Resource
+apiVersion: greenhouse.sap/v1alpha1
+kind: Organization
+metadata:
+  name: teamrolebinding-e2e
+spec:
+  description: e2e organization for teamrolebinding
+  displayName: TeamRoleBindingE2E
+  mappedOrgAdminIdPGroup: TEST_ORG_ADMIN


### PR DESCRIPTION
<!--
Please ensure the PR title follows the conventional commit format:
<type>(<scope>): description

For a list of accepted types and scopes see the workflow documentation: https://github.com/cloudoperators/greenhouse/blob/main/.github/workflows/ci-pr-title.yaml

-->
## Description
<!--
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
This PR adds E2E tests for multiple team refs introduced to TeamRoleBindings. Test scenarios are kept in separate files.

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 

- Related Issue # (issue)
- Closes # (issue)
- Fixes # (issue)

-->
- Closes #1874 

## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [x] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
