### PR TITLE
fix(docs): add site CNAME to license ignore

### DIFF
--- a/.github/licenserc.yaml
+++ b/.github/licenserc.yaml
@@ -48,6 +48,7 @@ header:
     - 'pkg/mocks/**'    # Mockery generated files
     - 'config/flux/**'  #Flux CD files
     - 'config/manifest/**'  #Flux CD files
+    - 'website/static/CNAME'
 
   comment: on-failure
   


### PR DESCRIPTION
## Description

CNAME was added to Hugo website and was not ignored in license check. This causes `make test` to fail

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [x] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
