### PR TITLE
fix(ci): add collaborator check and issues:write to e2e runner

### DIFF
--- a/.github/workflows/ci-e2e-run.yaml
+++ b/.github/workflows/ci-e2e-run.yaml
@@ -8,6 +8,7 @@ permissions:
   contents: read
   pull-requests: read
   statuses: write
+  issues: write
 
 jobs:
   parse:
@@ -19,6 +20,20 @@ jobs:
       suites: ${{ steps.suites.outputs.suites }}
       run: ${{ steps.cmd.outputs.run }}
     steps:
+      - name: Check commenter is a collaborator
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              username: context.actor,
+            });
+            const level = data.permission;
+            if (level !== 'write' && level !== 'admin') {
+              core.setFailed(`e2e trigger denied — @${context.actor} is not a maintainer.`);
+            }
+
       - name: Resolve PR head SHA
         id: pr
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0

--- a/.github/workflows/ci-e2e-run.yaml
+++ b/.github/workflows/ci-e2e-run.yaml
@@ -8,13 +8,17 @@ permissions:
   contents: read
   pull-requests: read
   statuses: write
-  issues: write
 
 jobs:
   parse:
     name: Parse E2E Command
     if: ${{ github.event.issue.pull_request && startsWith(github.event.comment.body, '/e2e') }}
     runs-on: [ubuntu-latest]
+    permissions:
+      contents: read
+      pull-requests: read
+      statuses: write
+      issues: write
     outputs:
       sha: ${{ steps.pr.outputs.sha }}
       suites: ${{ steps.suites.outputs.suites }}
@@ -24,13 +28,17 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
-            const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              username: context.actor,
-            });
-            const level = data.permission;
-            if (level !== 'write' && level !== 'admin') {
+            try {
+              const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                username: context.actor,
+              });
+              const level = data.permission;
+              if (level !== 'write' && level !== 'maintain' && level !== 'admin') {
+                core.setFailed(`e2e trigger denied — @${context.actor} is not a maintainer.`);
+              }
+            } catch {
               core.setFailed(`e2e trigger denied — @${context.actor} is not a maintainer.`);
             }
 


### PR DESCRIPTION
<!--
Please ensure the PR title follows the conventional commit format:
<type>(<scope>): description

For a list of accepted types and scopes see the workflow documentation: https://github.com/cloudoperators/greenhouse/blob/main/.github/workflows/ci-pr-title.yaml

-->

## Description

Adds a collaborator permission check as the first step of the e2e runner to prevent fork contributors from triggering e2e runs that execute arbitrary `Makefile` targets with access to app secrets. Also adds `issues: write` permission so the rocket reaction can be posted on the triggering comment.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [x] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

- Closes #1771

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [x] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes