### PR TITLE
fix(clusters): fix cyclic dependencies during cluster/secret removal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ generate-documentation: check-gen-crd-api-reference-docs generate-alerts-doc
 	$(GEN_DOCS) -api-dir=$(GEN_DOCS_API_DIR) -config=$(GEN_DOCS_CONFIG) -template-dir=$(GEN_DOCS_TEMPLATE_DIR) -out-file=$(GEN_DOCS_OUT_FILE)
 
 .PHONY: test
-test: manifests generate envtest flux-crds ## Run tests.
+test: manifests generate license envtest flux-crds ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -coverprofile cover.out -v
 	cd api; go test ./...
 

--- a/internal/controller/cluster/bootstrap_controller.go
+++ b/internal/controller/cluster/bootstrap_controller.go
@@ -69,10 +69,31 @@ func (r *BootstrapReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	if err := r.Get(ctx, req.NamespacedName, kubeConfigSecret); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
-	if !kubeConfigSecret.DeletionTimestamp.IsZero() {
+	if kubeConfigSecret.DeletionTimestamp.IsZero() {
+		if !controllerutil.ContainsFinalizer(kubeConfigSecret, secretFinalizer) {
+			controllerutil.AddFinalizer(kubeConfigSecret, secretFinalizer)
+			if err := r.Update(ctx, kubeConfigSecret); err != nil {
+				return ctrl.Result{}, err
+			}
+			return ctrl.Result{RequeueAfter: time.Second}, nil
+		}
+	} else {
 		// the secret is being deleted
-		return ctrl.Result{}, r.requestClusterDeletion(ctx, req.NamespacedName)
+		if controllerutil.ContainsFinalizer(kubeConfigSecret, secretFinalizer) {
+			// we have finalizer, so delete cluster if one can be found
+			cluster := greenhousev1alpha1.Cluster{}
+			if err := r.Get(ctx, req.NamespacedName, &cluster); err != nil {
+				return ctrl.Result{}, client.IgnoreNotFound(err)
+			}
+			log.FromContext(ctx).Info(
+				"Cluster secret is being deleted, requesting Cluster deletion",
+				"cluster", req.NamespacedName.String(),
+			)
+			return ctrl.Result{}, client.IgnoreNotFound(r.Delete(ctx, &cluster))
+		}
+		return ctrl.Result{}, nil
 	}
+
 	if kubeConfigSecret.Type == greenhouseapis.SecretTypeOIDCConfig {
 		// if secret type is oidc we check if a kubeconfig was already generated,
 		// and we also check if the greenhousekubeconfig key is present and the value is not empty
@@ -201,7 +222,7 @@ func (r *BootstrapReconciler) createOrUpdateCluster(
 		logMessage := fmt.Sprintf("%s cluster", result)
 		log.FromContext(ctx).Info(logMessage, "namespace", cluster.Namespace, "name", cluster.Name)
 	}
-	return r.ensureSecretFinalizer(ctx, kubeConfigSecret)
+	return nil
 }
 
 // ensureOwnerReferences adds the ownerReference to the secret containing the kubeconfig, so that it is garbage collected on cluster deletion.
@@ -219,28 +240,10 @@ func (r *BootstrapReconciler) ensureOwnerReferences(ctx context.Context, kubeCon
 	return err
 }
 
-// ensureSecretFinalizer adds the finalizer to the secret containing the kubeconfig, so that it will not be deleted before cluster deletion.
-func (r *BootstrapReconciler) ensureSecretFinalizer(ctx context.Context, secret *corev1.Secret) error {
-	if !controllerutil.ContainsFinalizer(secret, secretFinalizer) {
-		controllerutil.AddFinalizer(secret, secretFinalizer)
-		return r.Update(ctx, secret)
-	}
-	return nil
-}
-
 func (r *BootstrapReconciler) getCluster(ctx context.Context, kubeConfigSecret *corev1.Secret) (cluster *greenhousev1alpha1.Cluster, err error) {
 	cluster = new(greenhousev1alpha1.Cluster)
 	err = r.Get(ctx, client.ObjectKeyFromObject(kubeConfigSecret), cluster)
 	return cluster, client.IgnoreNotFound(err)
-}
-
-func (r *BootstrapReconciler) requestClusterDeletion(ctx context.Context, namespacedName types.NamespacedName) error {
-	cluster := greenhousev1alpha1.Cluster{}
-	if err := r.Get(ctx, namespacedName, &cluster); err != nil {
-		return client.IgnoreNotFound(err)
-	}
-	log.FromContext(ctx).Info("Cluster secret is being deleted, requesting Cluster deletion", "cluster", namespacedName.String())
-	return client.IgnoreNotFound(r.Delete(ctx, &cluster))
 }
 
 func enqueueSecretForCluster(_ context.Context, o client.Object) []ctrl.Request {

--- a/internal/controller/cluster/bootstrap_controller.go
+++ b/internal/controller/cluster/bootstrap_controller.go
@@ -83,11 +83,20 @@ func (r *BootstrapReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			// we have finalizer, so delete cluster if one can be found
 			cluster := greenhousev1alpha1.Cluster{}
 			if err := r.Get(ctx, req.NamespacedName, &cluster); err != nil {
+				if client.IgnoreNotFound(err) == nil {
+					// cluster not found - remove finalizer
+					if controllerutil.ContainsFinalizer(kubeConfigSecret, secretFinalizer) {
+						controllerutil.RemoveFinalizer(kubeConfigSecret, secretFinalizer)
+						if err := r.Update(ctx, kubeConfigSecret); err != nil {
+							return ctrl.Result{}, err
+						}
+					}
+				}
 				return ctrl.Result{}, client.IgnoreNotFound(err)
 			}
 			log.FromContext(ctx).Info(
 				"Cluster secret is being deleted, requesting Cluster deletion",
-				"cluster", req.NamespacedName.String(),
+				"cluster", req.String(),
 			)
 			return ctrl.Result{}, client.IgnoreNotFound(r.Delete(ctx, &cluster))
 		}

--- a/internal/controller/cluster/bootstrap_controller_test.go
+++ b/internal/controller/cluster/bootstrap_controller_test.go
@@ -153,6 +153,10 @@ var _ = Describe("Bootstrap controller", Ordered, func() {
 			id := types.NamespacedName{Name: kubeConfigSecret.Name, Namespace: setup.Namespace()}
 			Eventually(func(g Gomega) bool {
 				g.Expect(test.K8sClient.Get(test.Ctx, id, cluster)).Should(Succeed(), "the cluster should have been created")
+				readyCondition := cluster.Status.GetConditionByType(greenhousemetav1alpha1.ReadyCondition)
+				g.Expect(readyCondition).ToNot(BeNil())
+				g.Expect(readyCondition.Type).To(Equal(greenhousemetav1alpha1.ReadyCondition))
+				g.Expect(readyCondition.Status).To(Equal(metav1.ConditionTrue))
 				return true
 			}).Should(BeTrue(), "getting the cluster should succeed eventually")
 

--- a/internal/controller/cluster/cluster_controller.go
+++ b/internal/controller/cluster/cluster_controller.go
@@ -294,15 +294,17 @@ func (r *RemoteClusterReconciler) EnsureDeleted(ctx context.Context, resource li
 
 	kubeConfigSecret := &corev1.Secret{}
 	if err := r.Get(ctx, types.NamespacedName{Namespace: cluster.GetNamespace(), Name: cluster.GetSecretName()}, kubeConfigSecret); err != nil {
+		if client.IgnoreNotFound(err) == nil {
+			// Secret already missing, what means that parallel call to remove Cluster already finished removing
+			// finalizer on secret. that is possible only if parallel call to this func suceeded.
+			return ctrl.Result{}, lifecycle.Success, nil
+		}
 		return ctrl.Result{}, lifecycle.Failed, err
 	}
 	// early return if the cluster connectivity is via OIDC
 	if kubeConfigSecret.Type == greenhouseapis.SecretTypeOIDCConfig {
 		log.FromContext(ctx).Info("no resources to clean up", "secretType", kubeConfigSecret.Type, "cluster", cluster.Name)
 		deleteClusterMetrics(cluster)
-		if err := r.ensureSecretFinalizerRemoved(ctx, kubeConfigSecret); err != nil {
-			return ctrl.Result{}, lifecycle.Failed, err
-		}
 		return ctrl.Result{}, lifecycle.Success, nil
 	}
 	restClientGetter, err := clientutil.NewRestClientGetterFromSecret(kubeConfigSecret, cluster.Namespace)
@@ -320,18 +322,16 @@ func (r *RemoteClusterReconciler) EnsureDeleted(ctx context.Context, resource li
 		return ctrl.Result{}, lifecycle.Failed, err
 	}
 	deleteClusterMetrics(cluster)
-	if err := r.ensureSecretFinalizerRemoved(ctx, kubeConfigSecret); err != nil {
-		return ctrl.Result{}, lifecycle.Failed, err
+
+	if controllerutil.ContainsFinalizer(kubeConfigSecret, secretFinalizer) {
+		controllerutil.RemoveFinalizer(kubeConfigSecret, secretFinalizer)
+		err := r.Update(ctx, kubeConfigSecret)
+		if err != nil {
+			log.FromContext(ctx).Info("failed to remove finalizer", "error", err.Error())
+			return ctrl.Result{}, lifecycle.Failed, err
+		}
 	}
 	return ctrl.Result{}, lifecycle.Success, nil
-}
-
-func (r *RemoteClusterReconciler) ensureSecretFinalizerRemoved(ctx context.Context, secret *corev1.Secret) error {
-	if controllerutil.ContainsFinalizer(secret, secretFinalizer) {
-		controllerutil.RemoveFinalizer(secret, secretFinalizer)
-		return r.Update(ctx, secret)
-	}
-	return nil
 }
 
 func (r *RemoteClusterReconciler) EnsureSuspended(_ context.Context, _ lifecycle.RuntimeObject) (ctrl.Result, error) {

--- a/internal/controller/cluster/cluster_controller.go
+++ b/internal/controller/cluster/cluster_controller.go
@@ -275,6 +275,19 @@ func (r *RemoteClusterReconciler) reconcileServiceAccountToken(
 	return nil
 }
 
+func (r *RemoteClusterReconciler) ensureFinalizerAndMetricsCleanup(ctx context.Context, cluster *greenhousev1alpha1.Cluster, secret *corev1.Secret) error {
+	deleteClusterMetrics(cluster)
+	if controllerutil.ContainsFinalizer(secret, secretFinalizer) {
+		controllerutil.RemoveFinalizer(secret, secretFinalizer)
+		err := r.Update(ctx, secret)
+		if err != nil {
+			log.FromContext(ctx).Error(err, "failed to remove finalizer")
+			return err
+		}
+	}
+	return nil
+}
+
 // EnsureDeleted - handles the deletion / cleanup of cluster resource
 func (r *RemoteClusterReconciler) EnsureDeleted(ctx context.Context, resource lifecycle.RuntimeObject) (ctrl.Result, lifecycle.ReconcileResult, error) {
 	cluster := resource.(*greenhousev1alpha1.Cluster)
@@ -295,8 +308,9 @@ func (r *RemoteClusterReconciler) EnsureDeleted(ctx context.Context, resource li
 	kubeConfigSecret := &corev1.Secret{}
 	if err := r.Get(ctx, types.NamespacedName{Namespace: cluster.GetNamespace(), Name: cluster.GetSecretName()}, kubeConfigSecret); err != nil {
 		if client.IgnoreNotFound(err) == nil {
-			// Secret already missing, what means that parallel call to remove Cluster already finished removing
-			// finalizer on secret. that is possible only if parallel call to this func suceeded.
+			// Secret already missing. This means a parallel call to remove Cluster already removed its finalizer,
+			// which is only possible if that parallel call succeeded.
+			deleteClusterMetrics(cluster)
 			return ctrl.Result{}, lifecycle.Success, nil
 		}
 		return ctrl.Result{}, lifecycle.Failed, err
@@ -304,7 +318,9 @@ func (r *RemoteClusterReconciler) EnsureDeleted(ctx context.Context, resource li
 	// early return if the cluster connectivity is via OIDC
 	if kubeConfigSecret.Type == greenhouseapis.SecretTypeOIDCConfig {
 		log.FromContext(ctx).Info("no resources to clean up", "secretType", kubeConfigSecret.Type, "cluster", cluster.Name)
-		deleteClusterMetrics(cluster)
+		if err := r.ensureFinalizerAndMetricsCleanup(ctx, cluster, kubeConfigSecret); err != nil {
+			return ctrl.Result{}, lifecycle.Failed, err
+		}
 		return ctrl.Result{}, lifecycle.Success, nil
 	}
 	restClientGetter, err := clientutil.NewRestClientGetterFromSecret(kubeConfigSecret, cluster.Namespace)
@@ -321,15 +337,9 @@ func (r *RemoteClusterReconciler) EnsureDeleted(ctx context.Context, resource li
 	if err := r.deleteClusterRoleBindingInRemoteCluster(ctx, remoteClient); err != nil {
 		return ctrl.Result{}, lifecycle.Failed, err
 	}
-	deleteClusterMetrics(cluster)
 
-	if controllerutil.ContainsFinalizer(kubeConfigSecret, secretFinalizer) {
-		controllerutil.RemoveFinalizer(kubeConfigSecret, secretFinalizer)
-		err := r.Update(ctx, kubeConfigSecret)
-		if err != nil {
-			log.FromContext(ctx).Info("failed to remove finalizer", "error", err.Error())
-			return ctrl.Result{}, lifecycle.Failed, err
-		}
+	if err := r.ensureFinalizerAndMetricsCleanup(ctx, cluster, kubeConfigSecret); err != nil {
+		return ctrl.Result{}, lifecycle.Failed, err
 	}
 	return ctrl.Result{}, lifecycle.Success, nil
 }


### PR DESCRIPTION
## Description
This PR fixes circular dependency on secret vs cluster removal introduced in #2142 which lead to flaky tests (even if main branch seems to be green - tests are flapping in local env).

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

- Related Issue #2142

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
