### PR TITLE
feat(plugins): remove immutability of pluginDefinitionRef.Name

### DIFF
--- a/internal/webhook/v1alpha1/plugin_webhook.go
+++ b/internal/webhook/v1alpha1/plugin_webhook.go
@@ -202,10 +202,6 @@ func ValidateUpdatePlugin(ctx context.Context, c client.Client, oldPlugin, plugi
 
 	pluginDefinitionRefNamePath := field.NewPath("spec", "pluginDefinitionRef", "name")
 
-	if oldPlugin.Spec.PluginDefinitionRef.Name != "" {
-		allErrs = append(allErrs, validation.ValidateImmutableField(oldPlugin.Spec.PluginDefinitionRef.Name, plugin.Spec.PluginDefinitionRef.Name, pluginDefinitionRefNamePath)...)
-	}
-
 	allErrs = append(allErrs, validation.ValidateImmutableField(oldPlugin.Spec.ClusterName, plugin.Spec.ClusterName,
 		field.NewPath("spec", "clusterName"))...)
 

--- a/internal/webhook/v1alpha1/plugin_webhook_test.go
+++ b/internal/webhook/v1alpha1/plugin_webhook_test.go
@@ -442,7 +442,7 @@ var _ = Describe("Validate plugin spec fields", Ordered, func() {
 		Expect(err).ToNot(HaveOccurred(), "there should be no error updating the UI-only plugin")
 	})
 
-	It("should reject to update a plugin when the pluginDefinition reference name changes", func() {
+	It("should accept to update a plugin when the pluginDefinition reference name changes", func() {
 		secondClusterPluginDefinition := setup.CreateClusterPluginDefinition(test.Ctx, "foo-bar")
 		testPlugin = setup.CreatePlugin(test.Ctx, "test-plugin",
 			test.WithClusterPluginDefinition(testClusterPluginDefinition.Name),
@@ -453,8 +453,11 @@ var _ = Describe("Validate plugin spec fields", Ordered, func() {
 
 		testPlugin.Spec.PluginDefinitionRef.Name = secondClusterPluginDefinition.Name
 		err := test.K8sClient.Update(test.Ctx, testPlugin)
-		Expect(err).To(HaveOccurred(), "there should be an error changing the plugin's pluginDefinition name")
-		Expect(err.Error()).To(ContainSubstring(validation.FieldImmutableErrorMsg))
+		Expect(err).ToNot(HaveOccurred(), "there should be no error changing the plugin's pluginDefinition name")
+
+		testPlugin.Spec.PluginDefinitionRef.Name = testClusterPluginDefinition.Name
+		err = test.K8sClient.Update(test.Ctx, testPlugin)
+		Expect(err).ToNot(HaveOccurred(), "there should be no error changing back the plugin's pluginDefinition name")
 
 		test.EventuallyDeleted(test.Ctx, test.K8sClient, secondClusterPluginDefinition)
 	})

--- a/internal/webhook/v1alpha1/pluginpreset_webhook.go
+++ b/internal/webhook/v1alpha1/pluginpreset_webhook.go
@@ -163,12 +163,6 @@ func ValidateUpdatePluginPreset(ctx context.Context, c client.Client, oldPluginP
 		allWarns = append(allWarns, "PluginPreset should have a support-group Team set as its owner", warn)
 	}
 
-	if oldPluginPreset.Spec.Plugin.PluginDefinitionRef.Name != "" {
-		if err := webhook.ValidateImmutableField(oldPluginPreset.Spec.Plugin.PluginDefinitionRef.Name, pluginPreset.Spec.Plugin.PluginDefinitionRef.Name, field.NewPath("spec", "plugin", "pluginDefinitionRef", "name")); err != nil {
-			allErrs = append(allErrs, err)
-		}
-	}
-
 	if err := webhook.ValidateImmutableField(oldPluginPreset.Spec.Plugin.ClusterName, pluginPreset.Spec.Plugin.ClusterName, field.NewPath("spec", "plugin", "clusterName")); err != nil {
 		allErrs = append(allErrs, err)
 	}

--- a/internal/webhook/v1alpha1/pluginpreset_webhook_test.go
+++ b/internal/webhook/v1alpha1/pluginpreset_webhook_test.go
@@ -236,9 +236,7 @@ var _ = Describe("PluginPreset Admission Tests", Ordered, func() {
 			return nil
 		})
 		Expect(err).
-			To(HaveOccurred(), "there must be an error updating the PluginPreset pluginDefinition name")
-		Expect(err.Error()).
-			To(ContainSubstring("field is immutable"), "the error must reflect the field is immutable")
+			NotTo(HaveOccurred(), "there must be no error updating the PluginPreset pluginDefinition name")
 
 		_, err = clientutil.CreateOrPatch(test.Ctx, test.K8sClient, cut, func() error {
 			cut.Spec.Plugin.PluginDefinitionRef.Kind = greenhousev1alpha1.PluginDefinitionKind


### PR DESCRIPTION
with this change both Plugins & PluginPresets may allow to change
the name of the referenced PluginDefintion

<!--
Please ensure the PR title follows the conventional commit format:
<type>(<scope>): description

For a list of accepted types and scopes see the workflow documentation: https://github.com/cloudoperators/greenhouse/blob/main/.github/workflows/ci-pr-title.yaml

-->

## Description
<!--
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 

- Related Issue # (issue)
- Closes # (issue)
- Fixes # (issue)

-->

## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [ ] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
