### PR TITLE
feat(pluginpresets): add PluginDefinitionNotFound condition

### DIFF
--- a/api/v1alpha1/pluginpreset_types.go
+++ b/api/v1alpha1/pluginpreset_types.go
@@ -122,6 +122,8 @@ const (
 	PluginFailedCondition greenhousemetav1alpha1.ConditionType = "PluginFailed"
 	// AllPluginsReadyCondition is set when all Plugins managed by the PluginPreset are created and ready.
 	AllPluginsReadyCondition greenhousemetav1alpha1.ConditionType = "AllPluginsReady"
+	// PluginDefinitionNotFoundCondition is set when the referenced PluginDefinition or ClusterPluginDefinition cannot be resolved.
+	PluginDefinitionNotFoundCondition greenhousemetav1alpha1.ConditionType = "PluginDefinitionNotFound"
 )
 
 // PluginPresetStatus defines the observed state of PluginPreset

--- a/internal/controller/plugin/pluginpreset_controller.go
+++ b/internal/controller/plugin/pluginpreset_controller.go
@@ -38,6 +38,7 @@ var presetExposedConditions = []greenhousemetav1alpha1.ConditionType{
 	greenhousev1alpha1.PluginSkippedCondition,
 	greenhousev1alpha1.PluginFailedCondition,
 	greenhousev1alpha1.AllPluginsReadyCondition,
+	greenhousev1alpha1.PluginDefinitionNotFoundCondition,
 	greenhousemetav1alpha1.ClusterListEmpty,
 	greenhousemetav1alpha1.OwnerLabelSetCondition,
 }
@@ -93,6 +94,7 @@ func (r *PluginPresetReconciler) setConditions() lifecycle.Conditioner {
 			return
 		}
 
+		r.reconcilePluginDefinitionVersion(ctx, pluginPreset)
 		readyCondition := r.computeReadyCondition(pluginPreset.Status.StatusConditions)
 		ownerLabelCondition := util.ComputeOwnerLabelCondition(ctx, r.Client, pluginPreset)
 		util.UpdateOwnedByLabelMissingMetric(pluginPreset, ownerLabelCondition.IsFalse())
@@ -126,8 +128,6 @@ func (r *PluginPresetReconciler) EnsureCreated(ctx context.Context, resource lif
 	}
 
 	clusters = clientutil.FilterClustersBeingDeleted(clusters)
-
-	r.reconcilePluginDefinitionVersion(ctx, pluginPreset)
 
 	err = r.reconcilePluginPreset(ctx, pluginPreset, clusters)
 	if err != nil {
@@ -336,11 +336,18 @@ func (r *PluginPresetReconciler) reconcilePluginStatuses(
 func (r *PluginPresetReconciler) reconcilePluginDefinitionVersion(ctx context.Context, preset *greenhousev1alpha1.PluginPreset) {
 	pluginDefinitionSpec, err := common.GetPluginDefinitionSpec(ctx, r.Client, preset.Spec.Plugin.PluginDefinitionRef, preset.GetNamespace())
 	if err != nil {
-		// Best-effort: clear the field to avoid reporting a stale version when the referenced definition can't be resolved.
 		preset.Status.PluginDefinitionVersion = ""
+		preset.SetCondition(greenhousemetav1alpha1.TrueCondition(
+			greenhousev1alpha1.PluginDefinitionNotFoundCondition,
+			greenhousev1alpha1.PluginDefinitionNotFound,
+			err.Error(),
+		))
 		return
 	}
 	preset.Status.PluginDefinitionVersion = pluginDefinitionSpec.Version
+	preset.SetCondition(greenhousemetav1alpha1.FalseCondition(
+		greenhousev1alpha1.PluginDefinitionNotFoundCondition, "", "",
+	))
 }
 
 func isPluginManagedByPreset(plugin *greenhousev1alpha1.Plugin, presetName string) bool {
@@ -403,6 +410,12 @@ func (r *PluginPresetReconciler) computeReadyCondition(
 		} else {
 			readyCondition.Message = "Plugin reconciliation failed"
 		}
+		return readyCondition
+	}
+
+	if conditions.GetConditionByType(greenhousev1alpha1.PluginDefinitionNotFoundCondition).IsTrue() {
+		readyCondition.Status = metav1.ConditionFalse
+		readyCondition.Message = conditions.GetConditionByType(greenhousev1alpha1.PluginDefinitionNotFoundCondition).Message
 		return readyCondition
 	}
 

--- a/internal/controller/plugin/pluginpreset_controller_test.go
+++ b/internal/controller/plugin/pluginpreset_controller_test.go
@@ -436,6 +436,8 @@ var _ = Describe("PluginPreset Controller Lifecycle", Ordered, func() {
 			// Note: ReadyCondition may not be true since Flux is not running, but Plugin should exist
 			g.Expect(testPluginPreset.Status.TotalPlugins).To(Equal(1), "PluginPreset Status should show exactly one plugin in total")
 			g.Expect(testPluginPreset.Status.PluginDefinitionVersion).To(Equal(pluginPresetDefinition.Spec.Version), "PluginPreset status should expose the version of the referenced PluginDefinition")
+			g.Expect(testPluginPreset.Status.GetConditionByType(greenhousev1alpha1.PluginDefinitionNotFoundCondition)).ToNot(BeNil(), "PluginDefinitionNotFoundCondition should be present")
+			g.Expect(testPluginPreset.Status.GetConditionByType(greenhousev1alpha1.PluginDefinitionNotFoundCondition).IsFalse()).To(BeTrue(), "PluginDefinitionNotFoundCondition should be false when the PluginDefinition exists")
 		}).Should(Succeed())
 
 		By("verifying HelmRelease exists for the managed Plugin")
@@ -878,6 +880,20 @@ var _ = Describe("PluginPreset Controller Lifecycle", Ordered, func() {
 			g.Expect(pluginFailedCondition.Message).To(ContainSubstring(nonExistingDefinitionName),
 				"PluginFailedCondition message should reference the non-existing PluginDefinition")
 		}).Should(Succeed(), "PluginPreset should reflect the missing PluginDefinition in its status")
+
+		By("ensuring PluginDefinitionNotFoundCondition is set due to missing PluginDefinition")
+		Eventually(func(g Gomega) {
+			presetKey := types.NamespacedName{Name: pluginPresetName + "-missing-def", Namespace: test.TestNamespace}
+			g.Expect(test.K8sClient.Get(test.Ctx, presetKey, pluginPreset)).To(Succeed())
+			pdNotFoundCondition := pluginPreset.Status.GetConditionByType(greenhousev1alpha1.PluginDefinitionNotFoundCondition)
+			g.Expect(pdNotFoundCondition).ToNot(BeNil(), "PluginDefinitionNotFoundCondition should be set")
+			g.Expect(pdNotFoundCondition.IsTrue()).To(BeTrue(), "PluginDefinitionNotFoundCondition should be true")
+			g.Expect(string(pdNotFoundCondition.Reason)).To(Equal(string(greenhousev1alpha1.PluginDefinitionNotFound)),
+				"PluginDefinitionNotFoundCondition reason should be PluginDefinitionNotFound")
+			g.Expect(pdNotFoundCondition.Message).To(ContainSubstring(nonExistingDefinitionName),
+				"PluginDefinitionNotFoundCondition message should reference the non-existing PluginDefinition")
+			g.Expect(pluginPreset.Status.PluginDefinitionVersion).To(BeEmpty(), "PluginDefinitionVersion should be empty when the PluginDefinition does not exist")
+		}).Should(Succeed(), "PluginPreset should reflect the missing PluginDefinition via PluginDefinitionNotFoundCondition")
 
 		By("ensuring ReadyCondition is False")
 		Eventually(func(g Gomega) {


### PR DESCRIPTION
<!--
Please ensure the PR title follows the conventional commit format:
<type>(<scope>): description

For a list of accepted types and scopes see the workflow documentation: https://github.com/cloudoperators/greenhouse/blob/main/.github/workflows/ci-pr-title.yaml

-->

## Description
<!--
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
This PR adds a PluginNotFoundCondition and moves `reconcilePluginDefinitionVersion` to `r.setConditions()`.
The new PluginNotFoundCondition has an impact on overall Ready condition of PluginPreset.

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 

- Related Issue # (issue)
- Closes # (issue)
- Fixes # (issue)

-->
- Related Issue #1996 

## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [x] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
