### PR TITLE
feat(e2e): add OCI replication e2e test suite

### DIFF
--- a/e2e/plugin/e2e_test.go
+++ b/e2e/plugin/e2e_test.go
@@ -127,4 +127,24 @@ var _ = Describe("Plugin E2E", Ordered, func() {
 		By("executing the plugin integration scenario with plugin reference by label selector")
 		scenarios.PluginIntegrationBySelector(ctx, adminClient, remoteClient, env, remoteIntegrationCluster)
 	})
+
+	Context("OCI image replication", Ordered, func() {
+		BeforeAll(func() {
+			By("configuring mirror registry for OCI image replication tests")
+			shared.SetupOCIMirroringForOrg(ctx, adminClient, env.TestNamespace)
+		})
+
+		AfterAll(func() {
+			By("removing mirror registry configuration")
+			shared.TeardownOCIMirroringForOrg(ctx, adminClient, env.TestNamespace)
+		})
+
+		It("should replicate container images to registry mirror before HelmRelease", func() {
+			scenarios.PluginImageReplication(ctx, adminClient, remoteClient, env, remoteClusterName)
+		})
+
+		It("should block HelmRelease creation when image replication fails", func() {
+			scenarios.PluginImageReplicationFailure(ctx, adminClient, env, remoteClusterName)
+		})
+	})
 })

--- a/e2e/plugin/scenarios/plugin_image_replication.go
+++ b/e2e/plugin/scenarios/plugin_image_replication.go
@@ -1,0 +1,176 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package scenarios
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	greenhousev1alpha1 "github.com/cloudoperators/greenhouse/api/v1alpha1"
+	"github.com/cloudoperators/greenhouse/e2e/shared"
+	"github.com/cloudoperators/greenhouse/internal/test"
+	"github.com/cloudoperators/greenhouse/pkg/lifecycle"
+)
+
+// PluginImageReplication verifies that the Plugin controller pre-replicates container images via the registry mirror before applying the HelmRelease.
+func PluginImageReplication(ctx context.Context, adminClient, remoteClient client.Client, env *shared.TestEnv, remoteClusterName string) {
+	pd := shared.PrepareOCIPodInfoPluginDefinition("podinfo-image-replication", env.TestNamespace)
+
+	By("creating PluginDefinition and waiting for chart replication")
+	err := adminClient.Create(ctx, pd)
+	Expect(client.IgnoreAlreadyExists(err)).ToNot(HaveOccurred())
+	DeferCleanup(func() { test.EventuallyDeleted(ctx, adminClient, pd) })
+
+	Eventually(func(g Gomega) {
+		g.Expect(adminClient.Get(ctx, client.ObjectKeyFromObject(pd), pd)).To(Succeed())
+		cond := pd.Status.StatusConditions.GetConditionByType(greenhousev1alpha1.OCIReplicationReadyCondition)
+		g.Expect(cond).NotTo(BeNil())
+		g.Expect(cond.IsTrue()).To(BeTrue())
+		g.Expect(cond.Reason).To(Equal(greenhousev1alpha1.OCIReplicationSucceededReason))
+	}).WithTimeout(shared.OCIReplicationTimeout).Should(Succeed(), "chart must be replicated before Plugin creation")
+
+	By("creating Plugin targeting the remote cluster")
+	plugin := test.NewPlugin(ctx, "podinfo-image-replication", env.TestNamespace,
+		test.WithPluginDefinition(pd.Name),
+		test.WithCluster(remoteClusterName),
+		test.WithReleaseName("podinfo-image-replication"),
+		test.WithReleaseNamespace(env.TestNamespace),
+	)
+	err = adminClient.Create(ctx, plugin)
+	Expect(client.IgnoreAlreadyExists(err)).ToNot(HaveOccurred())
+	DeferCleanup(func() { test.EventuallyDeleted(ctx, adminClient, plugin) })
+
+	By("verifying image replication is recorded in Plugin status with upstream refs")
+	Eventually(func(g Gomega) {
+		g.Expect(adminClient.Get(ctx, client.ObjectKeyFromObject(plugin), plugin)).To(Succeed())
+		g.Expect(plugin.Status.ImageReplication).NotTo(BeEmpty(),
+			"Plugin controller should have replicated container images via the registry mirror")
+		g.Expect(plugin.Status.ImageReplication).To(ContainElement(ContainSubstring("ghcr.io/stefanprodan/podinfo")),
+			"imageReplication should record upstream ref, not the mirrored one")
+	}).WithTimeout(shared.OCIReplicationTimeout).Should(Succeed())
+
+	By("verifying HelmReleaseCreated condition is True with no ImageReplicationFailed reason")
+	Eventually(func(g Gomega) {
+		g.Expect(adminClient.Get(ctx, client.ObjectKeyFromObject(plugin), plugin)).To(Succeed())
+		cond := plugin.Status.StatusConditions.GetConditionByType(greenhousev1alpha1.HelmReleaseCreatedCondition)
+		g.Expect(cond).NotTo(BeNil())
+		g.Expect(cond.IsTrue()).To(BeTrue())
+		g.Expect(cond.Reason).NotTo(Equal(greenhousev1alpha1.ImageReplicationFailedReason),
+			"HelmRelease creation must not be blocked by image replication failure")
+	}).WithTimeout(shared.OCIReplicationTimeout).Should(Succeed())
+
+	By("verifying Plugin is Ready")
+	Eventually(func(g Gomega) {
+		g.Expect(adminClient.Get(ctx, client.ObjectKeyFromObject(plugin), plugin)).To(Succeed())
+		g.Expect(plugin.Status.IsReadyTrue()).To(BeTrue())
+	}).WithTimeout(shared.OCIReplicationTimeout).Should(Succeed())
+
+	By("verifying image replication is idempotent on re-reconciliation")
+	Expect(adminClient.Get(ctx, client.ObjectKeyFromObject(plugin), plugin)).To(Succeed())
+	originalImageReplication := append([]string(nil), plugin.Status.ImageReplication...)
+
+	ann := plugin.GetAnnotations()
+	if ann == nil {
+		ann = make(map[string]string)
+	}
+	ann[lifecycle.ReconcileAnnotation] = time.Now().UTC().Format(time.RFC3339Nano)
+	plugin.SetAnnotations(ann)
+	Expect(adminClient.Update(ctx, plugin)).To(Succeed())
+
+	Eventually(func(g Gomega) {
+		g.Expect(adminClient.Get(ctx, client.ObjectKeyFromObject(plugin), plugin)).To(Succeed())
+		g.Expect(plugin.Status.IsReadyTrue()).To(BeTrue())
+		g.Expect(plugin.Status.ImageReplication).To(Equal(originalImageReplication),
+			"re-reconciliation must not change the image replication list")
+	}).WithTimeout(shared.OCIReplicationTimeout).Should(Succeed())
+
+	By("verifying PostRenderer rewrote container images to baseDomain on remote cluster")
+	Eventually(func(g Gomega) {
+		podList := &corev1.PodList{}
+		g.Expect(remoteClient.List(ctx, podList, client.InNamespace(env.TestNamespace))).To(Succeed())
+		g.Expect(podList.Items).NotTo(BeEmpty(), "pods should be running on remote cluster")
+		g.Expect(podList.Items).To(ContainElement(
+			HaveField("Spec.Containers", ContainElement(
+				HaveField("Image", HavePrefix("registry:5000/greenhouse-ghcr-io-mirror/stefanprodan/podinfo")),
+			)),
+		), "PostRenderer should rewrite podinfo image to baseDomain/subPath/repo")
+	}).WithTimeout(shared.OCIReplicationTimeout).Should(Succeed())
+}
+
+// PluginImageReplicationFailure verifies that the Plugin controller sets HelmReleaseCreated=False with ImageReplicationFailed when the primaryMirror is unreachable.
+func PluginImageReplicationFailure(ctx context.Context, adminClient client.Client, env *shared.TestEnv, remoteClusterName string) {
+	DeferCleanup(func() {
+		By("restoring ConfigMap to valid primaryMirror")
+		shared.CreateMirrorConfigMap(ctx, adminClient, env.TestNamespace)
+	})
+
+	By("breaking primaryMirror in ConfigMap to simulate unreachable registry")
+	mirrorCM := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "oci-replication-config",
+			Namespace: env.TestNamespace,
+		},
+	}
+	_, err := controllerutil.CreateOrUpdate(ctx, adminClient, mirrorCM, func() error {
+		mirrorCM.Data = map[string]string{
+			"containerRegistryConfig": `primaryMirror: "broken-registry:9999"
+registryMirrors:
+  ghcr.io:
+    baseDomain: "broken-cdn:9999"
+    subPath: "greenhouse-ghcr-io-mirror"`,
+		}
+		return nil
+	})
+	Expect(err).ToNot(HaveOccurred())
+
+	pd := shared.PrepareOCIPodInfoPluginDefinition("podinfo-image-failure", env.TestNamespace)
+
+	By("creating PluginDefinition - registry:5000 does not match broken primaryMirror, replication not configured")
+	err = adminClient.Create(ctx, pd)
+	Expect(client.IgnoreAlreadyExists(err)).ToNot(HaveOccurred())
+	DeferCleanup(func() { test.EventuallyDeleted(ctx, adminClient, pd) })
+
+	By("verifying OCIReplicationNotConfigured is True for the PluginDefinition")
+	Eventually(func(g Gomega) {
+		g.Expect(adminClient.Get(ctx, client.ObjectKeyFromObject(pd), pd)).To(Succeed())
+		cond := pd.Status.StatusConditions.GetConditionByType(greenhousev1alpha1.OCIReplicationReadyCondition)
+		g.Expect(cond).NotTo(BeNil())
+		g.Expect(cond.IsTrue()).To(BeTrue())
+		g.Expect(cond.Reason).To(Equal(greenhousev1alpha1.OCIReplicationNotConfiguredReason))
+	}).WithTimeout(shared.OCIReplicationTimeout).Should(Succeed())
+
+	By("waiting for PluginDefinition Ready - Flux fetches chart directly from registry:5000")
+	Eventually(func(g Gomega) {
+		g.Expect(adminClient.Get(ctx, client.ObjectKeyFromObject(pd), pd)).To(Succeed())
+		g.Expect(pd.Status.IsReadyTrue()).To(BeTrue())
+	}).WithTimeout(shared.OCIReplicationTimeout).Should(Succeed())
+
+	plugin := test.NewPlugin(ctx, "podinfo-image-failure", env.TestNamespace,
+		test.WithPluginDefinition(pd.Name),
+		test.WithCluster(remoteClusterName),
+		test.WithReleaseName("podinfo-image-failure"),
+		test.WithReleaseNamespace(env.TestNamespace),
+	)
+
+	By("creating Plugin - image replication to broken-registry:9999 should fail")
+	err = adminClient.Create(ctx, plugin)
+	Expect(client.IgnoreAlreadyExists(err)).ToNot(HaveOccurred())
+	DeferCleanup(func() { test.EventuallyDeleted(ctx, adminClient, plugin) })
+
+	By("verifying HelmReleaseCreated is False with ImageReplicationFailed reason")
+	Eventually(func(g Gomega) {
+		g.Expect(adminClient.Get(ctx, client.ObjectKeyFromObject(plugin), plugin)).To(Succeed())
+		cond := plugin.Status.StatusConditions.GetConditionByType(greenhousev1alpha1.HelmReleaseCreatedCondition)
+		g.Expect(cond).NotTo(BeNil())
+		g.Expect(cond.IsTrue()).To(BeFalse())
+		g.Expect(cond.Reason).To(Equal(greenhousev1alpha1.ImageReplicationFailedReason))
+	}).WithTimeout(shared.OCIReplicationTimeout).Should(Succeed(), "Plugin controller should block HelmRelease creation on image replication failure")
+}

--- a/e2e/plugin/scenarios/plugin_image_replication.go
+++ b/e2e/plugin/scenarios/plugin_image_replication.go
@@ -22,7 +22,14 @@ import (
 
 // PluginImageReplication verifies that the Plugin controller pre-replicates container images via the registry mirror before applying the HelmRelease.
 func PluginImageReplication(ctx context.Context, adminClient, remoteClient client.Client, env *shared.TestEnv, remoteClusterName string) {
-	pd := shared.PrepareOCIPodInfoPluginDefinition("podinfo-image-replication", env.TestNamespace)
+	pd := test.NewPluginDefinition(ctx, "podinfo-image-replication", env.TestNamespace,
+		test.WithPluginDefinitionVersion("6.7.1"),
+		test.WithPluginDefinitionHelmChart(&greenhousev1alpha1.HelmChartReference{
+			Name:       "podinfo",
+			Repository: "oci://registry:5000/greenhouse-ghcr-io-mirror/stefanprodan/charts",
+			Version:    "6.7.1",
+		}),
+	)
 
 	By("creating PluginDefinition and waiting for chart replication")
 	err := adminClient.Create(ctx, pd)
@@ -131,7 +138,14 @@ registryMirrors:
 	})
 	Expect(err).ToNot(HaveOccurred())
 
-	pd := shared.PrepareOCIPodInfoPluginDefinition("podinfo-image-failure", env.TestNamespace)
+	pd := test.NewPluginDefinition(ctx, "podinfo-image-failure", env.TestNamespace,
+		test.WithPluginDefinitionVersion("6.7.1"),
+		test.WithPluginDefinitionHelmChart(&greenhousev1alpha1.HelmChartReference{
+			Name:       "podinfo",
+			Repository: "oci://registry:5000/greenhouse-ghcr-io-mirror/stefanprodan/charts",
+			Version:    "6.7.1",
+		}),
+	)
 
 	By("creating PluginDefinition - registry:5000 does not match broken primaryMirror, replication not configured")
 	err = adminClient.Create(ctx, pd)

--- a/e2e/plugindefinition/e2e_test.go
+++ b/e2e/plugindefinition/e2e_test.go
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build plugindefinitionE2E
+
+package plugindefinition
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	"github.com/cloudoperators/greenhouse/e2e/plugindefinition/scenarios"
+	"github.com/cloudoperators/greenhouse/e2e/shared"
+	"github.com/cloudoperators/greenhouse/internal/clientutil"
+)
+
+var (
+	env           *shared.TestEnv
+	ctx           context.Context
+	adminClient   client.Client
+	testStartTime time.Time
+)
+
+func TestE2e(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "PluginDefinition E2E Suite")
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+	ctx = context.Background()
+	env = shared.NewExecutionEnv()
+
+	var err error
+	adminClient, err = clientutil.NewK8sClientFromRestClientGetter(env.AdminRestClientGetter)
+	Expect(err).ToNot(HaveOccurred(), "there should be no error creating the admin client")
+
+	env = env.WithOrganization(ctx, adminClient, "./testdata/organization.yaml")
+
+	shared.SetupOCIMirroringForOrg(ctx, adminClient, env.TestNamespace)
+
+	testStartTime = time.Now().UTC()
+})
+
+var _ = AfterSuite(func() {
+	env.GenerateGreenhouseControllerLogs(ctx, testStartTime)
+	env.GenerateFluxControllerLogs(ctx, "helm-controller", testStartTime)
+})
+
+var _ = Describe("PluginDefinition E2E", Ordered, func() {
+	It("should replicate helm chart to registry mirror", func() {
+		scenarios.PDChartReplication(ctx, adminClient, env)
+	})
+
+	It("should fail chart replication for non-existent chart version", func() {
+		scenarios.PDChartReplicationFailure(ctx, adminClient, env)
+	})
+})

--- a/e2e/plugindefinition/scenarios/pd_chart_replication.go
+++ b/e2e/plugindefinition/scenarios/pd_chart_replication.go
@@ -1,0 +1,112 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package scenarios
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	greenhousev1alpha1 "github.com/cloudoperators/greenhouse/api/v1alpha1"
+	"github.com/cloudoperators/greenhouse/e2e/shared"
+	"github.com/cloudoperators/greenhouse/internal/test"
+	"github.com/cloudoperators/greenhouse/pkg/lifecycle"
+)
+
+// PDChartReplication verifies that the PluginDefinition controller replicates a Helm chart OCI artifact via the registry mirror.
+func PDChartReplication(ctx context.Context, adminClient client.Client, env *shared.TestEnv) {
+	pd := shared.PrepareOCIPodInfoPluginDefinition("podinfo-chart-replication", env.TestNamespace)
+
+	By("creating PluginDefinition with chart URL at registry mirror")
+	err := adminClient.Create(ctx, pd)
+	Expect(client.IgnoreAlreadyExists(err)).ToNot(HaveOccurred())
+	DeferCleanup(func() { test.EventuallyDeleted(ctx, adminClient, pd) })
+
+	By("verifying OCIReplicationReady condition becomes True with OCIReplicationSucceeded")
+	Eventually(func(g Gomega) {
+		g.Expect(adminClient.Get(ctx, client.ObjectKeyFromObject(pd), pd)).To(Succeed())
+		cond := pd.Status.StatusConditions.GetConditionByType(greenhousev1alpha1.OCIReplicationReadyCondition)
+		g.Expect(cond).NotTo(BeNil(), "OCIReplicationReady condition should be set")
+		g.Expect(cond.IsTrue()).To(BeTrue(), "chart replication should succeed")
+		g.Expect(cond.Reason).To(Equal(greenhousev1alpha1.OCIReplicationSucceededReason))
+	}).WithTimeout(shared.OCIReplicationTimeout).Should(Succeed(), "registry mirror should pull-through the podinfo chart from ghcr.io")
+
+	By("verifying LastSyncedArtifact is populated")
+	Eventually(func(g Gomega) {
+		g.Expect(adminClient.Get(ctx, client.ObjectKeyFromObject(pd), pd)).To(Succeed())
+		artifact := pd.GetLastSyncedArtifact()
+		g.Expect(artifact).NotTo(BeNil(), "LastSyncedArtifact should be set after replication")
+		g.Expect(artifact.Registry).To(Equal("registry:5000"))
+		g.Expect(artifact.ChartName).To(Equal("greenhouse-ghcr-io-mirror/stefanprodan/charts/podinfo"))
+		g.Expect(artifact.Version).To(Equal("6.7.1"))
+		g.Expect(artifact.Digest).NotTo(BeEmpty(), "digest should be populated after successful replication")
+		g.Expect(artifact.ReplicationStatus).To(Equal(greenhousev1alpha1.ReplicationStatusReplicated))
+	}).WithTimeout(shared.OCIReplicationTimeout).Should(Succeed())
+
+	By("verifying HelmChartReady condition becomes True")
+	Eventually(func(g Gomega) {
+		g.Expect(adminClient.Get(ctx, client.ObjectKeyFromObject(pd), pd)).To(Succeed())
+		cond := pd.Status.StatusConditions.GetConditionByType(greenhousev1alpha1.HelmChartReadyCondition)
+		g.Expect(cond).NotTo(BeNil())
+		g.Expect(cond.IsTrue()).To(BeTrue(), "Flux should fetch the chart from the registry mirror over HTTP")
+	}).WithTimeout(shared.OCIReplicationTimeout).Should(Succeed())
+
+	By("verifying PluginDefinition is Ready")
+	Eventually(func(g Gomega) {
+		g.Expect(adminClient.Get(ctx, client.ObjectKeyFromObject(pd), pd)).To(Succeed())
+		g.Expect(pd.Status.IsReadyTrue()).To(BeTrue())
+	}).WithTimeout(shared.OCIReplicationTimeout).Should(Succeed())
+
+	By("verifying chart replication is idempotent on re-reconciliation")
+	Expect(adminClient.Get(ctx, client.ObjectKeyFromObject(pd), pd)).To(Succeed())
+	originalDigest := pd.GetLastSyncedArtifact().Digest
+
+	ann := pd.GetAnnotations()
+	if ann == nil {
+		ann = make(map[string]string)
+	}
+	ann[lifecycle.ReconcileAnnotation] = time.Now().UTC().Format(time.RFC3339Nano)
+	pd.SetAnnotations(ann)
+	Expect(adminClient.Update(ctx, pd)).To(Succeed())
+
+	Eventually(func(g Gomega) {
+		g.Expect(adminClient.Get(ctx, client.ObjectKeyFromObject(pd), pd)).To(Succeed())
+		cond := pd.Status.StatusConditions.GetConditionByType(greenhousev1alpha1.OCIReplicationReadyCondition)
+		g.Expect(cond).NotTo(BeNil())
+		g.Expect(cond.IsTrue()).To(BeTrue())
+		artifact := pd.GetLastSyncedArtifact()
+		g.Expect(artifact).NotTo(BeNil())
+		g.Expect(artifact.Digest).To(Equal(originalDigest), "re-reconciliation must not change the replicated artifact digest")
+	}).WithTimeout(shared.OCIReplicationTimeout).Should(Succeed())
+}
+
+// PDChartReplicationFailure verifies that the PluginDefinition controller sets OCIReplicationFailed for a non-existent chart version.
+func PDChartReplicationFailure(ctx context.Context, adminClient client.Client, env *shared.TestEnv) {
+	pd := shared.PrepareOCIPodInfoPluginDefinition("podinfo-chart-failure", env.TestNamespace)
+	pd.Spec.Version = "99.99.99"
+	pd.Spec.HelmChart.Version = "99.99.99"
+
+	By("creating PluginDefinition with non-existent chart version")
+	err := adminClient.Create(ctx, pd)
+	Expect(client.IgnoreAlreadyExists(err)).ToNot(HaveOccurred())
+	DeferCleanup(func() { test.EventuallyDeleted(ctx, adminClient, pd) })
+
+	By("verifying OCIReplicationReady condition becomes False with OCIReplicationFailed reason")
+	Eventually(func(g Gomega) {
+		g.Expect(adminClient.Get(ctx, client.ObjectKeyFromObject(pd), pd)).To(Succeed())
+		cond := pd.Status.StatusConditions.GetConditionByType(greenhousev1alpha1.OCIReplicationReadyCondition)
+		g.Expect(cond).NotTo(BeNil())
+		g.Expect(cond.IsTrue()).To(BeFalse())
+		g.Expect(cond.Reason).To(Equal(greenhousev1alpha1.OCIReplicationFailedReason))
+	}).WithTimeout(shared.OCIReplicationTimeout).Should(Succeed(), "registry mirror pull-through should fail for a non-existent chart version")
+
+	By("verifying PluginDefinition is not Ready")
+	Eventually(func(g Gomega) {
+		g.Expect(adminClient.Get(ctx, client.ObjectKeyFromObject(pd), pd)).To(Succeed())
+		g.Expect(pd.Status.IsReadyTrue()).To(BeFalse())
+	}).WithTimeout(shared.OCIReplicationTimeout).Should(Succeed())
+}

--- a/e2e/plugindefinition/scenarios/pd_chart_replication.go
+++ b/e2e/plugindefinition/scenarios/pd_chart_replication.go
@@ -19,7 +19,14 @@ import (
 
 // PDChartReplication verifies that the PluginDefinition controller replicates a Helm chart OCI artifact via the registry mirror.
 func PDChartReplication(ctx context.Context, adminClient client.Client, env *shared.TestEnv) {
-	pd := shared.PrepareOCIPodInfoPluginDefinition("podinfo-chart-replication", env.TestNamespace)
+	pd := test.NewPluginDefinition(ctx, "podinfo-chart-replication", env.TestNamespace,
+		test.WithPluginDefinitionVersion("6.7.1"),
+		test.WithPluginDefinitionHelmChart(&greenhousev1alpha1.HelmChartReference{
+			Name:       "podinfo",
+			Repository: "oci://registry:5000/greenhouse-ghcr-io-mirror/stefanprodan/charts",
+			Version:    "6.7.1",
+		}),
+	)
 
 	By("creating PluginDefinition with chart URL at registry mirror")
 	err := adminClient.Create(ctx, pd)
@@ -86,9 +93,14 @@ func PDChartReplication(ctx context.Context, adminClient client.Client, env *sha
 
 // PDChartReplicationFailure verifies that the PluginDefinition controller sets OCIReplicationFailed for a non-existent chart version.
 func PDChartReplicationFailure(ctx context.Context, adminClient client.Client, env *shared.TestEnv) {
-	pd := shared.PrepareOCIPodInfoPluginDefinition("podinfo-chart-failure", env.TestNamespace)
-	pd.Spec.Version = "99.99.99"
-	pd.Spec.HelmChart.Version = "99.99.99"
+	pd := test.NewPluginDefinition(ctx, "podinfo-chart-failure", env.TestNamespace,
+		test.WithPluginDefinitionVersion("99.99.99"),
+		test.WithPluginDefinitionHelmChart(&greenhousev1alpha1.HelmChartReference{
+			Name:       "podinfo",
+			Repository: "oci://registry:5000/greenhouse-ghcr-io-mirror/stefanprodan/charts",
+			Version:    "99.99.99",
+		}),
+	)
 
 	By("creating PluginDefinition with non-existent chart version")
 	err := adminClient.Create(ctx, pd)

--- a/e2e/plugindefinition/testdata/organization.yaml
+++ b/e2e/plugindefinition/testdata/organization.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+# Cluster Scoped Resource
+apiVersion: greenhouse.sap/v1alpha1
+kind: Organization
+metadata:
+  name: plugindefinition-e2e
+spec:
+  description: e2e organization for PluginDefinition tests
+  displayName: PluginDefinitionE2E
+  mappedOrgAdminIdPGroup: TEST_ORG_ADMIN

--- a/e2e/shared/e2e.go
+++ b/e2e/shared/e2e.go
@@ -56,6 +56,9 @@ const (
 
 	// Define retry timeout for when backoff should stop
 	maxRetries = 10
+
+	// OCIReplicationTimeout allows for registry mirror pull-through from ghcr.io which can take 60-90s on first access.
+	OCIReplicationTimeout = 5 * time.Minute
 )
 
 const (

--- a/e2e/shared/oci.go
+++ b/e2e/shared/oci.go
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package shared
+
+import (
+	"context"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	greenhousev1alpha1 "github.com/cloudoperators/greenhouse/api/v1alpha1"
+)
+
+// PrepareOCIPodInfoPluginDefinition returns a PluginDefinition pointing at the podinfo chart via the registry mirror URL.
+func PrepareOCIPodInfoPluginDefinition(name, namespace string) *greenhousev1alpha1.PluginDefinition {
+	return &greenhousev1alpha1.PluginDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: greenhousev1alpha1.PluginDefinitionSpec{
+			Description: "podinfo for OCI replication e2e",
+			Version:     "6.7.1",
+			HelmChart: &greenhousev1alpha1.HelmChartReference{
+				Name:       "podinfo",
+				Repository: "oci://registry:5000/greenhouse-ghcr-io-mirror/stefanprodan/charts",
+				Version:    "6.7.1",
+			},
+		},
+	}
+}
+
+// CreateMirrorConfigMap creates or updates the OCI registry mirror ConfigMap in the given namespace
+// with the standard mirror configuration used in e2e tests.
+func CreateMirrorConfigMap(ctx context.Context, adminClient client.Client, namespace string) {
+	mirrorCM := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "oci-replication-config",
+			Namespace: namespace,
+		},
+	}
+	_, err := controllerutil.CreateOrUpdate(ctx, adminClient, mirrorCM, func() error {
+		mirrorCM.Data = map[string]string{
+			"containerRegistryConfig": `primaryMirror: "registry:5000"
+registryMirrors:
+  ghcr.io:
+    baseDomain: "registry:5000"
+    subPath: "greenhouse-ghcr-io-mirror"`,
+		}
+		return nil
+	})
+	Expect(err).ToNot(HaveOccurred(), "there should be no error creating the mirror ConfigMap")
+}
+
+func SetupOCIMirroringForOrg(ctx context.Context, adminClient client.Client, orgName string) {
+	CreateMirrorConfigMap(ctx, adminClient, orgName)
+	patchOrgConfigMapRef(ctx, adminClient, orgName, "oci-replication-config")
+}
+
+func TeardownOCIMirroringForOrg(ctx context.Context, adminClient client.Client, orgName string) {
+	patchOrgConfigMapRef(ctx, adminClient, orgName, "")
+}
+
+func patchOrgConfigMapRef(ctx context.Context, adminClient client.Client, orgName, ref string) {
+	org := &greenhousev1alpha1.Organization{}
+	Expect(adminClient.Get(ctx, client.ObjectKey{Name: orgName}, org)).To(Succeed())
+	patch := client.MergeFrom(org.DeepCopy())
+	org.Spec.ConfigMapRef = ref
+	Expect(adminClient.Patch(ctx, org, patch)).To(Succeed())
+}

--- a/e2e/shared/oci.go
+++ b/e2e/shared/oci.go
@@ -15,25 +15,6 @@ import (
 	greenhousev1alpha1 "github.com/cloudoperators/greenhouse/api/v1alpha1"
 )
 
-// PrepareOCIPodInfoPluginDefinition returns a PluginDefinition pointing at the podinfo chart via the registry mirror URL.
-func PrepareOCIPodInfoPluginDefinition(name, namespace string) *greenhousev1alpha1.PluginDefinition {
-	return &greenhousev1alpha1.PluginDefinition{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-		},
-		Spec: greenhousev1alpha1.PluginDefinitionSpec{
-			Description: "podinfo for OCI replication e2e",
-			Version:     "6.7.1",
-			HelmChart: &greenhousev1alpha1.HelmChartReference{
-				Name:       "podinfo",
-				Repository: "oci://registry:5000/greenhouse-ghcr-io-mirror/stefanprodan/charts",
-				Version:    "6.7.1",
-			},
-		},
-	}
-}
-
 // CreateMirrorConfigMap creates or updates the OCI registry mirror ConfigMap in the given namespace
 // with the standard mirror configuration used in e2e tests.
 func CreateMirrorConfigMap(ctx context.Context, adminClient client.Client, namespace string) {

--- a/internal/controller/plugin/plugin_controller_flux.go
+++ b/internal/controller/plugin/plugin_controller_flux.go
@@ -153,6 +153,11 @@ func (r *PluginReconciler) ensureHelmRelease(
 		return fmt.Errorf("failed to generate HelmRelease values for Plugin %s: %w", plugin.Name, err)
 	}
 
+	postRenderer, err := r.createRegistryMirrorPostRenderer(ctx, plugin, pluginDefinitionSpec, optionValues)
+	if err != nil {
+		return err
+	}
+
 	result, err := controllerutil.CreateOrPatch(ctx, r.Client, release, func() error {
 		builder := flux.NewHelmReleaseSpecBuilder().
 			WithHelmChartRef(&helmv2.CrossNamespaceSourceReference{
@@ -191,10 +196,6 @@ func (r *PluginReconciler) ensureHelmRelease(
 			WithStorageNamespace(plugin.Spec.ReleaseNamespace).
 			WithTargetNamespace(plugin.Spec.ReleaseNamespace)
 
-		postRenderer, err := r.createRegistryMirrorPostRenderer(ctx, plugin, pluginDefinitionSpec, optionValues)
-		if err != nil {
-			return err
-		}
 		if postRenderer != nil {
 			builder = builder.WithPostRenderers([]helmv2.PostRenderer{*postRenderer})
 		}


### PR DESCRIPTION
## Description

- Add e2e tests for OCI chart and image replication through an in-cluster ZOT mirror
- Fix image replication failures being masked as `FluxHelmReleaseConfigInvalid`
- Wire the `Insecure` flag through to `crane` and Flux `HelmRepository` to support the local KinD

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

- Closes https://github.com/cloudoperators/greenhouse/issues/1873

## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [x] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
