### PR TITLE
chore(docs): replace github-flavored admonitions with hugo hint shortcodes

### DIFF
--- a/docs/contribute/local-dev.md
+++ b/docs/contribute/local-dev.md
@@ -44,8 +44,9 @@ This handy CLI tool will help you to setup your development environment in no ti
 
 Build `greenhousectl` from source by running the following command: `make cli`
 
-> [!NOTE]  
-> The CLI binary will be available in the `bin` folder
+{{< hint info >}}
+The CLI binary will be available in the `bin` folder
+{{< /hint >}}
 
 ## Setting up the development environment
 
@@ -62,13 +63,14 @@ Use `kubectl config use-context kind-greenhouse-remote` to switch to `greenhouse
 If you do not have the contexts of the created cluster(s) in `~/.kube/config` file then you can extract it from the
 operating system's `tmp` folder, where the CLI will write `kubeconfig` of the created `KinD` clusters.
 
-> [!NOTE]
-> `linux / macOS`: in `unix` like systems you can find the `kubeconfig` at `$TMPDIR/greenhouse/<clusterName>.kubeconfig`
->
-> `windows`: in `windows` many tmp folders exist so the CLI can write the `kubeconfig` to the first non-empty value from
+{{< hint info >}}
+`linux / macOS`: in `unix` like systems you can find the `kubeconfig` at `$TMPDIR/greenhouse/<clusterName>.kubeconfig`
+
+`windows`: in `windows` many tmp folders exist so the CLI can write the `kubeconfig` to the first non-empty value from
 `%TMP%`, `%TEMP%`, `%USERPROFILE%`
->
-> The path where the `kubeconfig` is written will be displayed in the terminal after the command is executed by the CLI
+
+The path where the `kubeconfig` is written will be displayed in the terminal after the command is executed by the CLI
+{{< /hint >}}
 
 use `kubectl --kubeconfig=<path to admin / remote kubeconfig>` to interact with the local `greenhouse` clusters
 
@@ -89,10 +91,11 @@ make setup
 make setup-controller-dev
 ```
 
-> [!NOTE]
-> set the environment variable `CONTROLLERS_ONLY=true` in your debugger configuration
->
-> If no environment variable is set, the webhook server will error out due to the missing certs
+{{< hint info >}}
+set the environment variable `CONTROLLERS_ONLY=true` in your debugger configuration
+
+If no environment variable is set, the webhook server will error out due to the missing certs
+{{< /hint >}}
 
 ### Develop Admission Webhook server locally
 
@@ -100,9 +103,10 @@ make setup-controller-dev
 make setup-webhook-dev
 ```
 
-> [!NOTE]
-> set the environment variable `WEBHOOK_ONLY=true` in your debugger configuration if you only want to run the webhook
-> server
+{{< hint info >}}
+set the environment variable `WEBHOOK_ONLY=true` in your debugger configuration if you only want to run the webhook
+server
+{{< /hint >}}
 
 ### Develop Controllers and Admission Webhook server locally
 
@@ -119,10 +123,11 @@ Now you can run the webhook server and the controllers locally
 Since both need to be run locally no `CONTROLLERS_ONLY` or `WEBHOOK_ONLY` environment variables are needed in your
 debugger configuration
 
-> [!NOTE]
-> The dev setup will modify the webhook configurations to have 30s timeout for the webhook requests, but
-> when break points are used to debug webhook requests, it can result into timeouts.
-> In such cases, modify the CR with a dummy annotation to re-trigger the webhook request and reconciliation
+{{< hint info >}}
+The dev setup will modify the webhook configurations to have 30s timeout for the webhook requests, but
+when break points are used to debug webhook requests, it can result into timeouts.
+In such cases, modify the CR with a dummy annotation to re-trigger the webhook request and reconciliation
+{{< /hint >}}
 
 ### Running Greenhouse Dashboard in-cluster
 
@@ -130,10 +135,11 @@ debugger configuration
 make setup-dashboard
 ```
 
-> [!NOTE]
-> You will need to port-forward the cors-proxy service and the dashboard service to access the dashboard
->
-> Information on how to access the dashboard is displayed after the command is executed
+{{< hint info >}}
+You will need to port-forward the cors-proxy service and the dashboard service to access the dashboard
+
+Information on how to access the dashboard is displayed after the command is executed
+{{< /hint >}}
 
 ### Run Greenhouse Core for UI development
 
@@ -152,8 +158,9 @@ The Greenhouse UI consists of a [Juno application](https://github.com/cloudopera
 
 ### Test Plugin / Greenhouse Extension charts locally (Deprecated)
 
-> [!NOTE]
-> This setup is deprecated and will be removed in the future. Please refer to [Test Greenhouse Extensions with local OCI registry](#test-greenhouse-extensions-with-local-oci-registry)
+{{< hint info >}}
+This setup is deprecated and will be removed in the future. Please refer to [Test Greenhouse Extensions with local OCI registry](#test-greenhouse-extensions-with-local-oci-registry)
+{{< /hint >}}
 
 ```shell
 PLUGIN_DIR=<absolute-path-to-charts-dir> make setup
@@ -223,8 +230,9 @@ export PKG=$(helm package $PWD/perses/charts -d ./bin | awk '{print $NF}')
 export OCI=oci://localhost:5000/cloudoperators/greenhouse-extensions/charts
 ```
 
-> [!NOTE]
-> The bin folder is ignored by git, so it is safe to temporarily store the packaged chart
+{{< hint info >}}
+The bin folder is ignored by git, so it is safe to temporarily store the packaged chart
+{{< /hint >}}
 
 ### Push Package to Local Registry
 
@@ -232,8 +240,9 @@ export OCI=oci://localhost:5000/cloudoperators/greenhouse-extensions/charts
 helm push $PKG $OCI
 ```
 
-> [!NOTE]
-> You can see the charts in browser at http://localhost:5000/home
+{{< hint info >}}
+You can see the charts in browser at http://localhost:5000/home
+{{< /hint >}}
 
 ### Apply Perses PluginDefinition
 
@@ -250,8 +259,9 @@ Apply the PluginDefinition to the admin cluster
 kubectl --context=kind-greenhouse-admin apply -f bin/perses.yaml -n demo
 ```
 
-> [!NOTE]
-> demo is the organization namespace in Greenhouse local setup.
+{{< hint info >}}
+demo is the organization namespace in Greenhouse local setup.
+{{< /hint >}}
 
 ### Verify PluginDefinition is `Ready`
 

--- a/docs/getting-started/core-concepts/plugins.md
+++ b/docs/getting-started/core-concepts/plugins.md
@@ -13,8 +13,9 @@ The backend components of a PluginDefinition are packaged as a Helm Chart and pr
 
 A Plugin is used to deploy the Helm Chart referenced in a PluginDefinition to a Cluster. The Plugin can be considered as an instance of a PluginDefinition, this instance specifies the PluginDefinition, the desired Cluster and additional values to set. Depending on the PluginDefinition, it may be necessary to specify required values (e.g. credentials, endpoints, etc.), but in general the PluginDefinition provides well-established default values.
 
-> [!NOTE]
-> In this example the Plugin 'openTelemetry-cluster-a' is used to deploy the PluginDefinition 'openTelemetry' to the cluster 'cluster-a'.
+{{< hint info >}}
+In this example the Plugin 'openTelemetry-cluster-a' is used to deploy the PluginDefinition 'openTelemetry' to the cluster 'cluster-a'.
+{{< /hint >}}
 
 ```mermaid
 flowchart TB
@@ -42,8 +43,9 @@ flowchart TB
 
 PluginPresets are a mechanism to configure Plugins for multiple clusters at once. They are used to define a common configuration for a PluginDefinition that can be applied to multiple clusters, while allowing to override the configuration for individual clusters.
 
-> [!NOTE]
-> In this example the PluginPreset 'example-obs' references the PluginDefinition 'example' and contains a clusterSelector that matches the clusters 'cluster-a' and 'cluster-b'. The PluginPreset creates two Plugins 'example-obs-cluster-a' and 'example-obs-cluster-b' for the respective clusters.
+{{< hint info >}}
+In this example the PluginPreset 'example-obs' references the PluginDefinition 'example' and contains a clusterSelector that matches the clusters 'cluster-a' and 'cluster-b'. The PluginPreset creates two Plugins 'example-obs-cluster-a' and 'example-obs-cluster-b' for the respective clusters.
+{{< /hint >}}
 
 ```mermaid
 flowchart TB

--- a/docs/reference/components/teamrolebinding.md
+++ b/docs/reference/components/teamrolebinding.md
@@ -61,8 +61,9 @@ The subjects list on the remote cluster is the union of the IDP groups from all 
 
 ### `.spec.teamRef` (deprecated)
 
-> [!WARNING]
-> `spec.teamRef` is **deprecated**. Use `spec.teamRefs` instead.
+{{< hint danger >}}
+`spec.teamRef` is **deprecated**. Use `spec.teamRefs` instead.
+{{< /hint >}}
 
 The singular `teamRef` field accepts a single team name for backwards compatibility. The mutating webhook automatically merges `teamRef` into `teamRefs` on every create or update, so existing resources are migrated lazily without any manual intervention required.
 
@@ -114,8 +115,9 @@ spec:
     - logging
 ```
 
-> [!NOTE]
-> The scope of a TeamRoleBinding (cluster-scoped vs. namespace-scoped) is determined at creation time and cannot be changed afterwards. A cluster-scoped binding cannot gain namespaces, and a namespace-scoped binding cannot be made cluster-scoped, without deleting and re-creating the resource.
+{{< hint info >}}
+The scope of a TeamRoleBinding (cluster-scoped vs. namespace-scoped) is determined at creation time and cannot be changed afterwards. A cluster-scoped binding cannot gain namespaces, and a namespace-scoped binding cannot be made cluster-scoped, without deleting and re-creating the resource.
+{{< /hint >}}
 
 ### `.spec.createNamespaces`
 

--- a/docs/user-guides/plugin/plugin-tests.md
+++ b/docs/user-guides/plugin/plugin-tests.md
@@ -143,8 +143,9 @@ helm test <Release name>
 
 Some Plugins require other Plugins to be installed in the Cluster for their tests to run successfully. To support this, each Plugin can declare required dependencies using a `test-dependencies.yaml` file.
 
-> [!NOTE]  
->The `test-dependencies.yaml` file is required if other Plugins need to be installed in the Kind Cluster created by the GitHub Actions workflow before running tests during a Pull Request for the Plugin.
+{{< hint info >}}
+The `test-dependencies.yaml` file is required if other Plugins need to be installed in the Kind Cluster created by the GitHub Actions workflow before running tests during a Pull Request for the Plugin.
+{{< /hint >}}
 
 
 ### How It Works

--- a/docs/user-guides/team/rbac.md
+++ b/docs/user-guides/team/rbac.md
@@ -259,8 +259,9 @@ spec:
 
 ### Migrating from the deprecated teamRef field
 
-> [!WARNING]
-> `spec.teamRef` (singular) is **deprecated**. Use `spec.teamRefs` (plural list) instead.
+{{< hint danger >}}
+`spec.teamRef` (singular) is **deprecated**. Use `spec.teamRefs` (plural list) instead.
+{{< /hint >}}
 
 Existing TeamRoleBindings that still use the singular `teamRef` field are migrated automatically and lazily by the mutating webhook: the first time such a resource is created or updated, the webhook appends the value of `spec.teamRef` to `spec.teamRefs` (deduplicating if needed) and clears `spec.teamRef`. No manual migration is required for existing resources—they are migrated in-place on the next write.
 
@@ -293,8 +294,9 @@ spec:
     clusterName: my-cluster
 ```
 
-> [!NOTE]
-> If both `teamRef` and `teamRefs` are set on a resource, the webhook merges `teamRef` into `teamRefs` and deduplicates the list. `teamRefs` always takes precedence.
+{{< hint info >}}
+If both `teamRef` and `teamRefs` are set on a resource, the webhook merges `teamRef` into `teamRefs` and deduplicates the list. `teamRefs` always takes precedence.
+{{< /hint >}}
 
 ## Updating TeamRoleBindings
 


### PR DESCRIPTION
## Description

GitHub-flavored `> [!NOTE]` and `> [!WARNING]` callout syntax renders correctly on GitHub but appears as **raw text** in the Hugo docs site (e.g. `[!NOTE]` shows literally on the page instead of as a styled callout box). This PR replaces all occurrences with the `{{< hint >}}` shortcode provided by the Hugo theme (`sapcc/hugo-documentation-templater/v3`), which renders the intended callout styling in the docs site.

Affected pages:
- `docs/contribute/local-dev.md` — 10 occurrences
- `docs/user-guides/team/rbac.md` — 2 occurrences
- `docs/getting-started/core-concepts/plugins.md` — 2 occurrences
- `docs/reference/components/teamrolebinding.md` — 2 occurrences
- `docs/user-guides/plugin/plugin-tests.md` — 1 occurrence

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [x] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

Fixes #2197

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Verified that all replaced callouts render correctly in the local Hugo dev server (`hugo server --disableFastRender`).

## Added to documentation?

- [ ] 📜 README.md
- [x] 🤝 Documentation pages updated
- [ ] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings