### PR TITLE
fix(ci): pass PR SHA as ref to e2e action and drop redundant checkout

### DIFF
--- a/.github/workflows/ci-e2e-run.yaml
+++ b/.github/workflows/ci-e2e-run.yaml
@@ -114,17 +114,10 @@ jobs:
       fail-fast: true
       matrix:
         suite: ${{ fromJson(needs.parse.outputs.suites) }}
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - name: Checkout PR head
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ref: ${{ needs.parse.outputs.sha }}
-
       - name: Run ${{ matrix.suite }} e2e
         id: e2e
-        uses: cloudoperators/common/workflows/e2e@17d3d6b80851574fcd8c7b6e5c4fe6aee2922359
+        uses: cloudoperators/common/workflows/e2e@f87e1e6b7889707a9c10d1a8a9f9f481eb311c06
         env:
           RUNTIME_ENV: "CI"
           GH_APP_ID: ${{ secrets.CLOUDOPERATOR_APP_ID }}
@@ -134,6 +127,7 @@ jobs:
           admin-k8s-version: "v1.34.3"
           remote-k8s-version: "v1.32.11"
           scenario: ${{ matrix.suite }}
+          ref: ${{ needs.parse.outputs.sha }}
           admin-config: ${{ github.workspace }}/e2e/greenhouse-admin-cluster.yaml
           remote-config: ${{ github.workspace }}/dev-env/greenhouse-remote-cluster.yaml
 


### PR DESCRIPTION
## Description

Passes `ref: <PR head SHA>` to the `cloudoperators/common/workflows/e2e` composite action so e2e tests run against the PR's code rather than main. Drops the now-redundant `Checkout PR head` step (the common action handles checkout internally) and removes the job-level `GITHUB_TOKEN` env that caused duplicate `Authorization` headers on the internal git fetch.

Depends on cloudoperators/common#60.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [x] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

- Depends on cloudoperators/common#60

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [x] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes