### PR TITLE
docs(teamrolebindings): multiple team refs in TRB

### DIFF
--- a/docs/getting-started/core-concepts/teams.md
+++ b/docs/getting-started/core-concepts/teams.md
@@ -30,8 +30,9 @@ kind: TeamRoleBinding
 metadata:
   name: observability-admin
 spec:
-  teamRef: observability
-  roleRef: cluster-admin
+  teamRoleRef: cluster-admin
+  teamRefs:
+    - observability
   clusterSelector:
     clusterName: observability
   namespaces:

--- a/docs/reference/components/teamrolebinding.md
+++ b/docs/reference/components/teamrolebinding.md
@@ -1,0 +1,175 @@
+---
+title: "TeamRoleBinding"
+linkTitle: "TeamRoleBinding"
+landingSectionIndex: false
+description: >
+  Reference documentation for the TeamRoleBinding resource.
+---
+
+A `TeamRoleBinding` assigns a `TeamRole` to one or more Teams (and/or individual usernames) for a set of Clusters and optionally a set of Namespaces. The Greenhouse controller translates a TeamRoleBinding into native Kubernetes `rbacv1` resources on each targeted remote cluster.
+
+## Example TeamRoleBinding Spec
+
+```yaml
+apiVersion: greenhouse.sap/v1alpha2
+kind: TeamRoleBinding
+metadata:
+  name: example-team-pod-read
+  namespace: example-organization
+spec:
+  teamRoleRef: pod-read
+  teamRefs:
+    - example-team
+    - dev-team
+  clusterSelector:
+    labelSelector:
+      matchLabels:
+        environment: production
+  namespaces:
+    - monitoring
+    - logging
+  createNamespaces: false
+```
+
+## Writing a TeamRoleBinding Spec
+
+### `.spec.teamRoleRef`
+
+**Required.** The name of the `TeamRole` resource (in the same namespace) that defines the set of RBAC permissions to grant.
+
+```yaml
+spec:
+  teamRoleRef: pod-read
+```
+
+Changing `teamRoleRef` after creation requires deleting and re-creating the TeamRoleBinding (the field is effectively immutable for the underlying `rbacv1` binding objects).
+
+### `.spec.teamRefs`
+
+**Recommended.** A list of `Team` resource names (in the same namespace) to grant access. Each team's `spec.mappedIdPGroup` is used as the `Group` subject in the generated `rbacv1.ClusterRoleBinding` or `rbacv1.RoleBinding` on the remote cluster.
+
+```yaml
+spec:
+  teamRefs:
+    - example-team
+    - dev-team
+```
+
+The subjects list on the remote cluster is the union of the IDP groups from all referenced teams plus any entries in `spec.usernames`.
+
+**Partial failure**: if one or more teams do not exist, Greenhouse still creates RBAC for the teams that do exist. The `RBACReady` status condition will contain the names of any missing teams. Only if _all_ referenced teams are missing will RBAC not be applied at all and `RBACReady` will be set to `False` with reason `TeamNotFound`.
+
+### `.spec.teamRef` (deprecated)
+
+> [!WARNING]
+> `spec.teamRef` is **deprecated**. Use `spec.teamRefs` instead.
+
+The singular `teamRef` field accepts a single team name for backwards compatibility. The mutating webhook automatically merges `teamRef` into `teamRefs` on every create or update, so existing resources are migrated lazily without any manual intervention required.
+
+If both `teamRef` and `teamRefs` are present, `teamRef` is appended to `teamRefs` (deduplicated) and then `teamRef` is cleared.
+
+### `.spec.usernames`
+
+An optional list of individual Kubernetes usernames to add as `User` subjects alongside the Team IDP groups.
+
+```yaml
+spec:
+  usernames:
+    - jane@example.com
+    - bot-ci-user
+```
+
+### `.spec.clusterSelector`
+
+Specifies which Clusters to target. Accepts either a direct cluster name or a label selector.
+
+**By name** (single cluster):
+
+```yaml
+spec:
+  clusterSelector:
+    clusterName: example-cluster
+```
+
+**By label** (one or more clusters):
+
+```yaml
+spec:
+  clusterSelector:
+    labelSelector:
+      matchLabels:
+        environment: production
+```
+
+When a cluster's labels change so that it no longer matches the selector, Greenhouse removes the RBAC resources from that cluster. When a new cluster gains matching labels, RBAC is automatically applied.
+
+### `.spec.namespaces`
+
+An optional list of Kubernetes namespace names on the remote cluster. When set, the controller creates a `rbacv1.RoleBinding` per namespace (namespace-scoped). When empty, a single `rbacv1.ClusterRoleBinding` is created (cluster-scoped).
+
+```yaml
+spec:
+  namespaces:
+    - monitoring
+    - logging
+```
+
+> [!NOTE]
+> The scope of a TeamRoleBinding (cluster-scoped vs. namespace-scoped) is determined at creation time and cannot be changed afterwards. A cluster-scoped binding cannot gain namespaces, and a namespace-scoped binding cannot be made cluster-scoped, without deleting and re-creating the resource.
+
+### `.spec.createNamespaces`
+
+When `true`, the controller creates any namespaces listed in `.spec.namespaces` that do not already exist on the remote cluster. Defaults to `false`. Deleting the TeamRoleBinding never deletes the created namespaces.
+
+```yaml
+spec:
+  createNamespaces: true
+```
+
+## Status
+
+### `.status.statusConditions`
+
+Contains a `RBACReady` condition and an overall `Ready` condition.
+
+| Condition | Status | Reason | Meaning |
+| --- | --- | --- | --- |
+| `RBACReady` | `True` | `RBACReconciled` | All RBAC resources applied successfully on all target clusters |
+| `RBACReady` | `False` | `RBACReconcileFailed` | One or more clusters could not be reconciled |
+| `RBACReady` | `False` | `TeamNotFound` | All referenced teams are missing; no RBAC was applied |
+| `RBACReady` | `False` | `TeamRoleNotFound` | The referenced TeamRole does not exist |
+| `RBACReady` | `False` | `EmptyClusterList` | The cluster selector matched no clusters |
+| `RBACReady` | `False` | `ClusterConnectionFailed` | Could not connect to a target cluster |
+
+### `.status.clusters`
+
+A per-cluster propagation status list. Each entry records the cluster name and the `RBACReady` condition for that specific cluster, enabling operators to see at a glance which clusters succeeded or failed.
+
+```yaml
+status:
+  clusters:
+    - clusterName: cluster-a
+      condition:
+        type: RBACReady
+        status: "True"
+        reason: RBACReconciled
+    - clusterName: cluster-b
+      condition:
+        type: RBACReady
+        status: "False"
+        reason: RBACReconcileFailed
+        message: "Failed to reconcile RoleBindings: ..."
+```
+
+## What gets applied to the remote cluster
+
+| Condition | Remote resource created |
+| --- | --- |
+| `spec.namespaces` is empty | One `rbacv1.ClusterRole` + one `rbacv1.ClusterRoleBinding` named `greenhouse:<TRB-name>` |
+| `spec.namespaces` is set | One `rbacv1.ClusterRole` + one `rbacv1.RoleBinding` per namespace, each named `greenhouse:<TRB-name>` |
+
+The `ClusterRole` is created from the `TeamRole`'s `spec.rules` (and `spec.aggregationRule` if present). The subjects of the binding are the union of the `MappedIDPGroup` values of all referenced Teams plus any `spec.usernames`.
+
+## Next Steps
+
+- [Team RBAC user guide](./../../../user-guides/team/rbac)

--- a/docs/user-guides/team/rbac.md
+++ b/docs/user-guides/team/rbac.md
@@ -34,7 +34,7 @@ This guide is intended for users who want to manage Role-Based Access Control (R
  1. Create/Update TeamRoles and TeamRoleBindings in the Organization namespace.
  2. View Teams and Clusters in the Organization namespace
 
-By default the necessary authorizations are provieded via the `role:<organization>:admin` RoleBinding that is granted to members of the Organizations Admin Team. You can check the permissions inside the Organization namespace by running the following command:
+By default the necessary authorizations are provided via the `role:<organization>:admin` RoleBinding that is granted to members of the Organizations Admin Team. You can check the permissions inside the Organization namespace by running the following command:
 
 ```bash
 kubectl auth can-i --list --namespace=<organization-namespace>
@@ -160,11 +160,11 @@ spec:
 
 ### Aggregating TeamRoles
 
-It is possible with Kubernetes RBAC to aggregate `rbacv1.ClusterRoles`. This is also supported for TeamRoles. All label specified on a TeamRole's `.spec.Labels` will be set on the `rbacv1.ClusterRole` created on the target cluster. This makes it possible to aggregate multiple `rbacv1.ClusterRole` resources by using a `rbacv1.AggregationRule`. This can be specified on a TeamRole by setting `.spec.aggregationRule`.
+It is possible with Kubernetes RBAC to aggregate rbacv1.ClusterRoles. This is also supported for TeamRoles. All label specified on a TeamRole's `.spec.Labels` will be set on the rbacv1.ClusterRole created on the target cluster. This makes it possible to aggregate multiple rbacv1.ClusterRole resources by using a rbacv1.AggregationRule. This can be specified on a TeamRole by setting `.spec.aggregationRule`.
 
 More details on the concept of Aggregated ClusterRoles can be found in the Kubernetes documentation: [Aggregated ClusterRoles](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#aggregated-clusterroles)
 
-> [!NOTE] A TeamRole is only created on a cluster if it is referenced by a TeamRoleBinding. If a TeamRole is not referenced by a TeamRoleBinding it will not be created on any target cluster. A TeamRoleBinding referencing a TeamRole with an aggregationRule will only provide the correct access, if there is at least one TeamRoleBinding referencing a TeamRole with the corresponding label deployed to the same cluster.
+> :information_source: A TeamRole is only created on a cluster if it is referenced by a TeamRoleBinding. If a TeamRole is not referenced by a TeamRoleBinding it will not be created on any target cluster. A TeamRoleBinding referencing a TeamRole with an aggregationRule will only provide the correct access, if there is at least one TeamRoleBinding referencing a TeamRole with the corresponding label deployed to the same cluster.
 
 The following example shows how an AggregationRule can be used with TeamRoles and TeamRoleBindings.
 

--- a/docs/user-guides/team/rbac.md
+++ b/docs/user-guides/team/rbac.md
@@ -1,8 +1,11 @@
 ---
 title: "Role-based access control on remote clusters"
+linkTitle: "RBAC on remote clusters"
+landingSectionIndex: false
 description: >
   Creating and managing RBAC for Teams on Greenhouse-managed remote clusters.
 ---
+
 ## Greenhouse Team RBAC user guide
 
 Role-Based Access Control (RBAC) in Greenhouse allows Organization administrators to manage the access of Teams on Clusters. TeamRole and TeamRoleBindings are used to manage the RBAC on remote Clusters. These two Custom Resource Definitions allow for fine-grained control over the permissions of each Team within each Cluster and Namespace.
@@ -15,38 +18,41 @@ Role-Based Access Control (RBAC) in Greenhouse allows Organization administrator
   - [Example](#example)
 - [Seeded default TeamRoles](#seeded-default-teamroles)
 - [Defining TeamRoleBindings](#defining-teamrolebindings)
-  - [Assigning TeamRoles to Teams on a single Cluster](#assigning-teamroles-to-teams-on-a-single-cluster)
+  - [Assigning a TeamRole to a single Team on a Cluster](#assigning-a-teamrole-to-a-single-team-on-a-cluster)
+  - [Assigning a TeamRole to multiple Teams on a Cluster](#assigning-a-teamrole-to-multiple-teams-on-a-cluster)
   - [Assigning TeamRoles to Teams on multiple Clusters](#assigning-teamroles-to-teams-on-multiple-clusters)
   - [Aggregating TeamRoles](#aggregating-teamroles)
+  - [Migrating from the deprecated teamRef field](#migrating-from-the-deprecated-teamref-field)
+- [Updating TeamRoleBindings](#updating-teamrolebindings)
 
 ## Before you begin
 
 This guide is intended for users who want to manage Role-Based Access Control (RBAC) for Teams on remote clusters managed by Greenhouse. It assumes you have a basic understanding of [Kubernetes RBAC concepts](https://kubernetes.io/docs/reference/access-authn-authz/rbac/) and the Greenhouse platform.
 
-🔑 Permissions
+🔑 **Permissions**
 
  1. Create/Update TeamRoles and TeamRoleBindings in the Organization namespace.
  2. View Teams and Clusters in the Organization namespace
 
-By default the necessary authorizations are provieded via the `role:<organization>:admin` RoleBinding that is granted to members of the Organizations Admin Team.
-You can check the permissions inside the Organization namespace by running the following command:
+By default the necessary authorizations are provieded via the `role:<organization>:admin` RoleBinding that is granted to members of the Organizations Admin Team. You can check the permissions inside the Organization namespace by running the following command:
 
 ```bash
 kubectl auth can-i --list --namespace=<organization-namespace>
 ```
 
-💻 Software
+💻 **Software**
 
 1. [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl): The Kubernetes command-line tool which allows you to manage Kubernetes cluster resources.
 
 ## Overview
 
 - **TeamRole**: Defines a set of permissions that can be assigned to teams and individual users.
-- **TeamRoleBinding**: Assigns a TeamRole to a specific Team and/or a list of users fo Clusters and (optionally) Namespaces.
+- **TeamRoleBinding**: Assigns a TeamRole to one or more Teams and/or a list of users for Clusters and (optionally) Namespaces.
+
 
 ## Defining TeamRoles
 
-TeamRoles define the actions a Team can perform on a Kubernetes cluster. For each Organziation a set of TeamRoles is [seeded](#seeded-default-teamroles). The syntax of the TeamRole's `.spec` is following the Kubernetes RBAC API.
+TeamRoles define the actions a Team can perform on a Kubernetes cluster. For each Organization a set of TeamRoles is [seeded](#seeded-default-teamroles). The syntax of the TeamRole's `.spec` is following the Kubernetes RBAC API.
 
 ### Example
 
@@ -72,22 +78,23 @@ spec:
 
 Greenhouse provides a set of [default TeamRoles](https://github.com/cloudoperators/greenhouse/blob/main/internal/controller/organization/teamrole_seeder.go) that are seeded to all clusters:
 
-| TeamRole                | Description                                                                                                                         | APIGroups | Resources                                                                             | Verbs                                                         |
-| ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------- | --------- | ------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
-| `cluster-admin`         | Full privileges                                                                                                                     | \*        | \*                                                                                    | \*                                                            |
-| `cluster-viewer`        | `get`, `list` and `watch` all resources                                                                                             | \*        | \*                                                                                    | `get`, `list`, `watch`                                        |
-| `cluster-developer`     | Aggregated role. Greenhouse aggregates the `application-developer` and the `cluster-viewer`. Further TeamRoles can be aggregated. |           |                                                                                       |                                                               |
-| `application-developer` | Set of permissions on `pods`, `deployments` and `statefulsets` necessary to develop applications on k8s                             | `apps`    | `deployments`, `statefulsets`                                                         | `patch`                                                       |
-|                         |                                                                                                                                     | ""        | `pods`, `pods/portforward`, `pods/eviction`, `pods/proxy`, `pods/log`, `pods/status`, | `get`, `list`, `watch`, `create`, `update`, `patch`, `delete` |
-| `node-maintainer`       | `get` and `patch` `nodes`                                                                                                           | ""        | `nodes`                                                                               | `get`, `patch`                                                |
-| `namespace-creator`     | All permissions on `namespaces`                                                                                                     | ""        | `namespaces`                                                                          | \*                                                            |
+| TeamRole                | Description                                                                                                                       | APIGroups | Resources                                                                              | Verbs                                                         |
+| ----------------------- | --------------------------------------------------------------------------------------------------------------------------------- | --------- | -------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
+| `cluster-admin`         | Full privileges                                                                                                                   | \*        | \*                                                                                     | \*                                                            |
+| `cluster-viewer`        | `get`, `list` and `watch` all resources                                                                                           | \*        | \*                                                                                     | `get`, `list`, `watch`                                        |
+| `cluster-developer`     | Aggregated role. Greenhouse aggregates the `application-developer` and the `cluster-viewer`. Further TeamRoles can be aggregated. |           |                                                                                        |                                                               |
+| `application-developer` | Set of permissions on `pods`, `deployments` and `statefulsets` necessary to develop applications on k8s                           | `apps`    | `deployments`, `statefulsets`                                                          | `patch`                                                       |
+|                         |                                                                                                                                   | `""`      | `pods`, `pods/portforward`, `pods/eviction`, `pods/proxy`, `pods/log`, `pods/status`,  | `get`, `list`, `watch`, `create`, `update`, `patch`, `delete` |
+| `node-maintainer`       | `get` and `patch` `nodes`                                                                                                         | `""`      | `nodes`                                                                                | `get`, `patch`                                                |
+| `namespace-creator`     | All permissions on `namespaces`                                                                                                   | `""`      | `namespaces`                                                                           | \*                                                            |
 
 ## Defining TeamRoleBindings
 
-TeamRoleBindings link a Team, a TeamRole, one or more Clusters and optionally one or more Namespaces together. Once the TeamRoleBinding is created, the Team will have the permissions defined in the TeamRole within the specified Clusters and Namespaces. This allows for fine-grained control over the permissions of each Team within each Cluster.
-The TeamRoleBinding Controller within Greenhouse deploys RBAC resources to the targeted Clusters. The referenced TeamRole is created as a rbacv1.ClusterRole. In case the TeamRoleBinding references a Namespace, it is considered to be namespace-scoped. Hence, the controller will create a rbacv1.RoleBinding which links the Team with the rbacv1.ClusterRole. In case no Namespace is referenced, the Controller will create a cluster-scoped rbacv1.ClusterRoleBinding instead.
+TeamRoleBindings link one or more Teams, a TeamRole, one or more Clusters and optionally one or more Namespaces together. Once the TeamRoleBinding is created, all referenced Teams will have the permissions defined in the TeamRole within the specified Clusters and Namespaces. This allows for fine-grained control over the permissions of each Team within each Cluster.
 
-### Assigning TeamRoles to Teams on a single Cluster
+The TeamRoleBinding Controller within Greenhouse deploys RBAC resources to the targeted Clusters. The referenced TeamRole is created as a `rbacv1.ClusterRole`. In case the TeamRoleBinding references a Namespace, it is considered to be namespace-scoped. Hence, the controller will create a `rbacv1.RoleBinding` which links the Team with the `rbacv1.ClusterRole`. In case no Namespace is referenced, the Controller will create a cluster-scoped `rbacv1.ClusterRoleBinding` instead.
+
+### Assigning a TeamRole to a single Team on a Cluster
 
 Roles are assigned to Teams through the TeamRoleBinding configuration, which links Teams to their respective roles within specific clusters.
 
@@ -101,15 +108,38 @@ kind: TeamRoleBinding
 metadata:
   name: my-team-read-access
 spec:
-  teamRef: my-team
-  roleRef: pod-read
+  teamRoleRef: pod-read
+  teamRefs:
+    - my-team
   clusterSelector:
     clusterName: my-cluster
 ```
 
+### Assigning a TeamRole to multiple Teams on a Cluster
+
+A single TeamRoleBinding can reference multiple Teams via the `teamRefs` field. All referenced Teams will be granted the same permissions defined in the TeamRole. Greenhouse collects the `MappedIDPGroup` from each Team and includes all of them as subjects in the resulting `rbacv1.ClusterRoleBinding` or `rbacv1.RoleBinding`.
+
+This TeamRoleBinding grants `pod-read` to two teams—`my-team` and `dev-team`—on the Cluster named `my-cluster`.
+
+```yaml
+apiVersion: greenhouse.sap/v1alpha2
+kind: TeamRoleBinding
+metadata:
+  name: my-team-read-access
+spec:
+  teamRoleRef: pod-read
+  teamRefs:
+    - my-team
+    - dev-team
+  clusterSelector:
+    clusterName: my-cluster
+```
+
+**Partial failure handling**: if one of the referenced teams does not exist, Greenhouse will still apply RBAC for the teams that do exist and record the missing team names in the `RBACReady` status condition. Only if all referenced teams are missing will RBAC not be applied at all.
+
 ### Assigning TeamRoles to Teams on multiple Clusters
 
-A LabelSelector can be used to assign a TeamRoleBinding to multiple Clusters.
+A `LabelSelector` can be used to assign a TeamRoleBinding to multiple Clusters.
 
 This TeamRoleBinding assigns the `pod-read` TeamRole to the Team named `my-team` in all Clusters that have the label `environment: production` set.
 
@@ -119,8 +149,9 @@ kind: TeamRoleBinding
 metadata:
   name: production-cluster-admins
 spec:
-  teamRef: my-team
-  roleRef: pod-read
+  teamRoleRef: pod-read
+  teamRefs:
+    - my-team
   clusterSelector:
     labelSelector:
       matchLabels:
@@ -129,11 +160,11 @@ spec:
 
 ### Aggregating TeamRoles
 
-It is possible with Kubernetes RBAC to aggregate rbacv1.ClusterRoles. This is also supported for TeamRoles. All label specified on a TeamRole's `.spec.Labels` will be set on the rbacv1.ClusterRole created on the target cluster. This makes it possible to aggregate multiple rbacv1.ClusterRole resources by using a rbacv1.AggregationRule. This can be specified on a TeamRole by setting `.spec.aggregationRule`.
+It is possible with Kubernetes RBAC to aggregate `rbacv1.ClusterRoles`. This is also supported for TeamRoles. All label specified on a TeamRole's `.spec.Labels` will be set on the `rbacv1.ClusterRole` created on the target cluster. This makes it possible to aggregate multiple `rbacv1.ClusterRole` resources by using a `rbacv1.AggregationRule`. This can be specified on a TeamRole by setting `.spec.aggregationRule`.
 
 More details on the concept of Aggregated ClusterRoles can be found in the Kubernetes documentation: [Aggregated ClusterRoles](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#aggregated-clusterroles)
 
-[!NOTE] A TeamRole is only created on a cluster if it is referenced by a TeamRoleBinding. If a TeamRole is not referenced by a TeamRoleBinding it will not be created on any target cluster. A TeamRoleBinding referencing a TeamRole with an aggregationRule will only provide the correct access, if there is at least one TeamRoleBinding referencing a TeamRole with the corresponding label deployed to the same cluster.
+> [!NOTE] A TeamRole is only created on a cluster if it is referenced by a TeamRoleBinding. If a TeamRole is not referenced by a TeamRoleBinding it will not be created on any target cluster. A TeamRoleBinding referencing a TeamRole with an aggregationRule will only provide the correct access, if there is at least one TeamRoleBinding referencing a TeamRole with the corresponding label deployed to the same cluster.
 
 The following example shows how an AggregationRule can be used with TeamRoles and TeamRoleBindings.
 
@@ -165,8 +196,9 @@ kind: TeamRoleBinding
 metadata:
   name: production-pod-read
 spec:
-  teamRef: my-team
-  roleRef: pod-read
+  teamRoleRef: pod-read
+  teamRefs:
+    - my-team
   clusterSelector:
     labelSelector:
       matchLabels:
@@ -184,8 +216,9 @@ kind: TeamRoleBinding
 metadata:
   name: production-pod-read
 spec:
-  teamRef: my-team
-  roleRef: pod-read
+  teamRoleRef: pod-read
+  teamRefs:
+    - my-team
   clusterSelector:
     labelSelector:
       matchLabels:
@@ -215,18 +248,63 @@ kind: TeamRoleBinding
 metadata:
   name: aggregated-rolebinding
 spec:
-  teamRef: operators
-  roleRef: aggregated-role
+  teamRoleRef: aggregated-role
+  teamRefs:
+    - my-team
   clusterSelector:
     labelSelector:
       matchLabels:
         environment: production
 ```
 
-### Updating TeamRoleBindings
+### Migrating from the deprecated teamRef field
+
+> [!WARNING]
+> `spec.teamRef` (singular) is **deprecated**. Use `spec.teamRefs` (plural list) instead.
+
+Existing TeamRoleBindings that still use the singular `teamRef` field are migrated automatically and lazily by the mutating webhook: the first time such a resource is created or updated, the webhook appends the value of `spec.teamRef` to `spec.teamRefs` (deduplicating if needed) and clears `spec.teamRef`. No manual migration is required for existing resources—they are migrated in-place on the next write.
+
+**Before (deprecated)**:
+
+```yaml
+apiVersion: greenhouse.sap/v1alpha2
+kind: TeamRoleBinding
+metadata:
+  name: my-team-read-access
+spec:
+  teamRoleRef: pod-read
+  teamRef: my-team          # deprecated singular field
+  clusterSelector:
+    clusterName: my-cluster
+```
+
+**After (recommended)**:
+
+```yaml
+apiVersion: greenhouse.sap/v1alpha2
+kind: TeamRoleBinding
+metadata:
+  name: my-team-read-access
+spec:
+  teamRoleRef: pod-read
+  teamRefs:                 # preferred plural field
+    - my-team
+  clusterSelector:
+    clusterName: my-cluster
+```
+
+> [!NOTE]
+> If both `teamRef` and `teamRefs` are set on a resource, the webhook merges `teamRef` into `teamRefs` and deduplicates the list. `teamRefs` always takes precedence.
+
+## Updating TeamRoleBindings
 
 Updating the RoleRef of a ClusterRoleBinding and RoleBinding is not allowed, but requires recreating the TeamRoleBinding resources. See [ClusterRoleBinding docs](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#clusterrolebinding-example) for more information.
 This is to allow giving out permissions to update the subjects, while avoiding that privileges are changed. Furthermore, changing the TeamRole can change the extent of a binding significantly. Therefore it needs to be recreated.
 
-After the TeamRoleBinding has been created, it can be updated with some limitations. Similarly to RoleBindings, the `.spec.roleRef` and `.spec.teamRef` can not be changed.
+After the TeamRoleBinding has been created, it can be updated with some limitations. Similarly to RoleBindings, the `.spec.roleRef` and `.spec.teamRefs` cannot be changed.
+
 The TeamRoleBinding's `.spec.namespaces` can be amended to include more namespaces. However, the scope of the TeamRoleBinding cannot be changed. If a TeamRoleBinding has been created with `.spec.namespaces` specified, it is namespace-scoped, and cannot be changed to cluster-scoped by removing the `.spec.namespaces`. The reverse is true for a cluster-scoped TeamRoleBinding, where it is not possible to add `.spec.namespaces` once created.
+
+## Next Steps
+
+- [TeamRoleBinding reference](./../../../reference/components/teamrolebinding)

--- a/types/typescript/schema.d.ts
+++ b/types/typescript/schema.d.ts
@@ -361,6 +361,22 @@ export interface components {
             };
             /** @description ClusterPluginDefinitionStatus defines the observed state of ClusterPluginDefinition. */
             status?: {
+                /** @description LastSyncedArtifact tracks the last synced chart artifact and its replication status. */
+                lastSyncedArtifact?: {
+                    /** @description ChartName is the name of the chart. */
+                    chartName: string;
+                    /** @description Digest is the sha256 digest of the chart manifest. */
+                    digest?: string;
+                    /** @description Registry is the source registry of the chart. */
+                    registry: string;
+                    /**
+                     * @description ReplicationStatus indicates the outcome of replication to the mirror registry.
+                     * @enum {string}
+                     */
+                    replicationStatus: "Replicated" | "Failed" | "Skipped";
+                    /** @description Version is the chart version. */
+                    version: string;
+                };
                 /** @description StatusConditions contain the different conditions that constitute the status of the Plugin. */
                 statusConditions?: {
                     conditions?: {
@@ -458,15 +474,9 @@ export interface components {
                         /** @description Name of the node. */
                         name: string;
                     }[];
-                    /**
-                     * Format: int32
-                     * @description ReadyNodes represent the number of ready nodes in the cluster.
-                     */
+                    /** @description ReadyNodes represent the number of ready nodes in the cluster. */
                     ready?: number;
-                    /**
-                     * Format: int32
-                     * @description Total represent the number of all the nodes in the cluster.
-                     */
+                    /** @description Total represent the number of all the nodes in the cluster. */
                     total?: number;
                 };
                 /** @description StatusConditions contain the different conditions that constitute the status of the Cluster. */
@@ -753,6 +763,22 @@ export interface components {
             };
             /** @description PluginDefinitionStatus defines the observed state of PluginDefinition */
             status?: {
+                /** @description LastSyncedArtifact tracks the last synced chart artifact and its replication status. */
+                lastSyncedArtifact?: {
+                    /** @description ChartName is the name of the chart. */
+                    chartName: string;
+                    /** @description Digest is the sha256 digest of the chart manifest. */
+                    digest?: string;
+                    /** @description Registry is the source registry of the chart. */
+                    registry: string;
+                    /**
+                     * @description ReplicationStatus indicates the outcome of replication to the mirror registry.
+                     * @enum {string}
+                     */
+                    replicationStatus: "Replicated" | "Failed" | "Skipped";
+                    /** @description Version is the chart version. */
+                    version: string;
+                };
                 /** @description StatusConditions contain the different conditions that constitute the status of the Plugin. */
                 statusConditions?: {
                     conditions?: {
@@ -1328,6 +1354,12 @@ export interface components {
                     /** @description Status is the status of a HelmChart release. */
                     status: string;
                 };
+                /**
+                 * @description ImageReplication contains a list of container image references that have been
+                 *     successfully replicated to the configured mirror registry.
+                 *     Used to skip redundant replication on subsequent reconciliations.
+                 */
+                imageReplication?: string[];
                 /** @description LastReconciledAt contains the value when the reconcile was last triggered via annotation. */
                 lastReconciledAt?: string;
                 /** @description StatusConditions contain the different conditions that constitute the status of the Plugin. */
@@ -1456,8 +1488,13 @@ export interface components {
                  *     If empty, a ClusterRoleBinding will be created on the remote cluster, otherwise a RoleBinding per namespace.
                  */
                 namespaces?: string[];
-                /** @description TeamRef references a Greenhouse Team by name */
+                /**
+                 * @description Deprecated: Use TeamRefs instead.
+                 *     TeamRef references a Greenhouse Team by name
+                 */
                 teamRef?: string;
+                /** @description TeamRefs references Greenhouse Teams by name */
+                teamRefs?: string[];
                 /** @description TeamRoleRef references a Greenhouse TeamRole by name */
                 teamRoleRef?: string;
                 /** @description Usernames defines list of users to add to the (Cluster-)RoleBindings */


### PR DESCRIPTION
<!--
Please ensure the PR title follows the conventional commit format:
<type>(<scope>): description

For a list of accepted types and scopes see the workflow documentation: https://github.com/cloudoperators/greenhouse/blob/main/.github/workflows/ci-pr-title.yaml

-->

## Description
<!--
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
This PR updates the documentation for TeamRoleBindings, especially about the changes with multiple teamRefs.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [x] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 

- Related Issue # (issue)
- Closes # (issue)
- Fixes # (issue)

-->
- Closes #1876 

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Added to documentation?

- [ ] 📜 README.md
- [x] 🤝 Documentation pages updated
- [ ] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
