### PR TITLE
fix(actions): bump issue-triage to fixed SHA to resolve YAML parsing error

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -10,4 +10,4 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-      - uses: cloudoperators/common/workflows/issue-triage@f87e1e6b7889707a9c10d1a8a9f9f481eb311c06 # main
+      - uses: cloudoperators/common/workflows/issue-triage@c7ec5c47aac160939836a5444d17f098b786c234 # main


### PR DESCRIPTION
## Problem

The Issue Triage workflow has been failing with:

```
Failed to load cloudoperators/common/f87e1e6b7889707a9c10d1a8a9f9f481eb311c06/workflows/issue-triage/action.yaml
System.ArgumentException: Unexpected type '' encountered while reading 'action manifest root'.
cloudoperators/common/f87e1e6b.../action.yaml: While scanning a simple key, could not find expected ':'.
```

## Root Cause

The workflow was pinned (by Renovate) to SHA `f87e1e6b7889707a9c10d1a8a9f9f481eb311c06` which contains a heredoc in the composite action that the GitHub Actions YAML parser cannot handle.

## Fix

Bump the pinned SHA to `c7ec5c47aac160939836a5444d17f098b786c234` which contains the fix from cloudoperators/common#61.

## References

- Root fix: https://github.com/cloudoperators/common/pull/61