### PR TITLE
feat(pluginpresets): add additional metric for successful reconciliation

### DIFF
--- a/internal/controller/plugin/pluginpreset_controller.go
+++ b/internal/controller/plugin/pluginpreset_controller.go
@@ -96,7 +96,7 @@ func (r *PluginPresetReconciler) setConditions() lifecycle.Conditioner {
 		ownerLabelCondition := util.ComputeOwnerLabelCondition(ctx, r.Client, pluginPreset)
 		util.UpdateOwnedByLabelMissingMetric(pluginPreset, ownerLabelCondition.IsFalse())
 		pluginPreset.Status.SetConditions(readyCondition, ownerLabelCondition)
-		updatePluginPresetReadyMetric(pluginPreset)
+		updatePluginPresetMetrics(pluginPreset)
 	}
 }
 
@@ -185,7 +185,7 @@ func (r *PluginPresetReconciler) EnsureDeleted(ctx context.Context, resource lif
 			return ctrl.Result{}, lifecycle.Pending, nil
 		}
 	}
-	deletePluginPresetReadyMetric(pluginPreset)
+	deletePluginPresetMetrics(pluginPreset)
 	return ctrl.Result{}, lifecycle.Success, nil
 }
 

--- a/internal/controller/plugin/pluginpreset_metrics.go
+++ b/internal/controller/plugin/pluginpreset_metrics.go
@@ -9,42 +9,65 @@ import (
 	crmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 
 	greenhouseapis "github.com/cloudoperators/greenhouse/api"
-	greenhousemetav1alpha1 "github.com/cloudoperators/greenhouse/api/meta/v1alpha1"
 	greenhousev1alpha1 "github.com/cloudoperators/greenhouse/api/v1alpha1"
 )
 
 var pluginPresetReady = prometheus.NewGaugeVec(
 	prometheus.GaugeOpts{
 		Name: "greenhouse_pluginpreset_ready",
-		Help: "Indicates whether the pluginpreset is ready",
+		Help: "Indicates whether the PluginPreset is ready",
+	},
+	[]string{"pluginPreset", "organization", "owned_by"},
+)
+
+var pluginPresetPluginsReconciled = prometheus.NewGaugeVec(
+	prometheus.GaugeOpts{
+		Name: "greenhouse_pluginpreset_plugins_reconciled",
+		Help: "Indicates whether the PluginPreset's Plugins are reconciled successfully",
 	},
 	[]string{"pluginPreset", "organization", "owned_by"},
 )
 
 func init() {
 	crmetrics.Registry.MustRegister(pluginPresetReady)
+	crmetrics.Registry.MustRegister(pluginPresetPluginsReconciled)
 }
 
-func updatePluginPresetReadyMetric(preset *greenhousev1alpha1.PluginPreset) {
+func updatePluginPresetMetrics(preset *greenhousev1alpha1.PluginPreset) {
 	pluginPresetReady.DeletePartialMatch(prometheus.Labels{
 		"pluginPreset": preset.Name,
 		"organization": preset.Namespace,
 	})
+	pluginPresetPluginsReconciled.DeletePartialMatch(prometheus.Labels{
+		"pluginPreset": preset.Name,
+		"organization": preset.Namespace,
+	})
+
 	labels := prometheus.Labels{
 		"pluginPreset": preset.Name,
 		"organization": preset.Namespace,
 		"owned_by":     preset.Labels[greenhouseapis.LabelKeyOwnedBy],
 	}
-	readyCondition := preset.Status.GetConditionByType(greenhousemetav1alpha1.ReadyCondition)
-	if readyCondition != nil && readyCondition.Status == metav1.ConditionTrue {
+	if preset.Status.IsReadyTrue() {
 		pluginPresetReady.With(labels).Set(1)
 	} else {
 		pluginPresetReady.With(labels).Set(0)
 	}
+
+	pluginFailed := preset.Status.GetConditionByType(greenhousev1alpha1.PluginFailedCondition)
+	if pluginFailed.Status == metav1.ConditionFalse {
+		pluginPresetPluginsReconciled.With(labels).Set(1)
+	} else {
+		pluginPresetPluginsReconciled.With(labels).Set(0)
+	}
 }
 
-func deletePluginPresetReadyMetric(preset *greenhousev1alpha1.PluginPreset) {
+func deletePluginPresetMetrics(preset *greenhousev1alpha1.PluginPreset) {
 	pluginPresetReady.DeletePartialMatch(prometheus.Labels{
+		"pluginPreset": preset.Name,
+		"organization": preset.Namespace,
+	})
+	pluginPresetPluginsReconciled.DeletePartialMatch(prometheus.Labels{
 		"pluginPreset": preset.Name,
 		"organization": preset.Namespace,
 	})


### PR DESCRIPTION
The generic `greenhouse_pluginpreset_ready` is not useful for alerting, as it fires alongside any alert regarding plugins owned by the same preset.
The `greenhouse_pluginpreset_plugins_reconciled` will fire only if it is not possible to reconcile all Plugins successfuly. Hence, pointing to a configuration issue with the PluginPreset. In this case the Plugin does not necessarily also alert, since it could be a faulty PluginPreset/PluginDefintion update.

Signed-off-by: Ivo Gosemann <ivo.gosemann@sap.com>

<!--
Please ensure the PR title follows the conventional commit format:
<type>(<scope>): description

For a list of accepted types and scopes see the workflow documentation: https://github.com/cloudoperators/greenhouse/blob/main/.github/workflows/ci-pr-title.yaml

-->

## Description
<!--
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 

- Related Issue # (issue)
- Closes # (issue)
- Fixes # (issue)

-->

## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [ ] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
