### PR TITLE
fix(teamrolebindings): trigger reconciliation when Cluster becomes ready

### DIFF
--- a/internal/clientutil/predicates.go
+++ b/internal/clientutil/predicates.go
@@ -106,6 +106,31 @@ func PredicateOrganizationSCIMStatusChange() predicate.Predicate {
 	}
 }
 
+// PredicateClusterReadyStatusChange triggers on updates where a Cluster's Ready condition transitions to True.
+func PredicateClusterReadyStatusChange() predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(_ event.CreateEvent) bool { return false },
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			if e.ObjectOld == nil || e.ObjectNew == nil {
+				return false
+			}
+			oldCluster, okOld := e.ObjectOld.(*greenhousev1alpha1.Cluster)
+			newCluster, okNew := e.ObjectNew.(*greenhousev1alpha1.Cluster)
+			if !okOld || !okNew {
+				return false
+			}
+			oldCondition := oldCluster.Status.GetConditionByType(greenhousemetav1alpha1.ReadyCondition)
+			newCondition := newCluster.Status.GetConditionByType(greenhousemetav1alpha1.ReadyCondition)
+			if newCondition == nil {
+				return false
+			}
+			return (oldCondition == nil || !oldCondition.IsTrue()) && newCondition.IsTrue()
+		},
+		DeleteFunc:  func(_ event.DeleteEvent) bool { return false },
+		GenericFunc: func(_ event.GenericEvent) bool { return false },
+	}
+}
+
 func PredicateIgnoreDeletingResources() predicate.Predicate {
 	return predicate.Funcs{
 		UpdateFunc: func(e event.UpdateEvent) bool {

--- a/internal/controller/teamrbac/teamrolebinding_controller.go
+++ b/internal/controller/teamrbac/teamrolebinding_controller.go
@@ -85,9 +85,9 @@ func (r *TeamRoleBindingReconciler) SetupWithManager(name string, mgr ctrl.Manag
 			handler.EnqueueRequestsFromMapFunc(r.enqueueTeamRoleBindingsFor)).
 		Watches(&greenhousev1alpha1.Team{},
 			handler.EnqueueRequestsFromMapFunc(r.enqueueTeamRoleBindingsFor)).
-		// Reconcile TeamRoleBindings for all Cluster label changes in the same namespace
+		// Reconcile TeamRoleBindings for all Cluster label changes or Ready status transitions in the same namespace
 		Watches(&greenhousev1alpha1.Cluster{}, handler.EnqueueRequestsFromMapFunc(r.enqueueAllTeamRoleBindingsInNamespace),
-			builder.WithPredicates(predicate.LabelChangedPredicate{})).
+			builder.WithPredicates(predicate.Or(predicate.LabelChangedPredicate{}, clientutil.PredicateClusterReadyStatusChange()))).
 		Complete(r)
 }
 


### PR DESCRIPTION
This adds an additional predicate so that if a Cluster
becomes ready it will reconcile the TRB. Previously,
only label changes on the Cluster triggered the reconciliation
of the TeamRoleBinding

Signed-off-by: Ivo Gosemann <ivo.gosemann@sap.com>

<!--
Please ensure the PR title follows the conventional commit format:
<type>(<scope>): description

For a list of accepted types and scopes see the workflow documentation: https://github.com/cloudoperators/greenhouse/blob/main/.github/workflows/ci-pr-title.yaml

-->

## Description
<!--
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 

- Related Issue # (issue)
- Closes # (issue)
- Fixes # (issue)

-->

## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [ ] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
