### PR TITLE
feat(pluginpresets): expose PluginDefinition version in PluginPreset status

### DIFF
--- a/api/v1alpha1/pluginpreset_types.go
+++ b/api/v1alpha1/pluginpreset_types.go
@@ -137,6 +137,8 @@ type PluginPresetStatus struct {
 	ReadyPlugins int `json:"readyPlugins,omitempty"`
 	// FailedPlugins is the number of failed Plugins managed by the PluginPreset.
 	FailedPlugins int `json:"failedPlugins,omitempty"`
+	// PluginDefinitionVersion is the version of the PluginDefinition referenced by this PluginPreset.
+	PluginDefinitionVersion string `json:"pluginDefinitionVersion,omitempty"`
 }
 
 // ManagedPluginStatus defines the Ready condition of a managed Plugin identified by its name.
@@ -149,6 +151,7 @@ type ManagedPluginStatus struct {
 //+kubebuilder:subresource:status
 //+kubebuilder:resource:shortName=pp
 //+kubebuilder:printcolumn:name="Plugin Definition",type=string,JSONPath=`.spec.plugin.pluginDefinitionRef.name`
+//+kubebuilder:printcolumn:name="Version",type=string,JSONPath=`.status.pluginDefinitionVersion`
 //+kubebuilder:printcolumn:name="Release Namespace",type=string,JSONPath=`.spec.plugin.releaseNamespace`
 //+kubebuilder:printcolumn:name="Ready",type="string",JSONPath=`.status.statusConditions.conditions[?(@.type == "Ready")].status`
 //+kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"

--- a/charts/manager/crds/greenhouse.sap_pluginpresets.yaml
+++ b/charts/manager/crds/greenhouse.sap_pluginpresets.yaml
@@ -23,6 +23,9 @@ spec:
     - jsonPath: .spec.plugin.pluginDefinitionRef.name
       name: Plugin Definition
       type: string
+    - jsonPath: .status.pluginDefinitionVersion
+      name: Version
+      type: string
     - jsonPath: .spec.plugin.releaseNamespace
       name: Release Namespace
       type: string
@@ -498,6 +501,10 @@ spec:
                 description: FailedPlugins is the number of failed Plugins managed
                   by the PluginPreset.
                 type: integer
+              pluginDefinitionVersion:
+                description: PluginDefinitionVersion is the version of the PluginDefinition
+                  referenced by this PluginPreset.
+                type: string
               pluginStatuses:
                 description: PluginStatuses contains statuses of Plugins managed by
                   the PluginPreset.

--- a/docs/reference/api/index.html
+++ b/docs/reference/api/index.html
@@ -3649,6 +3649,17 @@ int
 <p>FailedPlugins is the number of failed Plugins managed by the PluginPreset.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>pluginDefinitionVersion</code><br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>PluginDefinitionVersion is the version of the PluginDefinition referenced by this PluginPreset.</p>
+</td>
+</tr>
 </tbody>
 </table>
 </div>

--- a/docs/reference/api/openapi.yaml
+++ b/docs/reference/api/openapi.yaml
@@ -1504,6 +1504,9 @@ components:
             failedPlugins:
               description: FailedPlugins is the number of failed Plugins managed by the PluginPreset.
               type: integer
+            pluginDefinitionVersion:
+              description: PluginDefinitionVersion is the version of the PluginDefinition referenced by this PluginPreset.
+              type: string
             pluginStatuses:
               description: PluginStatuses contains statuses of Plugins managed by the PluginPreset.
               items:

--- a/internal/controller/plugin/pluginpreset_controller.go
+++ b/internal/controller/plugin/pluginpreset_controller.go
@@ -27,6 +27,7 @@ import (
 	greenhousemetav1alpha1 "github.com/cloudoperators/greenhouse/api/meta/v1alpha1"
 	greenhousev1alpha1 "github.com/cloudoperators/greenhouse/api/v1alpha1"
 	"github.com/cloudoperators/greenhouse/internal/clientutil"
+	"github.com/cloudoperators/greenhouse/internal/common"
 	"github.com/cloudoperators/greenhouse/internal/util"
 	"github.com/cloudoperators/greenhouse/pkg/lifecycle"
 )
@@ -125,6 +126,8 @@ func (r *PluginPresetReconciler) EnsureCreated(ctx context.Context, resource lif
 	}
 
 	clusters = clientutil.FilterClustersBeingDeleted(clusters)
+
+	r.reconcilePluginDefinitionVersion(ctx, pluginPreset)
 
 	err = r.reconcilePluginPreset(ctx, pluginPreset, clusters)
 	if err != nil {
@@ -327,6 +330,16 @@ func (r *PluginPresetReconciler) reconcilePluginStatuses(
 	}
 
 	return nil
+}
+
+// reconcilePluginDefinitionVersion fetches the referenced PluginDefinition and updates the version in the preset's status.
+func (r *PluginPresetReconciler) reconcilePluginDefinitionVersion(ctx context.Context, preset *greenhousev1alpha1.PluginPreset) {
+	pluginDefinitionSpec, err := common.GetPluginDefinitionSpec(ctx, r.Client, preset.Spec.Plugin.PluginDefinitionRef, preset.GetNamespace())
+	if err != nil {
+		// Version is best-effort; errors are already surfaced via conditions.
+		return
+	}
+	preset.Status.PluginDefinitionVersion = pluginDefinitionSpec.Version
 }
 
 func isPluginManagedByPreset(plugin *greenhousev1alpha1.Plugin, presetName string) bool {

--- a/internal/controller/plugin/pluginpreset_controller.go
+++ b/internal/controller/plugin/pluginpreset_controller.go
@@ -336,7 +336,8 @@ func (r *PluginPresetReconciler) reconcilePluginStatuses(
 func (r *PluginPresetReconciler) reconcilePluginDefinitionVersion(ctx context.Context, preset *greenhousev1alpha1.PluginPreset) {
 	pluginDefinitionSpec, err := common.GetPluginDefinitionSpec(ctx, r.Client, preset.Spec.Plugin.PluginDefinitionRef, preset.GetNamespace())
 	if err != nil {
-		// Version is best-effort; errors are already surfaced via conditions.
+		// Best-effort: clear the field to avoid reporting a stale version when the referenced definition can't be resolved.
+		preset.Status.PluginDefinitionVersion = ""
 		return
 	}
 	preset.Status.PluginDefinitionVersion = pluginDefinitionSpec.Version

--- a/internal/controller/plugin/pluginpreset_controller_test.go
+++ b/internal/controller/plugin/pluginpreset_controller_test.go
@@ -435,6 +435,7 @@ var _ = Describe("PluginPreset Controller Lifecycle", Ordered, func() {
 			g.Expect(managedPluginStatus.PluginName).To(Equal(expectedPluginName), "managed plugin status should have the correct PluginName set")
 			// Note: ReadyCondition may not be true since Flux is not running, but Plugin should exist
 			g.Expect(testPluginPreset.Status.TotalPlugins).To(Equal(1), "PluginPreset Status should show exactly one plugin in total")
+			g.Expect(testPluginPreset.Status.PluginDefinitionVersion).To(Equal(pluginPresetDefinition.Spec.Version), "PluginPreset status should expose the version of the referenced PluginDefinition")
 		}).Should(Succeed())
 
 		By("verifying HelmRelease exists for the managed Plugin")


### PR DESCRIPTION
<!--
Please ensure the PR title follows the conventional commit format:
<type>(<scope>): description

For a list of accepted types and scopes see the workflow documentation: https://github.com/cloudoperators/greenhouse/blob/main/.github/workflows/ci-pr-title.yaml

-->

## Description
<!--
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
This PR adds PluginDefinitionVersion to PluginPresetStatus. The field is populated on every reconcile and exposed as a print column.

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 

- Related Issue # (issue)
- Closes # (issue)
- Fixes # (issue)

-->
- Closes #1996 

## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [x] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
