### PR TITLE
feat(webhook): remove PP deletion prevention

### DIFF
--- a/api/v1alpha1/pluginpreset_types.go
+++ b/api/v1alpha1/pluginpreset_types.go
@@ -22,10 +22,6 @@ const (
 
 	// PluginDefinitionNotFound is set when the PluginDefinition referenced by the PluginPreset does not exist.
 	PluginDefinitionNotFound greenhousemetav1alpha1.ConditionReason = "PluginDefinitionNotFound"
-
-	// PreventDeletionAnnotation is the annotation used to prevent deletion of a PluginPreset.
-	// If the annotation is set the PluginPreset cannot be deleted.
-	PreventDeletionAnnotation = "greenhouse.sap/prevent-deletion"
 )
 
 // PluginPresetSpec defines the desired state of PluginPreset

--- a/docs/user-guides/plugin/plugin-management.md
+++ b/docs/user-guides/plugin/plugin-management.md
@@ -21,8 +21,6 @@ In case the _PluginPreset_ is updated all of the Plugin instances that are manag
 Changes that are done directly on a _Plugin_ which was created from a _PluginPreset_ will be overwritten immediately by the _PluginPreset_ Controller. All changes must be performed on the _PluginPreset_ itself.
 If a _Plugin_ already existed with the same name as the _PluginPreset_ would create, this _Plugin_ will be ignored in following reconciliations.
 
-A __PluginPreset__ with the annotation `greenhouse.sap/prevent-deletion` may not be deleted. This is to prevent the accidental deletion of a __PluginPreset__ including the managed __Plugins__ and their deployed Helm releases. Only after removing the annotation it is possible to delete a __PluginPreset__.
-
 ## Example _PluginPreset_
 
 ```yaml

--- a/e2e/plugin/scenarios/flux_controller.go
+++ b/e2e/plugin/scenarios/flux_controller.go
@@ -505,8 +505,6 @@ func FluxControllerPluginDependencies(ctx context.Context, adminClient client.Cl
 	}).Should(Succeed())
 
 	By("Deleting both plugin presets")
-	test.MustRemoveAnnotation(ctx, adminClient, midPluginPreset, greenhousev1alpha1.PreventDeletionAnnotation)
-	test.MustRemoveAnnotation(ctx, adminClient, leafPluginPreset, greenhousev1alpha1.PreventDeletionAnnotation)
 	Expect(adminClient.Delete(ctx, midPluginPreset)).To(Succeed())
 	Expect(adminClient.Delete(ctx, leafPluginPreset)).To(Succeed())
 
@@ -604,7 +602,6 @@ func FluxControllerPluginDeletionLifecycle(ctx context.Context, adminClient clie
 	}).Should(Succeed(), "should be able to add test finalizer to HelmRelease")
 
 	By("Deleting the PluginPreset to trigger Plugin deletion")
-	test.MustRemoveAnnotation(ctx, adminClient, pluginPreset, greenhousev1alpha1.PreventDeletionAnnotation)
 	Expect(adminClient.Delete(ctx, pluginPreset)).To(Succeed())
 
 	By("Waiting for the Plugin to enter the deletion phase and the controller to hold its finalizer")

--- a/internal/test/assert.go
+++ b/internal/test/assert.go
@@ -27,10 +27,6 @@ func EventuallyDeleted(ctx context.Context, c client.Client, obj client.Object) 
 	if ok {
 		UpdateClusterWithDeletionAnnotation(ctx, c, cluster)
 	}
-	pluginPreset, ok := obj.(*greenhousev1alpha1.PluginPreset)
-	if ok {
-		MustRemoveAnnotation(ctx, c, pluginPreset, greenhousev1alpha1.PreventDeletionAnnotation)
-	}
 
 	// Retry delete on conflict - the object may have been modified by controllers
 	Eventually(func(g Gomega) {

--- a/internal/webhook/v1alpha1/pluginpreset_webhook.go
+++ b/internal/webhook/v1alpha1/pluginpreset_webhook.go
@@ -33,11 +33,6 @@ func SetupPluginPresetWebhookWithManager(mgr ctrl.Manager) error {
 //+kubebuilder:webhook:path=/mutate-greenhouse-sap-v1alpha1-pluginpreset,mutating=true,failurePolicy=fail,sideEffects=None,groups=greenhouse.sap,resources=pluginpresets,verbs=create;update,versions=v1alpha1,name=mpluginpreset.kb.io,admissionReviewVersions=v1
 
 func DefaultPluginPreset(ctx context.Context, c client.Client, pluginPreset *greenhousev1alpha1.PluginPreset) error {
-	// prevent deletion on plugin preset creation
-	if pluginPreset.Annotations == nil {
-		pluginPreset.Annotations = map[string]string{}
-	}
-
 	if pluginPreset.Spec.Plugin.PluginDefinitionRef.Kind == "" {
 		pluginPreset.Spec.Plugin.PluginDefinitionRef.Kind = greenhousev1alpha1.PluginDefinitionKind
 	}

--- a/internal/webhook/v1alpha1/pluginpreset_webhook.go
+++ b/internal/webhook/v1alpha1/pluginpreset_webhook.go
@@ -5,7 +5,6 @@ package v1alpha1
 
 import (
 	"context"
-	"fmt"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -27,7 +26,6 @@ func SetupPluginPresetWebhookWithManager(mgr ctrl.Manager) error {
 			DefaultFunc:        DefaultPluginPreset,
 			ValidateCreateFunc: ValidateCreatePluginPreset,
 			ValidateUpdateFunc: ValidateUpdatePluginPreset,
-			ValidateDeleteFunc: ValidateDeletePluginPreset,
 		},
 	)
 }
@@ -38,9 +36,6 @@ func DefaultPluginPreset(ctx context.Context, c client.Client, pluginPreset *gre
 	// prevent deletion on plugin preset creation
 	if pluginPreset.Annotations == nil {
 		pluginPreset.Annotations = map[string]string{}
-	}
-	if pluginPreset.CreationTimestamp.IsZero() {
-		pluginPreset.Annotations[greenhousev1alpha1.PreventDeletionAnnotation] = "true"
 	}
 
 	if pluginPreset.Spec.Plugin.PluginDefinitionRef.Kind == "" {
@@ -121,19 +116,6 @@ func ValidateUpdatePluginPreset(ctx context.Context, c client.Client, oldPluginP
 		return allWarns, apierrors.NewInvalid(pluginPreset.GroupVersionKind().GroupKind(), pluginPreset.Name, allErrs)
 	}
 	return allWarns, nil
-}
-
-func ValidateDeletePluginPreset(_ context.Context, _ client.Client, pluginPreset *greenhousev1alpha1.PluginPreset) (admission.Warnings, error) {
-	var allErrs field.ErrorList
-	if _, ok := pluginPreset.Annotations[greenhousev1alpha1.PreventDeletionAnnotation]; ok {
-		allErrs = append(allErrs, field.Invalid(field.NewPath("metadata").Child("annotation").Child(greenhousev1alpha1.PreventDeletionAnnotation),
-			pluginPreset.Annotations, fmt.Sprintf("PluginPreset with annotation '%s' set may not be deleted.", greenhousev1alpha1.PreventDeletionAnnotation)))
-	}
-
-	if len(allErrs) > 0 {
-		return nil, apierrors.NewInvalid(pluginPreset.GroupVersionKind().GroupKind(), pluginPreset.Name, allErrs)
-	}
-	return nil, nil
 }
 
 // validatePluginOptionValuesForPreset validates plugin options and their values, but skips the check for required options.

--- a/internal/webhook/v1alpha1/pluginpreset_webhook_test.go
+++ b/internal/webhook/v1alpha1/pluginpreset_webhook_test.go
@@ -230,41 +230,6 @@ var _ = Describe("PluginPreset Admission Tests", Ordered, func() {
 
 		test.EventuallyDeleted(test.Ctx, test.K8sClient, cut)
 	})
-
-	It("should reject delete operation when PluginPreset has prevent deletion annotation", func() {
-		pluginPreset := &greenhousev1alpha1.PluginPreset{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      pluginPresetUpdate,
-				Namespace: test.TestNamespace,
-				Labels:    map[string]string{greenhouseapis.LabelKeyOwnedBy: teamWithSupportGroupName},
-				Annotations: map[string]string{
-					greenhousev1alpha1.PreventDeletionAnnotation: "true",
-				},
-			},
-			Spec: greenhousev1alpha1.PluginPresetSpec{
-				Plugin: greenhousev1alpha1.PluginPresetPluginSpec{
-					PluginDefinitionRef: greenhousev1alpha1.PluginDefinitionReference{
-						Name: pluginPresetClusterDefinition,
-						Kind: greenhousev1alpha1.ClusterPluginDefinitionKind,
-					},
-				},
-				ClusterSelector: metav1.LabelSelector{MatchLabels: map[string]string{"foo": "bar"}},
-			},
-		}
-
-		err := test.K8sClient.Create(test.Ctx, pluginPreset)
-		Expect(err).ToNot(HaveOccurred())
-
-		err = test.K8sClient.Delete(test.Ctx, pluginPreset)
-		Expect(err).To(HaveOccurred())
-
-		pluginPreset.Annotations = map[string]string{}
-		err = test.K8sClient.Update(test.Ctx, pluginPreset)
-		Expect(err).ToNot(HaveOccurred())
-
-		err = test.K8sClient.Delete(test.Ctx, pluginPreset)
-		Expect(err).ToNot(HaveOccurred())
-	})
 })
 
 var _ = Describe("Validate Plugin OptionValues for PluginPreset", func() {


### PR DESCRIPTION
## Description
This PR removes annotation `greenhouse.sap/prevent-deletion` and operations around handling it. 

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [x] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

- Closes #1948

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

## Added to documentation?

- [x] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [ ] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
