### PR TITLE
fix(plugins): require image ref on same line as image: key

### DIFF
--- a/internal/ocimirror/ociref.go
+++ b/internal/ocimirror/ociref.go
@@ -10,7 +10,9 @@ import (
 	"github.com/google/go-containerregistry/pkg/name"
 )
 
-var imageFieldPattern = regexp.MustCompile(`(?m)^[\s-]*image:\s+["']?([^\s"']+)["']?`)
+// imageFieldPattern matches `image: <ref>` only when <ref> is on the same line.
+// Avoids false matches when `image:` opens a nested map (e.g. CRD field schemas).
+var imageFieldPattern = regexp.MustCompile(`(?m)^[\s-]*image:[\t ]+["']?([^\s"']+)["']?\s*$`)
 
 // ExtractUniqueOCIRefs extracts and deduplicates all OCI image references from YAML manifests.
 func ExtractUniqueOCIRefs(manifests string) []string {

--- a/internal/ocimirror/ociref_test.go
+++ b/internal/ocimirror/ociref_test.go
@@ -55,6 +55,23 @@ containers:
 			images := ExtractUniqueOCIRefs(manifests)
 			Expect(images).To(HaveLen(2))
 		})
+
+		It("should ignore `image:` used as a CRD field name with nested children", func() {
+			// Regression: OpenSearch index templates declare `image` as a field, not a container ref.
+			manifests := `
+mappings:
+  properties:
+    container:
+      properties:
+        image:
+          properties:
+            name:
+              type: keyword
+            tag:
+              type: keyword
+`
+			Expect(ExtractUniqueOCIRefs(manifests)).To(BeEmpty())
+		})
 	})
 
 	Describe("SplitOCIRef", func() {


### PR DESCRIPTION
## Description

The image-extraction regex used `\s+` which matches across newlines, causing false positives when `image:` opens a nested YAML map (e.g. CRD field schemas like OpenSearch index templates declaring an OTLP `container.image.{name,tag}` field). The next YAML key was captured as a bogus image reference, and the subsequent ParseReference call failed the entire Plugin reconcile.

Tighten the regex to require whitespace-only inline (`\t` and `space`) between `image:` and the value, plus an end-of-line anchor.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

- Fixes [# (issue)](https://github.com/cloudoperators/greenhouse/issues/2001)

## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [x] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
