### PR TITLE
fix(charts): drop duplicate app label on controller-manager VPA

### DIFF
--- a/charts/greenhouse/Chart.lock
+++ b/charts/greenhouse/Chart.lock
@@ -7,7 +7,7 @@ dependencies:
   version: 0.9.0
 - name: manager
   repository: file://../manager
-  version: 0.12.0
+  version: 0.12.1
 - name: dashboard
   repository: file://../dashboard
   version: 0.3.0
@@ -20,5 +20,5 @@ dependencies:
 - name: authz
   repository: file://../authz
   version: 0.5.0
-digest: sha256:c21c83285345f83e41f2a6f5c03320bb2d38562a6768549a6f2ee0cabab87e72
-generated: "2026-06-01T09:09:25.200587+02:00"
+digest: sha256:02fc3628a4f4fcc47e173063577b5975da709fb72a185390fe1df44826e47db6
+generated: "2026-06-02T14:14:22.18957+02:00"

--- a/charts/greenhouse/Chart.yaml
+++ b/charts/greenhouse/Chart.yaml
@@ -5,7 +5,7 @@ apiVersion: v2
 name: greenhouse
 description: A Helm chart for deploying greenhouse
 type: application
-version: 0.19.0
+version: 0.19.1
 appVersion: "v0.13.0"
 
 dependencies:
@@ -18,7 +18,7 @@ dependencies:
     repository: "file://../cors-proxy"
     version: 0.9.0
   - name: manager
-    version: 0.12.0
+    version: 0.12.1
     repository: "file://../manager"
   - condition: dashboard.enabled
     name: dashboard

--- a/charts/manager/Chart.yaml
+++ b/charts/manager/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.12.0
+version: 0.12.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/manager/templates/manager/vpa.yaml
+++ b/charts/manager/templates/manager/vpa.yaml
@@ -5,7 +5,6 @@ metadata:
   name: {{ include "manager.fullname" . }}-controller-manager
   namespace: greenhouse
   labels:
-    app: greenhouse
   {{- include "manager.labels" . | nindent 4 }}
 spec:
   resourcePolicy:


### PR DESCRIPTION
## Description

`charts/manager/templates/manager/vpa.yaml` renders the controller-manager VerticalPodAutoscaler's `metadata.labels` with the `app` key twice: the template hardcodes `app: greenhouse` and then also includes `manager.labels`, which already emits `app: greenhouse` via `common.selectorLabels`.

`helm template`, `helm install`, and `kubectl apply` tolerate duplicate map keys (last-one-wins), so this is invisible on the Helm CLI path. Flux helm-controller (v1.3.0) runs a strict kyaml post-renderer that rejects it and fails the install:

```
error while running post render on files: yaml: unmarshal errors:
  line 12: mapping key "app" already defined at line 8
```

`kustomize build` on the rendered VPA reproduces the identical error. The VPA only renders when the cluster advertises `autoscaling.k8s.io/v1` — true for every Gardener shoot — so it consistently breaks GitOps/Flux-driven installs there. `helm template` without `-a autoscaling.k8s.io/v1` hides it, while `helm install --dry-run=server` surfaces it. Reproduces on chart versions 0.13.2 through 0.16.0.

This drops the redundant hardcoded label; `manager.labels` already supplies the correct single `app` label.

## What type of PR is this? (check all applicable)

- [x] 🐛 Bug Fix

## Related Tickets & Documents

Surfaced while installing Greenhouse via Flux helm-controller on a Gardener shoot.

## Added tests?

- [x] 🙅 no, because they aren't needed

Verified by re-rendering the patched chart with `helm template ... -a autoscaling.k8s.io/v1`: the controller-manager VPA now carries a single `app` label, and the full manifest set has zero duplicate-key documents (`kustomize build` parses it cleanly).

## Added to documentation?

- [x] 🙅 no documentation needed

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
