### PR TITLE
fix(plugindefinitions): provide context for still in use error

### DIFF
--- a/internal/webhook/v1alpha1/plugindefinition_webhook.go
+++ b/internal/webhook/v1alpha1/plugindefinition_webhook.go
@@ -5,6 +5,8 @@ package v1alpha1
 
 import (
 	"context"
+	"fmt"
+	"strconv"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -115,7 +117,11 @@ func validateDelete(ctx context.Context, c client.Client, labelKey, name, namesp
 		return nil, err
 	}
 	if len(list.Items) > 0 {
-		return nil, apierrors.NewBadRequest("PluginDefinition is still in use by Plugins")
+		pluginName := list.Items[0].GetName()
+		if len(list.Items) > 1 {
+			pluginName += " and " + strconv.Itoa(len(list.Items)-1) + " more"
+		}
+		return nil, apierrors.NewBadRequest(fmt.Sprintf("PluginDefinition %s is still in use by Plugin %s", name, pluginName))
 	}
 	return nil, nil
 }


### PR DESCRIPTION
if a (Cluster-)PluginDefintion is still in use the definition and
one Plugin and the count of other plugins using it will be added
to the error message

<!--
Please ensure the PR title follows the conventional commit format:
<type>(<scope>): description

For a list of accepted types and scopes see the workflow documentation: https://github.com/cloudoperators/greenhouse/blob/main/.github/workflows/ci-pr-title.yaml

-->

## Description
<!--
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 

- Related Issue # (issue)
- Closes # (issue)
- Fixes # (issue)

-->

## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [ ] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
