### PR TITLE
feat(clusters): reconcile deletion policy

### DIFF
--- a/api/well_known.go
+++ b/api/well_known.go
@@ -112,6 +112,8 @@ const (
 
 // Deletion Policies
 const (
+	AnnotationKeyDeletionPolicy = "greenhouse.sap/plugin-deletion"
+
 	// DeletionPolicyRetain means owned resources will be retained on deletion.
 	DeletionPolicyRetain = "Retain"
 	// DeletionPolicyDelete means owned resources will be deleted on deletion.

--- a/docs/contribute/new-controller.md
+++ b/docs/contribute/new-controller.md
@@ -43,4 +43,4 @@ Within Greenhouse the controllers implement the `lifecycle.Reconciler` interface
 
 Unit/Integration tests for the controllers use Kubebuilder's envtest environment and are implemented using Ginkgo and Gomega. For examples on how to write tests please refer to the existing tests. There are also some helper functions in the `internal/test` package that can be used to simplify the testing of controllers.
 
-For e2e tests, please refer to the `test/e2e/README.md`.
+For e2e tests, please refer to the `e2e/README.md`.

--- a/e2e/plugin/e2e_test.go
+++ b/e2e/plugin/e2e_test.go
@@ -122,4 +122,8 @@ var _ = Describe("Plugin E2E", Ordered, func() {
 			scenarios.PluginImageReplicationFailure(ctx, adminClient, env, remoteClusterName)
 		})
 	})
+
+	It("should retain the helm release when Cluster annotated with DeletionPolicy set to `Retain` is deleted", func() {
+		scenarios.FluxControllerClusterDeletePolicyRetain(ctx, adminClient, env, remoteClusterName, team.Name)
+	})
 })

--- a/e2e/plugin/scenarios/flux_controller.go
+++ b/e2e/plugin/scenarios/flux_controller.go
@@ -756,3 +756,85 @@ func FluxControllerPluginDeletePolicyRetain(ctx context.Context, adminClient cli
 		g.Expect(err).NotTo(HaveOccurred(), "should be able to uninstall the helm release for the plugin")
 	}).Should(Succeed(), "the retained Helm release should eventually be uninstalled from the remote cluster")
 }
+
+// FluxControllerClusterDeletePolicyRetain tests that the helm release is left behind when deleting the Cluster.
+func FluxControllerClusterDeletePolicyRetain(ctx context.Context, adminClient client.Client, env *shared.TestEnv, remoteClusterName, teamName string) {
+	By("Creating plugin definition")
+	testPluginDefinition := fixtures.PreparePodInfoClusterPluginDefinition(env.TestNamespace, "6.9.0")
+	err := adminClient.Create(ctx, testPluginDefinition)
+	Expect(client.IgnoreAlreadyExists(err)).ToNot(HaveOccurred())
+
+	By("Checking the test plugin definition is ready")
+	Eventually(func(g Gomega) {
+		err = adminClient.Get(ctx, client.ObjectKeyFromObject(testPluginDefinition), testPluginDefinition)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(testPluginDefinition.Status.IsReadyTrue()).To(BeTrue(), "the plugin definition should be ready")
+	}).Should(Succeed())
+
+	By("Prepare the plugin spec for presets")
+	testPluginSpec := fixtures.PreparePlugin("test-podinfo-plugin", env.TestNamespace,
+		test.WithClusterPluginDefinition(testPluginDefinition.Name),
+		test.WithReleaseName("test-podinfo-plugin"),
+		test.WithReleaseNamespace(env.TestNamespace),
+		test.WithPluginOptionValue("replicaCount", &apiextensionsv1.JSON{Raw: []byte("1")}),
+	).Spec
+
+	By("Add labels to remote cluster and set DeletionPolicy on it")
+	remoteCluster := &greenhousev1alpha1.Cluster{}
+	err = adminClient.Get(ctx, client.ObjectKey{Name: remoteClusterName, Namespace: env.TestNamespace}, remoteCluster)
+	Expect(err).ToNot(HaveOccurred())
+	remoteCluster.Labels = map[string]string{
+		"app": "test-cluster",
+	}
+	remoteCluster.Annotations[greenhouseapis.AnnotationKeyDeletionPolicy] = greenhouseapis.DeletionPolicyRetain
+	err = adminClient.Update(ctx, remoteCluster)
+	Expect(err).ToNot(HaveOccurred())
+
+	pluginPresetName := "test-plugin-preset"
+
+	By("Creating PluginPreset")
+	pluginPreset := test.NewPluginPreset(pluginPresetName, env.TestNamespace,
+		test.WithPluginPresetLabel(greenhouseapis.LabelKeyOwnedBy, teamName),
+		test.WithPluginPresetPluginSpec(testPluginSpec),
+		test.WithPluginPresetClusterSelector(metav1.LabelSelector{MatchLabels: map[string]string{"app": "test-cluster"}}),
+		test.WithPluginPresetDeletionPolicy(greenhouseapis.DeletionPolicyRetain),
+	)
+	err = adminClient.Create(ctx, pluginPreset)
+	Expect(client.IgnoreAlreadyExists(err)).ToNot(HaveOccurred())
+
+	pluginNamespacedName := types.NamespacedName{Name: pluginPreset.Name + "-" + remoteClusterName, Namespace: env.TestNamespace}
+
+	By("Checking the plugin is successfully deployed")
+	plugin := &greenhousev1alpha1.Plugin{}
+	Eventually(func(g Gomega) {
+		err = adminClient.Get(ctx, pluginNamespacedName, plugin)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(plugin.Status.IsReadyTrue()).To(BeTrue(), "the plugin should be ready")
+	}).Should(Succeed(), "the plugin should eventually be created and ready")
+
+	By("Deleting the cluster")
+	test.EventuallyDeleted(ctx, adminClient, remoteCluster)
+
+	By("Verifying the Plugin is removed")
+	Eventually(func(g Gomega) {
+		removedPlugin := &greenhousev1alpha1.Plugin{}
+		err = adminClient.Get(ctx, pluginNamespacedName, removedPlugin)
+		g.Expect(apierrors.IsNotFound(err)).To(BeTrue(), "the plugin should be removed from the admin cluster")
+	}).Should(Succeed(), "the plugin should be remove after the cluster is deleted")
+
+	By("Verifying the HelmReleases is retained in the remote cluster and the flux helm release is removed")
+	Eventually(func(g Gomega) {
+		actHelmRelease := &helmv2.HelmRelease{}
+		err = adminClient.Get(ctx, pluginNamespacedName, actHelmRelease)
+		g.Expect(apierrors.IsNotFound(err)).To(BeTrue(), "there should be a not found error getting the flux HelmRelease in the admin cluster")
+		rel, err := helm.GetReleaseForHelmChartFromPlugin(ctx, env.RemoteRestClientGetter, plugin)
+		g.Expect(err).NotTo(HaveOccurred(), "should be able to get the helm release for the plugin")
+		g.Expect(rel.Info.Status).To(Equal(release.StatusDeployed), "the helm release should still be deployed in the remote cluster")
+	}).Should(Succeed(), "the flux HelmReleases should eventually be deleted but the Helm release retained")
+
+	By("Cleaning up the retained Helm release in the remote cluster")
+	Eventually(func(g Gomega) {
+		_, err := helm.UninstallHelmRelease(ctx, env.RemoteRestClientGetter, plugin)
+		g.Expect(err).NotTo(HaveOccurred(), "should be able to uninstall the helm release for the plugin")
+	}).Should(Succeed(), "the retained Helm release should eventually be uninstalled from the remote cluster")
+}

--- a/internal/controller/cluster/cluster_controller.go
+++ b/internal/controller/cluster/cluster_controller.go
@@ -128,6 +128,7 @@ func (r *RemoteClusterReconciler) EnsureCreated(ctx context.Context, resource li
 	if err := r.reconcileServiceAccountToken(ctx, restClientGetter, remoteClient, cluster, clusterSecret); err != nil {
 		return ctrl.Result{}, lifecycle.Failed, err
 	}
+
 	return ctrl.Result{RequeueAfter: utils.DefaultRequeueInterval}, lifecycle.Success, nil
 }
 
@@ -288,6 +289,17 @@ func (r *RemoteClusterReconciler) ensureFinalizerAndMetricsCleanup(ctx context.C
 	return nil
 }
 
+func (r *RemoteClusterReconciler) getPluginList(ctx context.Context, cluster *greenhousev1alpha1.Cluster) (*greenhousev1alpha1.PluginList, error) {
+	pluginList := &greenhousev1alpha1.PluginList{}
+	err := r.List(
+		ctx,
+		pluginList,
+		client.InNamespace(cluster.GetNamespace()),
+		client.MatchingLabels{greenhouseapis.LabelKeyCluster: cluster.GetName()},
+	)
+	return pluginList, err
+}
+
 // EnsureDeleted - handles the deletion / cleanup of cluster resource
 func (r *RemoteClusterReconciler) EnsureDeleted(ctx context.Context, resource lifecycle.RuntimeObject) (ctrl.Result, lifecycle.ReconcileResult, error) {
 	cluster := resource.(*greenhousev1alpha1.Cluster)
@@ -296,6 +308,32 @@ func (r *RemoteClusterReconciler) EnsureDeleted(ctx context.Context, resource li
 		deleteClusterMetrics(cluster)
 		return ctrl.Result{}, lifecycle.Success, nil
 	}
+
+	// if cluster is annotated with DeletionPolicyRetain - propagate it to plugings
+	if cluster.Annotations[greenhouseapis.AnnotationKeyDeletionPolicy] == greenhouseapis.DeletionPolicyRetain {
+		updatedCount := 0
+		pluginList, err := r.getPluginList(ctx, cluster)
+		if err != nil {
+			return ctrl.Result{}, lifecycle.Failed, err
+		}
+		for _, plugin := range pluginList.Items {
+			if plugin.Annotations[greenhouseapis.AnnotationKeyDeletionPolicy] != greenhouseapis.DeletionPolicyRetain {
+				if plugin.Annotations == nil {
+					plugin.Annotations = make(map[string]string)
+				}
+				plugin.Annotations[greenhouseapis.AnnotationKeyDeletionPolicy] = greenhouseapis.DeletionPolicyRetain
+				err := r.Update(ctx, &plugin)
+				if client.IgnoreNotFound(err) != nil {
+					return ctrl.Result{}, lifecycle.Failed, err
+				}
+				updatedCount++
+			}
+		}
+		if updatedCount > 0 {
+			return ctrl.Result{RequeueAfter: 10 * time.Second}, lifecycle.Pending, nil
+		}
+	}
+
 	// delete all plugins that are bound to this cluster
 	deletionCount, err := deletePlugins(ctx, r.Client, cluster)
 	if err != nil {

--- a/internal/controller/cluster/cluster_controller.go
+++ b/internal/controller/cluster/cluster_controller.go
@@ -6,6 +6,7 @@ package cluster
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -310,7 +311,7 @@ func (r *RemoteClusterReconciler) EnsureDeleted(ctx context.Context, resource li
 	}
 
 	// if cluster is annotated with DeletionPolicyRetain - propagate it to plugings
-	if cluster.Annotations[greenhouseapis.AnnotationKeyDeletionPolicy] == greenhouseapis.DeletionPolicyRetain {
+	if strings.EqualFold(cluster.Annotations[greenhouseapis.AnnotationKeyDeletionPolicy], greenhouseapis.DeletionPolicyRetain) {
 		updatedCount := 0
 		pluginList, err := r.getPluginList(ctx, cluster)
 		if err != nil {
@@ -318,15 +319,19 @@ func (r *RemoteClusterReconciler) EnsureDeleted(ctx context.Context, resource li
 		}
 		for _, plugin := range pluginList.Items {
 			if plugin.Annotations[greenhouseapis.AnnotationKeyDeletionPolicy] != greenhouseapis.DeletionPolicyRetain {
-				if plugin.Annotations == nil {
-					plugin.Annotations = make(map[string]string)
-				}
-				plugin.Annotations[greenhouseapis.AnnotationKeyDeletionPolicy] = greenhouseapis.DeletionPolicyRetain
-				err := r.Update(ctx, &plugin)
+				result, err := controllerutil.CreateOrUpdate(ctx, r.Client, &plugin, func() error {
+					if plugin.Annotations == nil {
+						plugin.Annotations = make(map[string]string)
+					}
+					plugin.Annotations[greenhouseapis.AnnotationKeyDeletionPolicy] = greenhouseapis.DeletionPolicyRetain
+					return nil
+				})
 				if client.IgnoreNotFound(err) != nil {
 					return ctrl.Result{}, lifecycle.Failed, err
 				}
-				updatedCount++
+				if result == controllerutil.OperationResultUpdated {
+					updatedCount++
+				}
 			}
 		}
 		if updatedCount > 0 {

--- a/internal/controller/plugin/plugin_controller_flux.go
+++ b/internal/controller/plugin/plugin_controller_flux.go
@@ -40,7 +40,7 @@ const (
 
 func (r *PluginReconciler) EnsureFluxDeleted(ctx context.Context, plugin *greenhousev1alpha1.Plugin) (ctrl.Result, lifecycle.ReconcileResult, error) {
 	// suspend the HelmRelease first to delete the Flux HelmRelease without removing the Helm release from the target cluster
-	if plugin.Spec.DeletionPolicy == greenhouseapis.DeletionPolicyRetain {
+	if plugin.Spec.DeletionPolicy == greenhouseapis.DeletionPolicyRetain || plugin.Annotations[greenhouseapis.AnnotationKeyDeletionPolicy] == greenhouseapis.DeletionPolicyRetain {
 		if _, err := r.EnsureFluxSuspended(ctx, plugin); err != nil {
 			plugin.SetCondition(greenhousemetav1alpha1.FalseCondition(greenhousev1alpha1.HelmReleaseDeployedCondition, greenhousev1alpha1.HelmUninstallFailedReason, err.Error()))
 			return ctrl.Result{}, lifecycle.Failed, err


### PR DESCRIPTION
## Description
This PR is introducing requested in #2089 deletion policy on cluster object level, which when set to `Retain` iterates over plugins:
 - updating plugin annotation `greenhouse.sap/plugin-deletion` to `Retain`
 - removing the plugin

and adds in flux removal logic check for above annotation to behave like it would be set on `.spec.deletionPolicy`


## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [x] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

Closes #2089

## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
