### PR TITLE
chore(plugins): allow permission manager plugin in greenhouse management cluster

### DIFF
--- a/hack/docs-generator/alerts/main_test.go
+++ b/hack/docs-generator/alerts/main_test.go
@@ -32,7 +32,7 @@ func TestRunAgainstRealSource(t *testing.T) {
 		t.Fatalf("read output: %v", err)
 	}
 	out := string(data)
-	if len(strings.TrimSpace(out)) == 0 {
+	if strings.TrimSpace(out) == "" {
 		t.Fatal("output is empty")
 	}
 
@@ -63,7 +63,7 @@ func TestRunAgainstRealSource(t *testing.T) {
 	ghIdx := strings.Index(out, "## Greenhouse admin team")
 	orgIdx := strings.Index(out, "## Organization admin team")
 	supIdx := strings.Index(out, "## Support groups")
-	if ghIdx < 0 || orgIdx < 0 || supIdx < 0 || !(ghIdx < orgIdx && orgIdx < supIdx) {
+	if ghIdx < 0 || orgIdx < 0 || supIdx < 0 || ghIdx >= orgIdx || orgIdx >= supIdx {
 		t.Fatalf("section ordering broken: gh=%d org=%d sup=%d", ghIdx, orgIdx, supIdx)
 	}
 	ghSection := out[ghIdx:orgIdx]
@@ -107,8 +107,8 @@ func TestRunAgainstRealSource(t *testing.T) {
 
 	// team.alerts contributes one rule to org-admin and one to support-groups
 	// — the file split itself does not determine bucketing.
-	if !(strings.Contains(orgSection, "GreenhouseTeamMembershipCountDrop") &&
-		strings.Contains(supSection, "GreenhouseTeamRoleBindingNotReady")) {
+	if !strings.Contains(orgSection, "GreenhouseTeamMembershipCountDrop") ||
+		!strings.Contains(supSection, "GreenhouseTeamRoleBindingNotReady") {
 		t.Error("team.alerts must contribute rules to both org-admin and support-groups buckets")
 	}
 
@@ -137,7 +137,7 @@ func collectAlertNamesFromSource(t *testing.T, alertsDir string) []string {
 		if err != nil {
 			t.Fatalf("read %s: %v", e.Name(), err)
 		}
-		for _, line := range strings.Split(string(data), "\n") {
+		for line := range strings.SplitSeq(string(data), "\n") {
 			line = strings.TrimSpace(line)
 			const prefix = "- alert:"
 			if !strings.HasPrefix(line, prefix) {

--- a/hack/docs-generator/alerts/parse_test.go
+++ b/hack/docs-generator/alerts/parse_test.go
@@ -18,9 +18,9 @@ func TestParseFile_PluginAlerts(t *testing.T) {
 		t.Fatalf("expected 3 rules in plugin.alerts, got %d", len(rules))
 	}
 	want := map[string]bool{
-		"GreenhousePluginNotReady":             false,
-		"GreenhousePluginPresetNotReconciled":  false,
-		"GreenhousePluginConstantlyFailing":    false,
+		"GreenhousePluginNotReady":            false,
+		"GreenhousePluginPresetNotReconciled": false,
+		"GreenhousePluginConstantlyFailing":   false,
 	}
 	for _, r := range rules {
 		if _, ok := want[r.Alert]; !ok {

--- a/hack/docs-generator/alerts/render_test.go
+++ b/hack/docs-generator/alerts/render_test.go
@@ -111,7 +111,7 @@ func TestRender_BasicShape(t *testing.T) {
 	ghIdx := strings.Index(s, "## Greenhouse admin team")
 	orgIdx := strings.Index(s, "## Organization admin team")
 	supIdx := strings.Index(s, "## Support groups")
-	if !(ghIdx < orgIdx && orgIdx < supIdx) {
+	if ghIdx >= orgIdx || orgIdx >= supIdx {
 		t.Errorf("section ordering broken: gh=%d org=%d sup=%d", ghIdx, orgIdx, supIdx)
 	}
 

--- a/internal/webhook/v1alpha1/plugin_webhook.go
+++ b/internal/webhook/v1alpha1/plugin_webhook.go
@@ -30,7 +30,17 @@ import (
 // pluginsAllowedInCentralCluster is a list of PluginDefinitions that are allowed to be installed in the central cluster.
 // TODO: Make this configurable on pluginDefinition level (AdminPlugin discussion) instead of maintaining a list here.
 var pluginsAllowedInCentralCluster = []string{
-	"alerts", "doop", "heureka", "kube-monitoring", "kubeconfig-generator", "perses", "repo-guard", "service-proxy", "teams2slack", "thanos",
+	"alerts",
+	"doop",
+	"heureka",
+	"kube-monitoring",
+	"kubeconfig-generator",
+	"perses",
+	"permission-manager",
+	"repo-guard",
+	"service-proxy",
+	"teams2slack",
+	"thanos",
 }
 
 // TODO: Consume this constant from the tool integrating Greenhouse with vault/openBao, once implemented.


### PR DESCRIPTION
## Description

enable permission-manager plugin to run in management cluster

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [x] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

- Related Issue #2100 

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [x] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
