### PR TITLE
fix(catalogs): ensure defaults on gitrepository are not overwritten

### DIFF
--- a/internal/controller/catalog/catalog_controller.go
+++ b/internal/controller/catalog/catalog_controller.go
@@ -256,7 +256,7 @@ func (r *CatalogReconciler) EnsureCreated(ctx context.Context, obj lifecycle.Run
 		}
 
 		if err = sourcer.reconcileGitRepository(ctx); err != nil {
-			r.Log.Error(err, "failed to reconcile git repository for catalog source", "namespace", catalog.Namespace, "name", sourcer.getGitRepoName())
+			r.Log.Error(err, "failed to reconcile git repository for catalog source", "catalog", catalog.Name, "namespace", catalog.Namespace, "name", sourcer.getGitRepoName())
 			sourcer.setInventory(sourcev1.GitRepositoryKind, sourcer.getGitRepoName(), err.Error(), metav1.ConditionFalse)
 			allErrors = append(allErrors, catalogError{InventoryType: sourcev1.GitRepositoryKind, Name: sourcer.getGitRepoName(), Error: err})
 			continue
@@ -264,20 +264,20 @@ func (r *CatalogReconciler) EnsureCreated(ctx context.Context, obj lifecycle.Run
 
 		var externalArtifact *sourcev1.ExternalArtifact
 		if externalArtifact, err = sourcer.reconcileArtifactGeneration(ctx); err != nil {
-			r.Log.Error(err, "failed to reconcile artifact generation for catalog source", "namespace", catalog.Namespace, "name", sourcer.getArtifactName())
+			r.Log.Error(err, "failed to reconcile artifact generation for catalog source", "catalog", catalog.Name, "namespace", catalog.Namespace, "name", sourcer.getArtifactName())
 			allErrors = append(allErrors, catalogError{InventoryType: sourcev2.ArtifactGeneratorKind, Name: sourcer.getGeneratorName(), Error: err})
 			continue
 		}
 
 		ready, msg := sourcer.objectReadiness(ctx, externalArtifact)
 		if ready != metav1.ConditionTrue {
-			r.Log.Info("external artifact not ready yet, retry in next reconciliation loop", "namespace", catalog.Namespace, "name", sourcer.getArtifactName())
+			r.Log.Info("external artifact not ready yet, retry in next reconciliation loop", "catalog", catalog.Name, "namespace", catalog.Namespace, "name", sourcer.getArtifactName())
 			allErrors = append(allErrors, catalogError{InventoryType: sourcev1.ExternalArtifactKind, Name: sourcer.getArtifactName(), Error: errors.New(msg)})
 			continue
 		}
 
 		if err = sourcer.reconcileKustomization(ctx, externalArtifact); err != nil {
-			r.Log.Error(err, "failed to reconcile kustomization for catalog source", "namespace", catalog.Namespace, "name", sourcer.getKustomizationName())
+			r.Log.Error(err, "failed to reconcile kustomization for catalog source", "catalog", catalog.Name, "namespace", catalog.Namespace, "name", sourcer.getKustomizationName())
 			allErrors = append(allErrors, catalogError{InventoryType: kustomizev1.KustomizationKind, Name: sourcer.getKustomizationName(), Error: err})
 			continue
 		}

--- a/internal/controller/catalog/source.go
+++ b/internal/controller/catalog/source.go
@@ -221,7 +221,12 @@ func (s *source) reconcileGitRepository(ctx context.Context) error {
 	}
 
 	result, err := controllerutil.CreateOrPatch(ctx, s.Client, gitRepo, func() error {
-		gitRepo.Spec = spec
+		gitRepo.Spec.URL = spec.URL
+		gitRepo.Spec.Interval = spec.Interval
+		gitRepo.Spec.Reference = spec.Reference
+		gitRepo.Spec.Provider = spec.Provider
+		gitRepo.Spec.Suspend = spec.Suspend
+		gitRepo.Spec.SecretRef = spec.SecretRef
 		common.EnsureAnnotation(gitRepo, fluxmeta.ReconcileRequestAnnotation, s.lastReconciledAt)
 		return controllerutil.SetControllerReference(s.catalog, gitRepo, s.scheme)
 	})
@@ -230,13 +235,13 @@ func (s *source) reconcileGitRepository(ctx context.Context) error {
 	}
 	switch result {
 	case controllerutil.OperationResultCreated:
-		s.log.Info("created git repository for catalog", "name", gitRepo.Name, "namespace", gitRepo.Namespace)
+		s.log.Info("created git repository for catalog", "catalog", s.catalog.Name, "name", gitRepo.Name, "namespace", gitRepo.Namespace)
 	case controllerutil.OperationResultUpdated:
-		s.log.Info("updated git repository for catalog", "name", gitRepo.Name, "namespace", gitRepo.Namespace)
+		s.log.Info("updated git repository for catalog", "catalog", s.catalog.Name, "name", gitRepo.Name, "namespace", gitRepo.Namespace)
 	case controllerutil.OperationResultNone:
-		s.log.Info("No changes to catalog git repository", "name", gitRepo.Name, "namespace", gitRepo.Namespace)
+		s.log.Info("no changes to catalog git repository", "catalog", s.catalog.Name, "name", gitRepo.Name, "namespace", gitRepo.Namespace)
 	default:
-		s.log.Info("result is unknown for catalog git repository", "name", gitRepo.Name, "namespace", gitRepo.Namespace, "result", result)
+		s.log.Info("unknown result for catalog git repository", "catalog", s.catalog.Name, "name", gitRepo.Name, "namespace", gitRepo.Namespace, "result", result)
 	}
 	return nil
 }
@@ -299,13 +304,13 @@ func (s *source) reconcileArtifactGeneration(ctx context.Context) (*sourcev1.Ext
 	}
 	switch result {
 	case controllerutil.OperationResultCreated:
-		s.log.Info("created artifact generator for catalog", "name", generator.Name, "namespace", generator.Namespace)
+		s.log.Info("created artifact generator for catalog", "catalog", s.catalog.Name, "name", generator.Name, "namespace", generator.Namespace)
 	case controllerutil.OperationResultUpdated:
-		s.log.Info("updated artifact generator for catalog", "name", generator.Name, "namespace", generator.Namespace)
+		s.log.Info("updated artifact generator for catalog", "catalog", s.catalog.Name, "name", generator.Name, "namespace", generator.Namespace)
 	case controllerutil.OperationResultNone:
-		s.log.Info("no changes to catalog artifact generator", "name", generator.Name, "namespace", generator.Namespace)
+		s.log.Info("no changes to catalog artifact generator", "catalog", s.catalog.Name, "name", generator.Name, "namespace", generator.Namespace)
 	default:
-		s.log.Info("result is unknown for catalog artifact generator", "name", generator.Name, "namespace", generator.Namespace, "result", result)
+		s.log.Info("unknown result for catalog artifact generator", "catalog", s.catalog.Name, "name", generator.Name, "namespace", generator.Namespace, "result", result)
 	}
 	extArtifact := &sourcev1.ExternalArtifact{}
 	extArtifact.SetName(s.externalArtifact.Name)
@@ -392,13 +397,13 @@ func (s *source) reconcileKustomization(ctx context.Context, extArtifact *source
 	}
 	switch result {
 	case controllerutil.OperationResultCreated:
-		s.log.Info("created kustomization for catalog", "name", kustomization.Name, "namespace", kustomization.Namespace)
+		s.log.Info("created kustomization for catalog", "catalog", s.catalog.Name, "name", kustomization.Name, "namespace", kustomization.Namespace)
 	case controllerutil.OperationResultUpdated:
-		s.log.Info("updated kustomization for catalog", "name", kustomization.Name, "namespace", kustomization.Namespace)
+		s.log.Info("updated kustomization for catalog", "catalog", s.catalog.Name, "name", kustomization.Name, "namespace", kustomization.Namespace)
 	case controllerutil.OperationResultNone:
-		s.log.Info("No changes to catalog kustomization", "name", kustomization.Name, "namespace", kustomization.Namespace)
+		s.log.Info("no changes to catalog kustomization", "catalog", s.catalog.Name, "name", kustomization.Name, "namespace", kustomization.Namespace)
 	default:
-		s.log.Info("result is unknown for catalog kustomization", "name", kustomization.Name, "namespace", kustomization.Namespace, "result", result)
+		s.log.Info("unknown result for catalog kustomization", "catalog", s.catalog.Name, "name", kustomization.Name, "namespace", kustomization.Namespace, "result", result)
 	}
 	return nil
 }
@@ -433,11 +438,11 @@ func (s *source) fetchArtifact(extArtifact *sourcev1.ExternalArtifact) error {
 func (s *source) getOptionOverridePatches(optionOverrides []greenhousev1alpha1.OptionsOverride, pluginDefinitionName string) ([]kustomize.Patch, error) {
 	spec, err := s.findPluginDefinition(s.externalArtifactManifest, pluginDefinitionName)
 	if err != nil {
-		s.log.Error(err, "failed to find plugin definition in store", "name", pluginDefinitionName)
+		s.log.Error(err, "failed to find plugin definition in store", "catalog", s.catalog.Name, "name", pluginDefinitionName)
 		return nil, err
 	}
 	if spec == nil {
-		s.log.Info("plugin definition not found in artifact for option overrides", "name", pluginDefinitionName)
+		s.log.Info("plugin definition not found in artifact for option overrides", "catalog", s.catalog.Name, "name", pluginDefinitionName)
 		return nil, nil
 	}
 	patches := make([]kustomize.Patch, 0, len(optionOverrides))
@@ -448,7 +453,7 @@ func (s *source) getOptionOverridePatches(optionOverrides []greenhousev1alpha1.O
 		})
 		if idx == -1 {
 			err = fmt.Errorf("failed to find plugin option override %s in plugin definition %s/%s", ov.Name, s.catalog.Namespace, pluginDefinitionName)
-			s.log.Info("option not found in plugin definition for override", "pluginDefinition", pluginDefinitionName, "option", ov.Name)
+			s.log.Info("option not found in plugin definition for override", "catalog", s.catalog.Name, "pluginDefinition", pluginDefinitionName, "option", ov.Name)
 			return nil, err
 		}
 		spec.Options[idx].Default = ov.Value
@@ -473,7 +478,7 @@ func (s *source) getOptionOverridePatches(optionOverrides []greenhousev1alpha1.O
 func (s *source) findPluginDefinition(manifestBytes []byte, name string) (spec *greenhousev1alpha1.PluginDefinitionSpec, err error) {
 	var manifestMap map[string][]byte
 	if err = json.Unmarshal(manifestBytes, &manifestMap); err != nil {
-		s.log.Error(err, "failed to unmarshal manifest bytes", "name", name)
+		s.log.Error(err, "failed to unmarshal manifest bytes", "catalog", s.catalog.Name, "name", name)
 		return
 	}
 	var combinedManifests strings.Builder
@@ -497,7 +502,7 @@ func (s *source) findPluginDefinition(manifestBytes []byte, name string) (spec *
 	}
 	objectMaps, err := helm.ObjectMapFromLocalManifest(filters, combinedManifests.String())
 	if err != nil {
-		s.log.Error(err, "failed to get object map from manifest", "name", name)
+		s.log.Error(err, "failed to get object map from manifest", "catalog", s.catalog.Name, "name", name)
 		return
 	}
 	for _, helmObj := range objectMaps {
@@ -531,7 +536,7 @@ func (s *source) objectReadiness(ctx context.Context, obj client.Object) (ready 
 	ready = metav1.ConditionFalse
 	key := client.ObjectKeyFromObject(obj)
 	if err := s.Get(ctx, key, obj); err != nil {
-		s.log.Error(err, "failed to get object", "key", key)
+		s.log.Error(err, "failed to get object", "catalog", s.catalog.Name, "key", key)
 		msg = err.Error()
 		return
 	}
@@ -540,7 +545,7 @@ func (s *source) objectReadiness(ctx context.Context, obj client.Object) (ready 
 	cObj, ok := obj.(lifecycle.CatalogObject)
 	if !ok {
 		err := fmt.Errorf("failed to assert catalog object kind %s - %s/%s", kind, key.Namespace, key.Name)
-		s.log.Error(err, "failed to assert catalog object", "key", key)
+		s.log.Error(err, "failed to assert catalog object", "catalog", s.catalog.Name, "key", key)
 		msg = err.Error()
 		return
 	}
@@ -548,7 +553,7 @@ func (s *source) objectReadiness(ctx context.Context, obj client.Object) (ready 
 	readyCondition := meta.FindStatusCondition(conditions, fluxmeta.ReadyCondition)
 
 	if readyCondition == nil {
-		s.log.Info("Object not ready yet, requeue...", "kind", kind, "namespace", key.Namespace, "name", key.Name)
+		s.log.Info("object not ready yet, requeue", "catalog", s.catalog.Name, "kind", kind, "namespace", key.Namespace, "name", key.Name)
 		msg = kind + " not ready yet"
 		return
 	}


### PR DESCRIPTION
enhance logging to include catalog name in error and info messages
.spec.timeout is defaulted to 60, but got removed with every reonciliation of the gitrepository

Signed-off-by: Ivo Gosemann <ivo.gosemann@sap.com>

<!--
Please ensure the PR title follows the conventional commit format:
<type>(<scope>): description

For a list of accepted types and scopes see the workflow documentation: https://github.com/cloudoperators/greenhouse/blob/main/.github/workflows/ci-pr-title.yaml

-->

## Description
<!--
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 

- Related Issue # (issue)
- Closes # (issue)
- Fixes # (issue)

-->

## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [ ] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
