### PR TITLE
chore(release/v0.13): bump chart versions for v0.13.1

### DIFF
--- a/charts/authz/Chart.yaml
+++ b/charts/authz/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.0
+version: 0.5.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/authz/Chart.yaml
+++ b/charts/authz/Chart.yaml
@@ -24,4 +24,4 @@ version: 0.5.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.13.0"
+appVersion: "v0.13.1"

--- a/charts/cors-proxy/Chart.yaml
+++ b/charts/cors-proxy/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.9.0
+version: 0.9.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/cors-proxy/Chart.yaml
+++ b/charts/cors-proxy/Chart.yaml
@@ -24,4 +24,4 @@ version: 0.9.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.13.0"
+appVersion: "v0.13.1"

--- a/charts/greenhouse/Chart.yaml
+++ b/charts/greenhouse/Chart.yaml
@@ -5,8 +5,8 @@ apiVersion: v2
 name: greenhouse
 description: A Helm chart for deploying greenhouse
 type: application
-version: 0.19.1
-appVersion: "v0.13.0"
+version: 0.19.2
+appVersion: "v0.13.1"
 
 dependencies:
   - condition: idproxy.enabled
@@ -18,7 +18,7 @@ dependencies:
     repository: "file://../cors-proxy"
     version: 0.9.0
   - name: manager
-    version: 0.12.1
+    version: 0.12.2
     repository: "file://../manager"
   - condition: dashboard.enabled
     name: dashboard

--- a/charts/greenhouse/Chart.yaml
+++ b/charts/greenhouse/Chart.yaml
@@ -12,11 +12,11 @@ dependencies:
   - condition: idproxy.enabled
     name: idproxy
     repository: "file://../idproxy"
-    version: 0.10.0
+    version: 0.10.1
   - condition: proxy.enabled
     name: cors-proxy
     repository: "file://../cors-proxy"
-    version: 0.9.0
+    version: 0.9.1
   - name: manager
     version: 0.12.2
     repository: "file://../manager"
@@ -34,6 +34,6 @@ dependencies:
     repository: "oci://ghcr.io/sapcc/helm-charts"
     condition: postgresqlng.enabled
   - name: authz
-    version: 0.5.0
+    version: 0.5.1
     repository: "file://../authz"
     condition: authz.enabled

--- a/charts/idproxy/Chart.yaml
+++ b/charts/idproxy/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.10.0
+version: 0.10.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/idproxy/Chart.yaml
+++ b/charts/idproxy/Chart.yaml
@@ -24,4 +24,4 @@ version: 0.10.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.13.0"
+appVersion: "v0.13.1"

--- a/charts/manager/Chart.yaml
+++ b/charts/manager/Chart.yaml
@@ -16,10 +16,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.12.1
+version: 0.12.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.13.0"
+appVersion: "v0.13.1"


### PR DESCRIPTION
## Summary

- `manager` chart: `0.12.1` → `0.12.2`, `appVersion` `v0.13.0` → `v0.13.1`
- `greenhouse` chart: `0.19.1` → `0.19.2`, `appVersion` `v0.13.0` → `v0.13.1`
- `authz` chart: `0.5.0` → `0.5.1`, `appVersion` `v0.13.0` → `v0.13.1`
- `idproxy` chart: `0.10.0` → `0.10.1`, `appVersion` `v0.13.0` → `v0.13.1`
- `cors-proxy` chart: `0.9.0` → `0.9.1`, `appVersion` `v0.13.0` → `v0.13.1`
- `greenhouse` dependency refs updated to match

 