### PR TITLE
feat(plugins): remove obsolete global.greenhouse OptionValues

### DIFF
--- a/docs/contribute/plugins.md
+++ b/docs/contribute/plugins.md
@@ -48,11 +48,12 @@ Here's a high-level overview of how to develop a plugin for Greenhouse:
    - Provide a list of `PluginOptions` which are values that are consumed to configure the actual `Plugin` instance of your `PluginDefinition`.
      Greenhouse always provides some global values that are injected into your `Plugin` upon deployment:
      - `global.greenhouse.organizationName`: The `name` of your `Organization`
-     - `global.greenhouse.teamNames`: All available `Teams` in your `Organization`
-     - `global.greenhouse.clusterNames`: All available `Clusters` in your `Organization`
      - `global.greenhouse.clusterName`: The `name` of the `Cluster` this `Plugin` instance is deployed to.
      - `global.greenhouse.baseDomain`: The base domain of your Greenhouse installation
      - `global.greenhouse.ownedBy`: The owner (usually a owning `Team`) of this `Plugin` instance
+     - `global.greenhouse.metadata.*`: The metadata labels of the `Cluster` this `Plugin` instance is deployed to
+
+     See [Injected Greenhouse Values](./../../reference/components/plugin#injected-greenhouse-values).
 
 3. **Plugin Components**:
 

--- a/docs/reference/components/plugin.md
+++ b/docs/reference/components/plugin.md
@@ -85,6 +85,22 @@ spec:
     - /spec/replicas
 ```
 
+## Injected Greenhouse Values
+
+The defaulting webhook adds a set of `global.greenhouse.*` OptionValues to every Plugin. A PluginDefinition does not need to declare them as PluginOptions. They are passed to the Helm chart like any other OptionValue and can be referenced in [PluginPreset expressions](./../pluginpreset#cel-expressions-in-optionvalues).
+
+| Value                                | Description                                                     | Example                  |
+|--------------------------------------|-----------------------------------------------------------------|--------------------------|
+| `global.greenhouse.organizationName` | Name of the `Organization`                                      | `my-org`                 |
+| `global.greenhouse.clusterName`      | Name of the target `Cluster`                                    | `cluster-a`              |
+| `global.greenhouse.baseDomain`       | Base domain of the Greenhouse installation                      | `greenhouse.example.com` |
+| `global.greenhouse.ownedBy`          | Owning `Team` of the Plugin                                     | `team-1`                 |
+| `global.greenhouse.metadata.*`       | [Cluster metadata labels](./../cluster#setting-metadata-labels) | `eu-de-1`                |
+
+`clusterName` and `metadata.*` are only set for Plugins targeting a Cluster, `ownedBy` only if the Plugin has the `greenhouse.sap/owned-by` label.
+
+> :warning: `global.greenhouse.clusterNames` and `global.greenhouse.teamNames` held all Clusters and Teams of an Organization. They are no longer passed to the Helm chart, which takes effect on the next reconciliation of a Plugin, not only when it is edited. They are additionally removed from `.spec.optionValues` the next time the Plugin is created or updated. A PluginPreset `.spec.plugin.optionValues[].expression` still referencing either of them fails to evaluate and blocks the PluginPreset from rolling out its Plugins, so migrate those to `global.greenhouse.clusterName` and `global.greenhouse.metadata.*` first.
+
 ## Working with Plugins
 
 ### Suspending the Plugin's reconciliation

--- a/docs/reference/components/pluginpreset.md
+++ b/docs/reference/components/pluginpreset.md
@@ -121,12 +121,13 @@ spec:
 |--------------------------------------|----------------------------|------------------------------|
 | `global.greenhouse.clusterName`      | Name of the target cluster | `cluster-a`                  |
 | `global.greenhouse.organizationName` | Organization namespace     | `my-org`                     |
-| `global.greenhouse.clusterNames`     | List of all cluster names  | `["cluster-a", "cluster-b"]` |
-| `global.greenhouse.teamNames`        | List of all team names     | `["team-1", "team-2"]`       |
 | `global.greenhouse.baseDomain`       | Base DNS domain            | `greenhouse.example.com`     |
+| `global.greenhouse.ownedBy`          | Owning `Team`              | `team-1`                     |
 | `global.greenhouse.metadata.*`       | Cluster metadata labels    | `eu-de-1`                    |
 
 > :information_source: `global.greenhouse.metadata.*` values are derived from cluster labels prefixed with `metadata.greenhouse.sap/`. For example, the label `metadata.greenhouse.sap/region: eu-de-1` becomes available as `global.greenhouse.metadata.region`.
+
+> :warning: `global.greenhouse.clusterNames` and `global.greenhouse.teamNames` were removed. An expression still referencing either of them fails to evaluate and blocks the PluginPreset from rolling out its Plugins. See [Injected Greenhouse Values](./../plugin#injected-greenhouse-values).
 
 ### Examples
 

--- a/docs/user-guides/plugin/metadata-expressions.md
+++ b/docs/user-guides/plugin/metadata-expressions.md
@@ -54,10 +54,11 @@ The following `global.greenhouse.*` variables are available in expressions:
 |----------|-------------|
 | `global.greenhouse.clusterName` | The name of the target cluster |
 | `global.greenhouse.organizationName` | The name of the organization |
-| `global.greenhouse.clusterNames` | Names of all clusters in the organization |
-| `global.greenhouse.teamNames` | Names of all teams in the organization |
 | `global.greenhouse.baseDomain` | DNS base domain for Greenhouse |
+| `global.greenhouse.ownedBy` | The owning team of the Plugin |
 | `global.greenhouse.metadata.*` | Cluster metadata labels |
+
+> :warning: `global.greenhouse.clusterNames` and `global.greenhouse.teamNames` were removed. An expression still referencing either of them fails to evaluate and blocks the PluginPreset from rolling out its Plugins. See [Injected Greenhouse Values](./../../../reference/components/plugin#injected-greenhouse-values).
 
 ### Using CEL Functions
 

--- a/internal/cmd/plugin_template.go
+++ b/internal/cmd/plugin_template.go
@@ -202,7 +202,7 @@ func (o *PluginTemplatePresetOptions) prepareValues() error {
 		return err
 	}
 
-	o.values = values
+	o.values = helminternal.StripRetiredGreenhouseValues(values)
 	return nil
 }
 

--- a/internal/cmd/plugin_template.go
+++ b/internal/cmd/plugin_template.go
@@ -243,8 +243,6 @@ func (o *PluginTemplatePresetOptions) runHelmTemplate(valuesFile string) error {
 
 func (o *PluginTemplatePresetOptions) getGreenhouseValuesForTemplate() ([]greenhousev1alpha1.PluginOptionValue, error) {
 	literalPaths := []string{
-		"global.greenhouse.clusterNames",
-		"global.greenhouse.teamNames",
 		"global.greenhouse.baseDomain",
 		"global.greenhouse.ownedBy",
 	}

--- a/internal/cmd/plugin_template.go
+++ b/internal/cmd/plugin_template.go
@@ -202,7 +202,7 @@ func (o *PluginTemplatePresetOptions) prepareValues() error {
 		return err
 	}
 
-	o.values = helminternal.StripRetiredGreenhouseValues(values)
+	o.values = helminternal.StripExcludedGreenhouseValues(values)
 	return nil
 }
 

--- a/internal/cmd/plugin_template_test.go
+++ b/internal/cmd/plugin_template_test.go
@@ -155,6 +155,25 @@ var _ = Describe("prepareValues", func() {
 		opts.pluginPreset = pluginPreset
 	})
 
+	Context("with retired greenhouse values in the preset", func() {
+		It("should not render values the controller no longer injects", func() {
+			pluginPreset.Spec.Plugin.OptionValues = []greenhousev1alpha1.PluginPresetPluginOptionValue{
+				{Name: "global.greenhouse.clusterNames", Value: &apiextensionsv1.JSON{Raw: []byte(`["cluster-a"]`)}},
+				{Name: "global.greenhouse.teamNames", Value: &apiextensionsv1.JSON{Raw: []byte(`["team-1"]`)}},
+			}
+
+			err := opts.prepareValues()
+			Expect(err).NotTo(HaveOccurred())
+
+			names := make([]string, 0, len(opts.values))
+			for _, v := range opts.values {
+				names = append(names, v.Name)
+			}
+			Expect(names).NotTo(ContainElement("global.greenhouse.clusterNames"))
+			Expect(names).NotTo(ContainElement("global.greenhouse.teamNames"))
+		})
+	})
+
 	Context("with PluginDefinition defaults only", func() {
 		It("should include default values", func() {
 			err := opts.prepareValues()

--- a/internal/cmd/plugin_template_test.go
+++ b/internal/cmd/plugin_template_test.go
@@ -155,7 +155,7 @@ var _ = Describe("prepareValues", func() {
 		opts.pluginPreset = pluginPreset
 	})
 
-	Context("with retired greenhouse values in the preset", func() {
+	Context("with excluded greenhouse values in the preset", func() {
 		It("should not render values the controller no longer injects", func() {
 			pluginPreset.Spec.Plugin.OptionValues = []greenhousev1alpha1.PluginPresetPluginOptionValue{
 				{Name: "global.greenhouse.clusterNames", Value: &apiextensionsv1.JSON{Raw: []byte(`["cluster-a"]`)}},

--- a/internal/helm/helm_test.go
+++ b/internal/helm/helm_test.go
@@ -87,14 +87,14 @@ var _ = Describe("helm package test", func() {
 				ContainElement(HaveField("Name", "global.greenhouse.teamNames")), "the obsolete teamNames should not be generated")
 		})
 
-		It("should not mutate its input when stripping retired values", func() {
+		It("should not mutate its input when stripping excluded values", func() {
 			values := []greenhousev1alpha1.PluginOptionValue{
 				{Name: "key1", Value: test.MustReturnJSONFor("pluginValue1")},
 				{Name: "global.greenhouse.clusterNames", Value: test.MustReturnJSONFor([]string{"stale-cluster"})},
 			}
 			valuesBefore := slices.Clone(values)
 
-			Expect(helm.StripRetiredGreenhouseValues(values)).To(HaveLen(1), "the retired value should be dropped")
+			Expect(helm.StripExcludedGreenhouseValues(values)).To(HaveLen(1), "the excluded value should be dropped")
 			Expect(values).To(Equal(valuesBefore), "the input should be left untouched")
 		})
 
@@ -129,7 +129,7 @@ var _ = Describe("helm package test", func() {
 				ContainElement(greenhousev1alpha1.PluginOptionValue{Name: "key1", Value: test.MustReturnJSONFor("pluginValue1"), ValueFrom: nil}), "unrelated option values should be preserved")
 		})
 
-		It("should not mutate the plugin spec while dropping retired values", func() {
+		It("should not mutate the plugin spec while dropping excluded values", func() {
 			definitionWithoutOptions := testPluginWithHelmChart.DeepCopy()
 			definitionWithoutOptions.Name = "definition-without-options"
 			definitionWithoutOptions.Spec.Options = nil

--- a/internal/helm/helm_test.go
+++ b/internal/helm/helm_test.go
@@ -68,8 +68,6 @@ var _ = Describe("helm package test", func() {
 			Expect(pluginOptionValues).To(
 				ContainElement(greenhousev1alpha1.PluginOptionValue{Name: "key1", Value: test.MustReturnJSONFor("pluginValue1"), ValueFrom: nil}), "the plugin option values should contain default from pluginDefinition spec")
 			Expect(pluginOptionValues).To(
-				ContainElement(greenhousev1alpha1.PluginOptionValue{Name: "global.greenhouse.teamNames", Value: test.MustReturnJSONFor([]string{"test-team-1"}), ValueFrom: nil}), "the plugin option values should contain greenhouse values")
-			Expect(pluginOptionValues).To(
 				ContainElement(greenhousev1alpha1.PluginOptionValue{Name: "global.greenhouse.clusterName", Value: test.MustReturnJSONFor(plugin.Spec.ClusterName), ValueFrom: nil}), "the plugin option values should contain the clusterName from the plugin")
 			Expect(pluginOptionValues).To(
 				ContainElement(greenhousev1alpha1.PluginOptionValue{Name: "global.greenhouse.organizationName", Value: test.MustReturnJSONFor(plugin.GetNamespace()), ValueFrom: nil}), "the plugin option values should contain the orgName from the plugin namespace")
@@ -78,6 +76,20 @@ var _ = Describe("helm package test", func() {
 			Expect(pluginOptionValues).To(
 				ContainElement(greenhousev1alpha1.PluginOptionValue{Name: "global.greenhouse.ownedBy", Value: test.MustReturnJSONFor(plugin.Labels[string(greenhouseapis.LabelKeyOwnedBy)]), ValueFrom: nil}), "the plugin option values should contain the owning team")
 		})
+
+		It("should not inject the obsolete clusterNames and teamNames greenhouse values", func() {
+			plugin.Spec.OptionValues = []greenhousev1alpha1.PluginOptionValue{*optionValue}
+			ensureExists(testPluginWithHelmChart)
+			ensureExists(team)
+
+			pluginOptionValues, err := helm.GetPluginOptionValuesForPlugin(test.Ctx, test.K8sClient, plugin)
+			Expect(err).ShouldNot(HaveOccurred(), "there should be no error getting the plugin option values")
+			Expect(pluginOptionValues).ToNot(
+				ContainElement(HaveField("Name", "global.greenhouse.clusterNames")), "the obsolete clusterNames should not be injected")
+			Expect(pluginOptionValues).ToNot(
+				ContainElement(HaveField("Name", "global.greenhouse.teamNames")), "the obsolete teamNames should not be injected")
+		})
+
 	})
 
 	When("handling a helm chart from a pluginDefinition", func() {
@@ -252,3 +264,14 @@ var _ = Describe("Plugin option checksum", Ordered, func() {
 		Entry("different option values should not be equal", optionValuesRequiredAndOptional, optionValuesRequiredAndSecret, false),
 	)
 })
+
+// ensureExists creates a copy of obj unless it already exists, dropping the resourceVersion
+// so shared fixtures can be reused across specs.
+func ensureExists(obj client.Object) {
+	GinkgoHelper()
+	objCopy, ok := obj.DeepCopyObject().(client.Object)
+	Expect(ok).To(BeTrue(), "the deep copy should implement client.Object")
+	objCopy.SetResourceVersion("")
+	Expect(client.IgnoreAlreadyExists(test.K8sClient.Create(test.Ctx, objCopy))).
+		To(Succeed(), "creating %T %s should be successful", obj, obj.GetName())
+}

--- a/internal/helm/helm_test.go
+++ b/internal/helm/helm_test.go
@@ -6,6 +6,7 @@ package helm_test
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -90,6 +91,50 @@ var _ = Describe("helm package test", func() {
 				ContainElement(HaveField("Name", "global.greenhouse.teamNames")), "the obsolete teamNames should not be injected")
 		})
 
+		It("should drop obsolete greenhouse values already persisted in the plugin spec", func() {
+			plugin.Spec.OptionValues = []greenhousev1alpha1.PluginOptionValue{
+				*optionValue,
+				{Name: "global.greenhouse.clusterNames", Value: test.MustReturnJSONFor([]string{"stale-cluster"})},
+				{Name: "global.greenhouse.teamNames", Value: test.MustReturnJSONFor([]string{"stale-team"})},
+			}
+			ensureExists(testPluginWithHelmChart)
+
+			pluginOptionValues, err := helm.GetPluginOptionValuesForPlugin(test.Ctx, test.K8sClient, plugin)
+			Expect(err).ShouldNot(HaveOccurred(), "there should be no error getting the plugin option values")
+			Expect(pluginOptionValues).ToNot(
+				ContainElement(HaveField("Name", "global.greenhouse.clusterNames")), "the stale clusterNames should be removed from the spec")
+			Expect(pluginOptionValues).ToNot(
+				ContainElement(HaveField("Name", "global.greenhouse.teamNames")), "the stale teamNames should be removed from the spec")
+			Expect(pluginOptionValues).To(
+				ContainElement(greenhousev1alpha1.PluginOptionValue{Name: "key1", Value: test.MustReturnJSONFor("pluginValue1"), ValueFrom: nil}), "unrelated option values should be preserved")
+		})
+
+		It("should not mutate the plugin spec while dropping retired values", func() {
+			definitionWithoutOptions := testPluginWithHelmChart.DeepCopy()
+			definitionWithoutOptions.Name = "definition-without-options"
+			definitionWithoutOptions.Spec.Options = nil
+			ensureExists(definitionWithoutOptions)
+
+			// Nil Options plus a spec that already holds every greenhouse value means the merge
+			// neither copies nor reallocates, which is what leaves the slice aliased to the spec.
+			// The values are deliberately stale, so an in-place overwrite is observable.
+			pluginWithoutOptions := plugin.DeepCopy()
+			pluginWithoutOptions.Labels = nil
+			pluginWithoutOptions.Spec.ClusterName = ""
+			pluginWithoutOptions.Spec.PluginDefinitionRef.Name = definitionWithoutOptions.Name
+			pluginWithoutOptions.Spec.OptionValues = []greenhousev1alpha1.PluginOptionValue{
+				{Name: "key1", Value: test.MustReturnJSONFor("pluginValue1")},
+				{Name: "global.greenhouse.organizationName", Value: test.MustReturnJSONFor("stale-org")},
+				{Name: "global.greenhouse.baseDomain", Value: test.MustReturnJSONFor("stale.example.com")},
+				{Name: "global.greenhouse.clusterNames", Value: test.MustReturnJSONFor([]string{"stale-cluster"})},
+				{Name: "global.greenhouse.teamNames", Value: test.MustReturnJSONFor([]string{"stale-team"})},
+			}
+			specBefore := slices.Clone(pluginWithoutOptions.Spec.OptionValues)
+
+			_, err := helm.GetPluginOptionValuesForPlugin(test.Ctx, test.K8sClient, pluginWithoutOptions)
+			Expect(err).ShouldNot(HaveOccurred(), "there should be no error getting the plugin option values")
+			Expect(pluginWithoutOptions.Spec.OptionValues).To(Equal(specBefore), "the plugin spec should be left untouched")
+		})
 	})
 
 	When("handling a helm chart from a pluginDefinition", func() {

--- a/internal/helm/helm_test.go
+++ b/internal/helm/helm_test.go
@@ -78,6 +78,26 @@ var _ = Describe("helm package test", func() {
 				ContainElement(greenhousev1alpha1.PluginOptionValue{Name: "global.greenhouse.ownedBy", Value: test.MustReturnJSONFor(plugin.Labels[string(greenhouseapis.LabelKeyOwnedBy)]), ValueFrom: nil}), "the plugin option values should contain the owning team")
 		})
 
+		It("should not generate the obsolete clusterNames and teamNames greenhouse values", func() {
+			greenhouseValues, err := helm.GetGreenhouseValues(test.Ctx, test.K8sClient, *plugin)
+			Expect(err).ShouldNot(HaveOccurred(), "there should be no error getting the greenhouse values")
+			Expect(greenhouseValues).ToNot(
+				ContainElement(HaveField("Name", "global.greenhouse.clusterNames")), "the obsolete clusterNames should not be generated")
+			Expect(greenhouseValues).ToNot(
+				ContainElement(HaveField("Name", "global.greenhouse.teamNames")), "the obsolete teamNames should not be generated")
+		})
+
+		It("should not mutate its input when stripping retired values", func() {
+			values := []greenhousev1alpha1.PluginOptionValue{
+				{Name: "key1", Value: test.MustReturnJSONFor("pluginValue1")},
+				{Name: "global.greenhouse.clusterNames", Value: test.MustReturnJSONFor([]string{"stale-cluster"})},
+			}
+			valuesBefore := slices.Clone(values)
+
+			Expect(helm.StripRetiredGreenhouseValues(values)).To(HaveLen(1), "the retired value should be dropped")
+			Expect(values).To(Equal(valuesBefore), "the input should be left untouched")
+		})
+
 		It("should not inject the obsolete clusterNames and teamNames greenhouse values", func() {
 			plugin.Spec.OptionValues = []greenhousev1alpha1.PluginOptionValue{*optionValue}
 			ensureExists(testPluginWithHelmChart)

--- a/internal/helm/values.go
+++ b/internal/helm/values.go
@@ -6,6 +6,7 @@ package helm
 import (
 	"context"
 	"encoding/json"
+	"slices"
 	"strings"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -17,20 +18,34 @@ import (
 	"github.com/cloudoperators/greenhouse/internal/common"
 )
 
+var retiredGreenhouseValues = []string{
+	"global.greenhouse.clusterNames",
+	"global.greenhouse.teamNames",
+}
+
 func GetPluginOptionValuesForPlugin(ctx context.Context, c client.Client, plugin *greenhousev1alpha1.Plugin) ([]greenhousev1alpha1.PluginOptionValue, error) {
 	pluginDefinitionSpec, err := common.GetPluginDefinitionSpec(ctx, c, plugin.Spec.PluginDefinitionRef, plugin.GetNamespace())
 	if err != nil {
 		return nil, err
 	}
 
-	values := MergePluginAndPluginOptionValueSlice(pluginDefinitionSpec.Options, plugin.Spec.OptionValues)
+	// Clone, as the merge writes through to its input when the PluginDefinition declares no options.
+	values := MergePluginAndPluginOptionValueSlice(pluginDefinitionSpec.Options, slices.Clone(plugin.Spec.OptionValues))
 	// Enrich with default greenhouse values.
 	greenhouseValues, err := GetGreenhouseValues(ctx, c, *plugin)
 	if err != nil {
 		return nil, err
 	}
 	values = MergePluginOptionValues(values, greenhouseValues)
-	return values, nil
+	return StripRetiredGreenhouseValues(values), nil
+}
+
+// StripRetiredGreenhouseValues drops the values Greenhouse no longer injects.
+// It clones, as the input may alias a Plugin's OptionValues.
+func StripRetiredGreenhouseValues(values []greenhousev1alpha1.PluginOptionValue) []greenhousev1alpha1.PluginOptionValue {
+	return slices.DeleteFunc(slices.Clone(values), func(v greenhousev1alpha1.PluginOptionValue) bool {
+		return slices.Contains(retiredGreenhouseValues, v.Name)
+	})
 }
 
 // GetGreenhouseValues generate values for greenhouse core resources in the form:

--- a/internal/helm/values.go
+++ b/internal/helm/values.go
@@ -18,7 +18,7 @@ import (
 	"github.com/cloudoperators/greenhouse/internal/common"
 )
 
-var retiredGreenhouseValues = []string{
+var excludedGreenhouseValues = []string{
 	"global.greenhouse.clusterNames",
 	"global.greenhouse.teamNames",
 }
@@ -37,14 +37,14 @@ func GetPluginOptionValuesForPlugin(ctx context.Context, c client.Client, plugin
 		return nil, err
 	}
 	values = MergePluginOptionValues(values, greenhouseValues)
-	return StripRetiredGreenhouseValues(values), nil
+	return StripExcludedGreenhouseValues(values), nil
 }
 
-// StripRetiredGreenhouseValues drops the values Greenhouse no longer injects.
+// StripExcludedGreenhouseValues drops the values Greenhouse no longer injects.
 // It clones, as the input may alias a Plugin's OptionValues.
-func StripRetiredGreenhouseValues(values []greenhousev1alpha1.PluginOptionValue) []greenhousev1alpha1.PluginOptionValue {
+func StripExcludedGreenhouseValues(values []greenhousev1alpha1.PluginOptionValue) []greenhousev1alpha1.PluginOptionValue {
 	return slices.DeleteFunc(slices.Clone(values), func(v greenhousev1alpha1.PluginOptionValue) bool {
-		return slices.Contains(retiredGreenhouseValues, v.Name)
+		return slices.Contains(excludedGreenhouseValues, v.Name)
 	})
 }
 

--- a/internal/helm/values.go
+++ b/internal/helm/values.go
@@ -6,7 +6,6 @@ package helm
 import (
 	"context"
 	"encoding/json"
-	"sort"
 	"strings"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -38,52 +37,14 @@ func GetPluginOptionValuesForPlugin(ctx context.Context, c client.Client, plugin
 //
 //	global:
 //	  greenhouse:
-//	    clusterNames:
-//		  - <name>
-//		teams:
-//		  - <name>
+//	    organizationName: <name>
+//	    clusterName: <name>
+//	    baseDomain: <domain>
+//	    ownedBy: <team>
+//	    metadata:
+//	      <key>: <value>
 func GetGreenhouseValues(ctx context.Context, c client.Client, p greenhousev1alpha1.Plugin) ([]greenhousev1alpha1.PluginOptionValue, error) {
 	greenhouseValues := make([]greenhousev1alpha1.PluginOptionValue, 0)
-	var clusterList = new(greenhousev1alpha1.ClusterList)
-	if err := c.List(ctx, clusterList, &client.ListOptions{Namespace: p.GetNamespace()}); err != nil {
-		return nil, err
-	}
-	clusterNames := make([]string, len(clusterList.Items))
-	for idx, cluster := range clusterList.Items {
-		clusterNames[idx] = cluster.Name
-	}
-
-	clusterNamesVal, err := stringSliceToHelmValue(clusterNames)
-	if err != nil {
-		return nil, err
-	}
-
-	greenhouseValues = append(greenhouseValues, greenhousev1alpha1.PluginOptionValue{
-		Name:      "global.greenhouse.clusterNames",
-		Value:     clusterNamesVal,
-		ValueFrom: nil,
-	})
-
-	// Teams within the organization.
-	var teamList = new(greenhousev1alpha1.TeamList)
-	if err := c.List(ctx, teamList, client.InNamespace(p.GetNamespace())); err != nil {
-		return nil, err
-	}
-	teamNames := make([]string, len(teamList.Items))
-	for idx, team := range teamList.Items {
-		teamNames[idx] = team.Name
-	}
-
-	teamNamesVal, err := stringSliceToHelmValue(teamNames)
-	if err != nil {
-		return nil, err
-	}
-
-	greenhouseValues = append(greenhouseValues, greenhousev1alpha1.PluginOptionValue{
-		Name:      "global.greenhouse.teamNames",
-		Value:     teamNamesVal,
-		ValueFrom: nil,
-	})
 
 	// append orgName
 	orgNameVal, err := json.Marshal(p.GetNamespace())
@@ -165,17 +126,6 @@ func setOrAppendNameValue(valueSlice []greenhousev1alpha1.PluginOptionValue, val
 		}
 	}
 	return append(valueSlice, valueToSetOrAppend)
-}
-
-// stringSliceToHelmValue sorts theSlice, marshals it to JSON and returns an apiextensionsv1.JSON object.
-func stringSliceToHelmValue(theSlice []string) (*apiextensionsv1.JSON, error) {
-	sort.Strings(theSlice)
-
-	raw, err := json.Marshal(theSlice)
-	if err != nil {
-		return nil, err
-	}
-	return &apiextensionsv1.JSON{Raw: raw}, nil
 }
 
 // extractMetadataKey extracts the metadata key from cluster labels with the pattern "metadata.greenhouse.sap/<key>".

--- a/internal/helm/values.go
+++ b/internal/helm/values.go
@@ -48,7 +48,7 @@ func StripRetiredGreenhouseValues(values []greenhousev1alpha1.PluginOptionValue)
 	})
 }
 
-// GetGreenhouseValues generate values for greenhouse core resources in the form:
+// GetGreenhouseValues generates values for greenhouse core resources in the form:
 //
 //	global:
 //	  greenhouse:


### PR DESCRIPTION
## Description

**Before:** `global.greenhouse.clusterNames` and `global.greenhouse.teamNames` were injected into every Plugin and consumed by none, so every Helm values file carried the full list of clusters and teams in the Organization.

**After:** they are no longer injected, and are stripped from Plugins that already have them persisted in `.spec.optionValues`.

A PluginPreset `expression` referencing either value blocks the PluginPreset from rolling out its Plugins, a chart template ranging over them renders nothing. Migrate to `global.greenhouse.clusterName` and `global.greenhouse.metadata.*`.

`spec.values` changes on every existing HelmRelease.

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [x] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

- Closes #1959

## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

## Added to documentation?

- [ ] 📜 README.md
- [x] 🤝 Documentation pages updated
- [ ] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

